### PR TITLE
IOS code scan freezing freezing capability

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
@@ -74,7 +74,7 @@ public class RCTCameraView extends ViewGroup {
                 _viewFinder.setFlashMode(this._flashMode);
             }
             if (-1 != this._torchMode) {
-                _viewFinder.setFlashMode(this._torchMode);
+                _viewFinder.setTorchMode(this._torchMode);
             }
             addView(_viewFinder);
         }

--- a/index.js
+++ b/index.js
@@ -256,6 +256,28 @@ export default class Camera extends Component {
     }
     return CameraManager.hasFlash();
   }
+
+  freezeCapture(){
+    if (Platform.OS === 'ios') 
+      return CameraManager.freezeCapture();
+  }
+
+  unfreezeCapture(){
+    if (Platform.OS === 'ios')
+      return CameraManager.unfreezeCapture();
+  }
+
+  addObserver(handler){
+
+    const observer = Platform.select({
+      ios: NativeAppEventEmitter.once('CameraBarCodeRead', handler),
+      android: DeviceEventEmitter.once('CameraBarCodeReadAndroid',  handler)
+    })
+
+    return observer;
+    
+  }
+
 }
 
 export const constants = Camera.constants;

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -417,6 +417,42 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
     resolve(@(device.hasFlash));
 }
 
+RCT_EXPORT_METHOD(freezeCapture){
+    
+#if TARGET_IPHONE_SIMULATOR
+    return;
+#endif
+    
+    if (self.session.isRunning) {
+        
+        self.previewLayer.connection.enabled = NO;
+        
+        dispatch_async(self.sessionQueue, ^{
+            [self.session stopRunning];
+        });
+    }
+}
+
+RCT_EXPORT_METHOD(unfreezeCapture){
+    
+#if TARGET_IPHONE_SIMULATOR
+    return;
+#endif
+    
+    if (!self.session) {
+        return;
+    }
+    
+    self.previewLayer.connection.enabled = YES;
+    
+    if (!self.session.isRunning) {
+        
+        dispatch_async(self.sessionQueue, ^{
+            [self.session startRunning];
+        });
+    }
+}
+
 - (void)startSession {
 #if TARGET_IPHONE_SIMULATOR
   return;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/lwansbrough/react-native-camera.git"
   },
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A Camera component for React Native. Also reads barcodes.",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "nativePackage": true,


### PR DESCRIPTION
Changes required to introduce the following camera behaviour while scanning codes on IOS:
1-Subscribe for a single event camera scan
2-Single event with the code read
3-Camera Preview freezing for a while
4-Camera Preview resumes
5-Subscribe again for single event if needed

Usage:

`<Camera ref={(cam) => this.camera = cam } onBarCodeRead={ ()=>null }/>

Note: onBarCodeRead prop is needed to force Camera component to emit events

componentDidMount(){
this.startScanning();
}

componentWillUnmount(){
this.stopScanning();
}

startScanning() {
this.scanObserver = this.camera.addObserver(this._onBarCodeRead.bind(this));
}

stopScanning() {
this.scanObserver && this.scanObserver.remove();
}

_onBarCodeRead(data){
this.camera.freezeCapture();
Vibration.vibrate();
setTimeout(()=>{
this.camera.unfreezeCapture();
this.startScanning();
}, 3000);
}`