### PR TITLE
Use dispatch_async when capturing still images (iOS)

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -530,60 +530,66 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
       [self.stillImageOutput captureStillImageAsynchronouslyFromConnection:[self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo] completionHandler:^(CMSampleBufferRef imageDataSampleBuffer, NSError *error) {
 
         if (imageDataSampleBuffer) {
-          NSData *imageData = [AVCaptureStillImageOutput jpegStillImageNSDataRepresentation:imageDataSampleBuffer];
 
-          // Create image source
-          CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-          //get all the metadata in the image
-          NSMutableDictionary *imageMetadata = [(NSDictionary *) CFBridgingRelease(CGImageSourceCopyPropertiesAtIndex(source, 0, NULL)) mutableCopy];
+          CFRetain(imageDataSampleBuffer);
+          dispatch_async(self.sessionQueue, ^{
 
-          // create cgimage
-          CGImageRef CGImage;
-          CGImage = CGImageSourceCreateImageAtIndex(source, 0, NULL);
+            NSData *imageData = [AVCaptureStillImageOutput jpegStillImageNSDataRepresentation:imageDataSampleBuffer];
 
-          // Rotate it
-          CGImageRef rotatedCGImage;
-          if ([options objectForKey:@"rotation"]) {
-            float rotation = [[options objectForKey:@"rotation"] floatValue];
-            rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:rotation];
-          } else {
-            // Get metadata orientation
-            int metadataOrientation = [[imageMetadata objectForKey:(NSString *)kCGImagePropertyOrientation] intValue];
+            // Create image source
+            CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
+            //get all the metadata in the image
+            NSMutableDictionary *imageMetadata = [(NSDictionary *) CFBridgingRelease(CGImageSourceCopyPropertiesAtIndex(source, 0, NULL)) mutableCopy];
 
-            if (metadataOrientation == 6) {
-              rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:270];
-            } else if (metadataOrientation == 1) {
-              rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:0];
-            } else if (metadataOrientation == 3) {
-              rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:180];
+            // create cgimage
+            CGImageRef CGImage;
+            CGImage = CGImageSourceCreateImageAtIndex(source, 0, NULL);
+
+            // Rotate it
+            CGImageRef rotatedCGImage;
+            if ([options objectForKey:@"rotation"]) {
+              float rotation = [[options objectForKey:@"rotation"] floatValue];
+              rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:rotation];
             } else {
-              rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:0];
+              // Get metadata orientation
+              int metadataOrientation = [[imageMetadata objectForKey:(NSString *)kCGImagePropertyOrientation] intValue];
+
+              if (metadataOrientation == 6) {
+                rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:270];
+              } else if (metadataOrientation == 1) {
+                rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:0];
+              } else if (metadataOrientation == 3) {
+                rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:180];
+              } else {
+                rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:0];
+              }
             }
-          }
-          CGImageRelease(CGImage);
+            CGImageRelease(CGImage);
 
-          // Erase metadata orientation
-          [imageMetadata removeObjectForKey:(NSString *)kCGImagePropertyOrientation];
-          // Erase stupid TIFF stuff
-          [imageMetadata removeObjectForKey:(NSString *)kCGImagePropertyTIFFDictionary];
+            // Erase metadata orientation
+            [imageMetadata removeObjectForKey:(NSString *)kCGImagePropertyOrientation];
+            // Erase stupid TIFF stuff
+            [imageMetadata removeObjectForKey:(NSString *)kCGImagePropertyTIFFDictionary];
 
-          // Add input metadata
-          [imageMetadata mergeMetadata:[options objectForKey:@"metadata"]];
+            // Add input metadata
+            [imageMetadata mergeMetadata:[options objectForKey:@"metadata"]];
 
-          // Create destination thing
-          NSMutableData *rotatedImageData = [NSMutableData data];
-          CGImageDestinationRef destination = CGImageDestinationCreateWithData((CFMutableDataRef)rotatedImageData, CGImageSourceGetType(source), 1, NULL);
-          CFRelease(source);
-          // add the image to the destination, reattaching metadata
-          CGImageDestinationAddImage(destination, rotatedCGImage, (CFDictionaryRef) imageMetadata);
-          // And write
-          CGImageDestinationFinalize(destination);
-          CFRelease(destination);
+            // Create destination thing
+            NSMutableData *rotatedImageData = [NSMutableData data];
+            CGImageDestinationRef destination = CGImageDestinationCreateWithData((CFMutableDataRef)rotatedImageData, CGImageSourceGetType(source), 1, NULL);
+            CFRelease(source);
+            // add the image to the destination, reattaching metadata
+            CGImageDestinationAddImage(destination, rotatedCGImage, (CFDictionaryRef) imageMetadata);
+            // And write
+            CGImageDestinationFinalize(destination);
+            CFRelease(destination);
 
-          [self saveImage:rotatedImageData target:target metadata:imageMetadata resolve:resolve reject:reject];
+            [self saveImage:rotatedImageData target:target metadata:imageMetadata resolve:resolve reject:reject];
 
-          CGImageRelease(rotatedCGImage);
-        }
+            CGImageRelease(rotatedCGImage);
+            CFRelease(imageDataSampleBuffer);
+          });
+        } 
         else {
           reject(RCTErrorUnspecified, nil, RCTErrorWithMessage(error.description));
         }


### PR DESCRIPTION
Added one more dispatch_async call when capturing still images. If I understood correctly the code is already wrapped in one dispatch_async but the actual completion handler is called outside of it.

Noticed this when capturing photos with "photo" quality which are taking some time....and rendering progressbar without this patch does not really work because it will just freeze the whole ui.

Not sure if there is some problems with this approach but at least with my limited testing it seems to work and ui remains responsive enough for the progressbar.

Also the actual time that it takes to capture a photo seems to have increased slightly from the previous version I was using (don't have any real data to back this up, just eyeballing it) but that is probably another issue.
