### PR TITLE
Suggestion about memory target

### DIFF
--- a/ios/RCTCamera.xcodeproj/project.pbxproj
+++ b/ios/RCTCamera.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../react-native/Libraries/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -227,6 +228,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../react-native/Libraries/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -2,6 +2,7 @@
 #import "RCTCamera.h"
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
+#import "RCTImageStoreManager.h"
 #import "RCTUtils.h"
 #import "RCTLog.h"
 #import "UIView+React.h"
@@ -427,7 +428,15 @@ RCT_EXPORT_METHOD(stopCapture) {
   NSString *responseString;
 
   if (target == RCTCameraCaptureTargetMemory) {
-    responseString = [imageData base64EncodedStringWithOptions:0];
+      return [self.bridge.imageStoreManager storeImage:[UIImage imageWithData:imageData] withBlock:^(NSString *imageTag) {
+          if (!imageTag) {
+              NSString *errorMessage = @"Error storing image in RCTImageStoreManager";
+              RCTLogWarn(@"%@", errorMessage);
+              callback(@[RCTMakeError(errorMessage, nil, nil)]);
+              return;
+          }
+          callback(@[[NSNull null], imageTag]);
+      }];
   }
 
   else if (target == RCTCameraCaptureTargetDisk) {


### PR DESCRIPTION
Hi,

This is my proposition about the memory target.
Currently it returns a base64 string though the bridge, which is not really something good to do.

In react native there already is an in-memory store for images, RTCImageStoreManager.
So my change suggests to store the image in it and return the specific store uri created by it. These uri can be used in any of the built in react image stuff.
People who want the base64 can always do so as RTCImageStoreManager exposes getBase64ForTag.

My use case is that I want to implement a series of treatments (resizes, metadata, watermark..) to the image before saving the resulting images to disk. I want to be able to command the transformations in JS for more flexibility.
## Warning, below this line is just an extreme conclusion i had after making this change.

This also led me to think that this camera module should only return in memory images and let the other stuff (resize, metata/gps edition, file/camera roll saving...) to be handled by others modules.
That's what react native ImageEditingManager does for example.
