### PR TITLE
Pick a preview size with the same aspect ratio as the picture size(Re-PR)

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -90,6 +90,47 @@ public class RCTCamera {
         return bestSize;
     }
 
+    public Camera.Size getBestPreviewSize(int type, int width, int height)
+    {
+        Camera camera = _cameras.get(type);
+        Camera.Size result = null;
+        if(camera == null) {
+            return null;
+        }
+
+        Camera.Size pictureSize = getBestPictureSize(type, width, height);
+        float pictureAspect = (float) pictureSize.width / (float) pictureSize.height;
+
+        Camera.Parameters params = camera.getParameters();
+        // We want to find a preview size that is both as big as possible while still having the same (or very similar) aspect ratio
+        for (Camera.Size size : params.getSupportedPreviewSizes()) {
+            if (size.width <= width && size.height <= height) {
+                if (result == null) {
+                    result = size;
+                } else {
+                    float resultAspect = (float) result.width / (float) result.height;
+                    float newAspect = (float) size.width / (float) size.height;
+
+                    float aspectErrorDifference = Math.abs(resultAspect - pictureAspect) - Math.abs(newAspect - pictureAspect);
+
+                    if (Math.abs(aspectErrorDifference) < 0.01) {
+                        // If there's not much difference then choose the best based on area
+                        int resultArea = result.width * result.height;
+                        int newArea = size.width * size.height;
+
+                        if (newArea > resultArea) {
+                            result = size;
+                        }
+                    } else if (aspectErrorDifference > 0) {
+                        result = size;
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
     private Camera.Size getSmallestSize(List<Camera.Size> supportedSizes) {
         Camera.Size smallestSize = null;
         for (Camera.Size size : supportedSizes) {


### PR DESCRIPTION
This Pull Request resolves a conflict bringing with #371. `getBestSizeWIthSameAspect` function just do same operation with [`getBestPreviewSize`](https://github.com/lwansbrough/react-native-camera/pull/371/files).

I also agree with making a `previewSize` property to select the preview aspect ratio. For example, `previewSize` property allows
- `bestWithStill`(same aspect ratio with the picture size)
- `bestWithVideo`(same aspect ratio with the video size)
- `default`(the highest resolution of `getSupportedPreviewSizes`)
