### PR TITLE
Fix iOS images always saved as Portrait

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -568,18 +568,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
             float rotation = [[options objectForKey:@"rotation"] floatValue];
             rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:rotation];
           } else {
-            // Get metadata orientation
-            int metadataOrientation = [[imageMetadata objectForKey:(NSString *)kCGImagePropertyOrientation] intValue];
-
-            if (metadataOrientation == 6) {
-              rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:270];
-            } else if (metadataOrientation == 1) {
-              rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:0];
-            } else if (metadataOrientation == 3) {
-              rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:180];
-            } else {
-              rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:0];
-            }
+            rotatedCGImage = [self newCGImageRotatedByAngle:CGImage angle:0];
           }
           CGImageRelease(CGImage);
 

--- a/ios/RCTSensorOrientationChecker.m
+++ b/ios/RCTSensorOrientationChecker.m
@@ -71,18 +71,20 @@
 
 - (UIInterfaceOrientation)getOrientationBy:(CMAcceleration)acceleration
 {
-    if(acceleration.x >= 0.75) {
-        return UIInterfaceOrientationLandscapeLeft;
-    }
-    if(acceleration.x <= -0.75) {
+    float x = -acceleration.x;
+    float y = acceleration.y;
+    float angle = atan2(y, x);
+
+    if (angle >= -2.25 && angle <= -0.75) {
+         return UIInterfaceOrientationPortrait;
+    } else if (angle >= -0.75 && angle <= 0.75){
         return UIInterfaceOrientationLandscapeRight;
+    } else if (angle >= 0.75 && angle <= 2.25) {
+         return UIInterfaceOrientationPortraitUpsideDown;
+    } else if (angle <= -2.25 || angle >= 2.25) {
+         return UIInterfaceOrientationLandscapeLeft;
     }
-    if(acceleration.y >= -0.75) {
-        return UIInterfaceOrientationPortrait;
-    }
-    if(acceleration.y >= 0.75) {
-        return UIInterfaceOrientationPortraitUpsideDown;
-    }
+
     return [[UIApplication sharedApplication] statusBarOrientation];
 }
 
@@ -93,10 +95,11 @@
             return AVCaptureVideoOrientationPortrait;
         case UIInterfaceOrientationPortraitUpsideDown:
             return AVCaptureVideoOrientationPortraitUpsideDown;
+        // Landscape UI and device orientation are opposite
         case UIInterfaceOrientationLandscapeLeft:
-            return AVCaptureVideoOrientationLandscapeLeft;
-        case UIInterfaceOrientationLandscapeRight:
             return AVCaptureVideoOrientationLandscapeRight;
+        case UIInterfaceOrientationLandscapeRight:
+            return AVCaptureVideoOrientationLandscapeLeft;
         default:
             return 0; // unknown
     }


### PR DESCRIPTION
The determination of device orientation using accelerometer values was not complete. Other issue reporters and our team found that the the accelerometer values fell outside the defined bounds, coincidentally always landing on portrait.

This PR updates the calculation and removes the subsequent image rotation during save (the intent of which I assume was to rectify the incorrect value from SensorOrientationChecker). 
