### PR TITLE
Fix set after mount error

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,8 +181,7 @@ export default class Camera extends Component {
     if (check) {
       this.checkPromise = makeCancelable(check());
       this.checkPromise.promise
-      .then((result) => {
-        const isAuthorized = result;
+      .then((isAuthorized) => {
         this.setState({ isAuthorized });
       })
       .catch(() => {}); // Ignore the rejection for now.


### PR DESCRIPTION
Under certain situations (which happened in our app) the camera component would attempt to set its state after the component was unmounted.  This was due to an asynchronous `check()` operation which which completed after the component was unmounted.  In most cases this is fairly benign, and not noticeable outside of dev mode, but in the case that a new instance of the camera component is instantiated immediately after the old one is unmounted, the error actually interferes with the operation of the new component.

This PR fixes the problem by making the asynchronous operation cancelable and by using the `isAuthorized` state that is set after the operation is complete to control the rendering of the component.