### PR TITLE
Disallow capture when Camera is null (Android)

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -486,6 +486,11 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
 
     @ReactMethod
     public void capture(final ReadableMap options, final Promise promise) {
+        if (RCTCamera.getInstance() == null) {
+            promise.reject("Camera is not ready yet.");
+            return;
+        }
+
         int orientation = options.hasKey("orientation") ? options.getInt("orientation") : RCTCamera.getInstance().getOrientation();
         if (orientation == RCT_CAMERA_ORIENTATION_AUTO) {
             _sensorOrientationChecker.onResume();


### PR DESCRIPTION
If a user of the library called `capture` too early then it tries to get
the device orientation from the RCTCamera instance... which doesn't yet
exist.

Instead of adding anything clever in the library, just call
promise.reject() so that the host application can decide what to do with
this issue (probably wait, retry in a bit).

This mainly effects slower Android devices where the camera can take a
long time to initialize.