### PR TITLE
Update RCTCameraManager.m

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -34,11 +34,8 @@ RCT_EXPORT_MODULE();
     self.previewLayer = [AVCaptureVideoPreviewLayer layerWithSession:self.session];
     self.previewLayer.needsDisplayOnBoundsChange = YES;
   #endif
-
-  if(!self.camera){
-    self.camera = [[RCTCamera alloc] initWithManager:self bridge:self.bridge];
-  }
-  return self.camera;
+    
+  return [[RCTCamera alloc] initWithManager:self bridge:self.bridge];
 }
 
 - (NSDictionary *)constantsToExport


### PR DESCRIPTION
Camera crashes on iPhone when invoked a second time. This change seems to fix it.