### PR TITLE
Orientation only specifies recording output

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Values:
 `Camera.constants.Orientation.auto` or `"auto"` (default),
 `Camera.constants.Orientation.landscapeLeft` or `"landscapeLeft"`, `Camera.constants.Orientation.landscapeRight` or `"landscapeRight"`, `Camera.constants.Orientation.portrait` or `"portrait"`, `Camera.constants.Orientation.portraitUpsideDown` or `"portraitUpsideDown"`
 
-The `orientation` property allows you to specify the current orientation of the phone to ensure the viewfinder is "the right way up."
+The `orientation` property allows you to specify the current orientation of the phone to ensure the picture or recorded video is correctly rotated.
 
 #### `Android` `playSoundOnCapture`
 

--- a/ios/RCTCamera.m
+++ b/ios/RCTCamera.m
@@ -27,20 +27,6 @@
   BOOL _previousIdleTimerDisabled;
 }
 
-- (void)setOrientation:(NSInteger)orientation
-{
-  [self.manager changeOrientation:orientation];
-
-  if (orientation == RCTCameraOrientationAuto) {
-    [self changePreviewOrientation:[UIApplication sharedApplication].statusBarOrientation];
-    [[NSNotificationCenter defaultCenter] addObserver:self  selector:@selector(orientationChanged:)    name:UIDeviceOrientationDidChangeNotification  object:nil];
-  }
-  else {
-    [[NSNotificationCenter defaultCenter]removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
-    [self changePreviewOrientation:orientation];
-  }
-}
-
 - (void)setOnFocusChanged:(BOOL)enabled
 {
   if (_onFocusChanged != enabled) {
@@ -77,6 +63,7 @@
     _defaultOnFocusComponent = YES;
     _onZoomChanged = NO;
     _previousIdleTimerDisabled = [UIApplication sharedApplication].idleTimerDisabled;
+    [[NSNotificationCenter defaultCenter] addObserver:self  selector:@selector(orientationChanged:) name:UIDeviceOrientationDidChangeNotification  object:nil];
   }
   return self;
 }
@@ -109,9 +96,10 @@
   [UIApplication sharedApplication].idleTimerDisabled = _previousIdleTimerDisabled;
 }
 
-- (void)orientationChanged:(NSNotification *)notification{
-  UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-  [self changePreviewOrientation:orientation];
+- (void)orientationChanged:(NSNotification *)notification {
+  if (self.manager.previewLayer.connection.isVideoOrientationSupported) {
+    self.manager.previewLayer.connection.videoOrientation = [[UIApplication sharedApplication] statusBarOrientation];
+  }
 }
 
 
@@ -176,13 +164,6 @@
 
     if (pinchRecognizer.state == UIGestureRecognizerStateChanged) {
         [self.manager zoom:pinchRecognizer.velocity reactTag:self.reactTag];
-    }
-}
-
-- (void)changePreviewOrientation:(NSInteger)orientation
-{
-    if (self.manager.previewLayer.connection.isVideoOrientationSupported) {
-        self.manager.previewLayer.connection.videoOrientation = orientation;
     }
 }
 

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -110,10 +110,14 @@ RCT_EXPORT_MODULE();
            };
 }
 
-RCT_EXPORT_VIEW_PROPERTY(orientation, NSInteger);
 RCT_EXPORT_VIEW_PROPERTY(defaultOnFocusComponent, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(onFocusChanged, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(onZoomChanged, BOOL);
+
+RCT_CUSTOM_VIEW_PROPERTY(orientation, NSInteger, RCTCamera) {
+  NSInteger orientation = [RCTConvert NSInteger:json];
+  [self setOrientation:orientation];
+}
 
 RCT_CUSTOM_VIEW_PROPERTY(aspect, NSInteger, RCTCamera) {
   NSInteger aspect = [RCTConvert NSInteger:json];
@@ -301,10 +305,6 @@ RCT_EXPORT_METHOD(checkAudioAuthorizationStatus:(RCTPromiseResolveBlock)resolve
     }];
 }
 
-RCT_EXPORT_METHOD(changeOrientation:(NSInteger)orientation) {
-  [self setOrientation:orientation];
-}
-
 RCT_EXPORT_METHOD(capture:(NSDictionary *)options
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
@@ -405,6 +405,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
       });
     }]];
 
+    self.previewLayer.connection.videoOrientation = [[UIApplication sharedApplication] statusBarOrientation];
     [self.session startRunning];
   });
 }

--- a/ios/RCTSensorOrientationChecker.m
+++ b/ios/RCTSensorOrientationChecker.m
@@ -77,12 +77,13 @@
     if(acceleration.x <= -0.75) {
         return UIInterfaceOrientationLandscapeRight;
     }
-    if(acceleration.y >= -0.75) {
+    if(acceleration.y <= -0.75) {
         return UIInterfaceOrientationPortrait;
     }
     if(acceleration.y >= 0.75) {
         return UIInterfaceOrientationPortraitUpsideDown;
     }
+
     return [[UIApplication sharedApplication] statusBarOrientation];
 }
 


### PR DESCRIPTION
@rpopovici recently added functionality to automatically set the output file's orientation based on the device's sensor data, which is great. However, there are still some cases where you might need to explicitly set the `orientation` prop of the camera. For example, when the device is held near-horizontal the accelerometer can't know whether you were intending to record something in landscape or portrait.

The `orientation` prop is meant to deal with this kind of case, but unfortunately it is too powerful! Currently `orientation` sets the orientation of both the preview display and the output file. This makes it impossible to eg. record landscape videos if the user's UI is rotation-locked to portrait.

This PR simplifies the `orientation` code and updates it to **only determine the output file's rotation**. It's still important that the preview orientation stays in sync as well of course, so I've moved the preview rotation code to the camera's initialization, so the preview will always be in sync with the device's rotation.
