### PR TITLE
onBarCodeRead listener when navigating

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,11 @@ export default class Camera extends Component {
 
   _onBarCodeRead = (data) => {
     if (this.props.onBarCodeRead) {
+      this.componentWillUnmount()
       this.props.onBarCodeRead(data)
+      setTimeout(() => {
+        this.componentWillMount()
+      }, 3000)
     }
   };
 


### PR DESCRIPTION
When the action when a bar code is detected is to change the current view using navigation, then, if we go back to the view with the camera component, the onBarCodeRead is not trigger anymore because the listener is removed.

By doing that, it will mount the component so we can reuse it in the case we come back to the previous view.