### PR TITLE
Adding final width and height of picture to capture response

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -519,6 +519,10 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
                 camera.stopPreview();
                 camera.startPreview();
                 WritableMap response = new WritableNativeMap();
+                Camera.Size pictureSize = camera.getParameters().getPictureSize();
+                response.putInt("width", pictureSize.width);
+                response.putInt("height", pictureSize.height);
+
                 switch (options.getInt("target")) {
                     case RCT_CAMERA_CAPTURE_TARGET_MEMORY:
                         String encoded = Base64.encodeToString(data, Base64.DEFAULT);

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -479,7 +479,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
         }
     }
 
-    private void captureWithOrientation(final ReadableMap options, final Promise promise, int deviceOrientation) {
+    private void captureWithOrientation(final ReadableMap options, final Promise promise, final int deviceOrientation) {
         Camera camera = RCTCamera.getInstance().acquireCameraInstance(options.getInt("type"));
         if (null == camera) {
             promise.reject("No camera found.");
@@ -520,8 +520,16 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
                 camera.startPreview();
                 WritableMap response = new WritableNativeMap();
                 Camera.Size pictureSize = camera.getParameters().getPictureSize();
-                response.putInt("width", pictureSize.width);
-                response.putInt("height", pictureSize.height);
+                if (
+                    deviceOrientation == RCT_CAMERA_ORIENTATION_PORTRAIT ||
+                    deviceOrientation == RCT_CAMERA_ORIENTATION_PORTRAIT_UPSIDE_DOWN
+                ) {
+                    response.putInt("width", pictureSize.height);
+                    response.putInt("height", pictureSize.width);
+                } else {
+                    response.putInt("width", pictureSize.width);
+                    response.putInt("height", pictureSize.height);
+                }
 
                 switch (options.getInt("target")) {
                     case RCT_CAMERA_CAPTURE_TARGET_MEMORY:


### PR DESCRIPTION
To be consistent this should be done in iOS, although I know nothing about coding in iOS.

This information can save calling `Image.getSize` which currently has implementation problems in Android.

Cheers,
Miguel
