### PR TITLE
Fix issue #461

### DIFF
--- a/ios/RCTCamera.m
+++ b/ios/RCTCamera.m
@@ -182,9 +182,11 @@
 - (void)changePreviewOrientation:(NSInteger)orientation
 {
     dispatch_async(self.manager.sessionQueue, ^{
-        if (self.manager.previewLayer.connection.isVideoOrientationSupported) {
-            self.manager.previewLayer.connection.videoOrientation = orientation;
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (self.manager.previewLayer.connection.isVideoOrientationSupported) {
+                self.manager.previewLayer.connection.videoOrientation = orientation;
+            }
+        });
     });
 }
 


### PR DESCRIPTION
Hi. I don't have much experience with iOS code, but this issue is affecting a project I'm involved with that depends on this module, and I believe I have a fix that works and makes sense.

I think the issue described in #461 was caused by the fix for #354, which moved preview orientation updates off of the main thread. [Apple documentation suggests that most UI updates are thread-unsafe and should be run on the main queue](http://stackoverflow.com/a/6087096), and this issue seems to confirm that - orientation deadlock always occurs between the `previewLayer` updates in `layoutSubviews` and `changePreviewOrientation`, as shown below. This deadlock also stops if the #354 fix is reverted.

![Deadlock thread details](https://cloud.githubusercontent.com/assets/15933018/20024956/6b025902-a2c0-11e6-8277-50986fa47c27.png)

@johnryan's comment introducing issue #461 contained a workaround moving the `layoutSubviews` `previewLayer` update to the main queue, but it didn't work for me (on an iPhone 6 running iOS 10), and I think that makes sense - the main queue and the manager's `sessionQueue` need not run on the same thread, so they can still deadlock. However, moving **both** `previewLayer` updates to the main queue serializes them properly. I did also try just moving the `layoutSubviews` update to the `sessionQueue`, but this resulted in unacceptably slow resizing, often lagging multiple seconds behind device reorientation.

In this commit, I've kept the `changePreviewOrientation` `previewLayer` update enqueued in the `sessionQueue` as well, so #354 should be unaffected by these changes. The changes have been tested on the following phones so far:

- iPhone 6, iOS 10.0.2
- iPhone 6S, iOS 9.3.5
- iPhone 6S Plus, iOS 10.1.1