### PR TITLE
use defaultOnFocusComponent to enable touch to focus in android

### DIFF
--- a/Example/android/app/src/main/java/com/example/MainApplication.java
+++ b/Example/android/app/src/main/java/com/example/MainApplication.java
@@ -17,7 +17,7 @@ public class MainApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
-    protected boolean getUseDeveloperSupport() {
+    public boolean getUseDeveloperSupport() {
       return BuildConfig.DEBUG;
     }
 

--- a/Example/package.json
+++ b/Example/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "react": "~15.3.0",
-    "react-native": "^0.34.0",
+    "react-native": "^0.41.2",
     "react-native-camera": "file:../"
   }
 }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
@@ -123,6 +123,10 @@ public class RCTCameraView extends ViewGroup {
         RCTCamera.getInstance().setBarCodeTypes(types);
     }
 
+    public void setDefaultOnFocusComponent(boolean defaultOnFocusComponent) {
+        this._viewFinder.setDefaultOnFocusComponent(defaultOnFocusComponent);
+    }
+
     private boolean setActualDeviceOrientation(Context context) {
         int actualDeviceOrientation = getDeviceOrientation(context);
         if (_actualDeviceOrientation != actualDeviceOrientation) {

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
@@ -36,6 +36,7 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
     private boolean _isStopping;
     private Camera _camera;
     private float mFingerSpacing;
+    private boolean _defaultOnFocusComponent;
 
     // concurrency lock for barcode scanner to avoid flooding the runtime
     public static volatile boolean barcodeScannerTaskLock = false;
@@ -108,6 +109,10 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
         RCTCamera.getInstance().setFlashMode(_cameraType, flashMode);
     }
 
+    public void setDefaultOnFocusComponent(boolean defaultOnFocusComponent) {
+        this._defaultOnFocusComponent = defaultOnFocusComponent;
+    }
+
     private void startPreview() {
         if (_surfaceTexture != null) {
             startCamera();
@@ -128,7 +133,7 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
                 Camera.Parameters parameters = _camera.getParameters();
                 // set autofocus
                 List<String> focusModes = parameters.getSupportedFocusModes();
-                if (focusModes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+                if (!this._defaultOnFocusComponent && focusModes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
                     parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
                 }
                 // set picture size

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
@@ -86,4 +86,8 @@ public class RCTCameraViewManager extends ViewGroupManager<RCTCameraView> {
         }
         view.setBarCodeTypes(result);
     }
+    @ReactProp(name="defaultOnFocusComponent")
+    public void setDefaultOnFocusComponent(RCTCameraView view, boolean defaultOnFocusComponent) {
+        view.setDefaultOnFocusComponent(defaultOnFocusComponent);
+    }
 }


### PR DESCRIPTION
Hi,

I made a small change so that one can disable 'FOCUS_MODE_CONTINUOUS_PICTURE' if they set 'defaultONFocusComponent' to 'true' so that touch to focus works in android.

I had to make a prior commit to get the 'Example' working on my device due to incompantible react-native version.

I am also thinking about adding a 'drawing view' so that a rectangle appears when  the user taps the screen to show that 'tap to focus' is enabled.

If you want me to change anything please let me know!

Thanks,
Aaron