### PR TITLE
Preview camera before trying to capture on Android

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -546,6 +546,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
 
         if(mSafeToCapture) {
           try {
+            camera.startPreview();
             camera.takePicture(null, null, captureCallback);
             mSafeToCapture = false;
           } catch(RuntimeException ex) {


### PR DESCRIPTION
Fixes https://github.com/lwansbrough/react-native-camera/issues/770

Not sure if there is a better place to perform the preview, or why preview isn't being run by default, but in my case it isn't, and needs to be.