### PR TITLE
Removed deprecated React CocoaPod from Podspec

### DIFF
--- a/react-native-camera.podspec
+++ b/react-native-camera.podspec
@@ -18,5 +18,4 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'
 
-  s.dependency 'React'
 end


### PR DESCRIPTION
The CocoaPod dependency is deprecated since React is now installed during **react-native init** 