### PR TITLE
Fix issue #249 - capture to camera roll crashes on certain Android de…

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -182,6 +182,9 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
                     case RCT_CAMERA_CAPTURE_TARGET_CAMERA_ROLL:
                         BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
                         Bitmap bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, bitmapOptions);
+
+                        createMediaDirIfMissing();
+
                         String url = MediaStore.Images.Media.insertImage(
                                 _reactContext.getContentResolver(),
                                 bitmap, options.getString("title"),
@@ -293,6 +296,23 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
         } catch (Exception e) {
             Log.e(TAG, e.getMessage());
             return null;
+        }
+    }
+
+    public static void createMediaDirIfMissing() {
+        File sdcard = Environment.getExternalStorageDirectory();
+        if (sdcard == null) {
+            return;
+        }
+
+        File dcim = new File(sdcard, "DCIM");
+        if (dcim == null) {
+            return;
+        }
+
+        File camera = new File(dcim, "Camera");
+        if (!camera.exists()) {
+            camera.mkdir();
         }
     }
 }


### PR DESCRIPTION
Fix #249 - To resolve the crash, this fix creates the missing directory if necessary 
