### PR TITLE
fix json stringify non string key error

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -407,8 +407,8 @@ RCT_EXPORT_METHOD(getFOV:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejec
   }
 
   resolve(@{
-    [NSNumber numberWithInt:RCTCameraTypeBack]: [NSNumber numberWithDouble: backFov],
-    [NSNumber numberWithInt:RCTCameraTypeFront]: [NSNumber numberWithDouble: frontFov]
+            @"Back": [NSNumber numberWithDouble: backFov],
+            @"Front"  : [NSNumber numberWithDouble: frontFov]
   });
 }
 


### PR DESCRIPTION
Error occurs with CameraManager.getFOV().  I had to hard code string keys in the resolve parameter object to use "getFOV".

Please merge.  My project is dependent on this fix.