### PR TITLE
Manual controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ On Android, use `getSupportedISOValues` to obtain a list of valid values for thi
 
 #### `iOS` `exposureDuration`
 
-Use the `exposureDuration` property to set the exposure duration (in seconds).
+Use the `exposureDuration` property to set the exposure. This property is an object containing two integer values: `value` and `scale`. Those values are passed to [CMTimeMake](https://developer.apple.com/documentation/coremedia/1400785-cmtimemake?language=objc) to create a CMTime.
 
 Use `getSupportedExposureDurationRange` to obtain the range of valid values for this property. Setting this property disables the automatic exposure algorithm.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The comprehensive camera module for React Native. Including photographs, videos,
 - Pull Requests are welcome, if you open a pull request we will do our best to get to it in a timely manner
 - Pull Request Reviews and even more welcome! we need help testing, reviewing, and updating open PRs
 - If you are interested in contributing more actively, please contact me (same username on Twitter, Facebook, etc.) Thanks!
-- We are now on [Open Collective](https://opencollective.com/react-native-camera#sponsor)! Contributions are appreciated and will be used to fund core contributors. [more details](#open-collective) 
+- We are now on [Open Collective](https://opencollective.com/react-native-camera#sponsor)! Contributions are appreciated and will be used to fund core contributors. [more details](#open-collective)
 
 #### Breaking Changes
 ##### android build tools has been bumped to 25.0.2, please update (can be done via android cli or AndroidStudio)
@@ -272,6 +272,50 @@ Values:
 
 Use the `torchMode` property to specify the camera torch mode.
 
+#### `iso`
+
+Use the `iso` property to define the sensor sensitivity (ISO).
+
+On iOS, use `getSupportedISORange` to obtain the range of valid values for this property. Setting this property on iOS disables the automatic exposure algorithm.
+
+On Android, use `getSupportedISOValues` to obtain a list of valid values for this property. An empty list means this setting is not supported on the device.
+
+#### `iOS` `exposureDuration`
+
+Use the `exposureDuration` property to set the exposure duration (in seconds).
+
+Use `getSupportedExposureDurationRange` to obtain the range of valid values for this property. Setting this property disables the automatic exposure algorithm.
+
+#### `exposureCompensation`
+
+Use the `exposureCompensation` property to define the bias to be applied to the target exposure value (in EV units).
+
+Use `getSupportedExposureCompensationRange` to obtain the range of valid valures for this property.
+
+#### `whiteBalancePreset`
+
+Values:
+`Camera.constants.WhiteBalancePreset.auto`,
+`Camera.constants.WhiteBalancePreset.cloudyDaylight`,
+`Camera.constants.WhiteBalancePreset.daylight`,
+`Camera.constants.WhiteBalancePreset.fluorescent`,
+`Camera.constants.WhiteBalancePreset.incandescent`,
+`Camera.constants.WhiteBalancePreset.shade`,
+`Camera.constants.WhiteBalancePreset.twilight`,
+`Camera.constants.WhiteBalancePreset.warmFluorescent`
+
+Use the `whiteBalancePreset` property to set a white balance preset.
+
+On Android, those constants map to the presets defined by the [API](https://developer.android.com/reference/android/hardware/Camera.Parameters.html#WHITE_BALANCE_AUTO).
+
+On iOS, they map to temperature settings defined by `react-native-camera` itself. Those presets do not necessarily look the same on both platforms. This option exists on iOS merely to make the API more consistent across platforms. iOS provides a much finer control of the white balance that can be accessed using the `whiteBalance` property.
+
+#### `iOS` `whiteBalance`
+
+Use the `whiteBalance` property to adjust the white balance. Do not use `whiteBalance` and `whiteBalancePreset` at the same time.
+
+This property is an object containing two values: `temperature` contains the color temperature in kelvin and `tint` is a value between -150 and +150.
+
 #### `iOS` `onFocusChanged: Event { nativeEvent: { touchPoint: { x, y } }`
 
 iOS: Called when a touch focus gesture has been made.
@@ -311,8 +355,8 @@ If set to `true`, the image returned will be mirrored.
 If set to `true`, the image returned will be rotated to the _right way up_.  WARNING: It uses a significant amount of memory and my cause your application to crash if the device cannot provide enough RAM to perform the rotation.
 
 (_If you find that you need to use this option because your images are incorrectly oriented by default,
-could please submit a PR and include the make model of the device.  We believe that it's not 
-required functionality any more and would like to remove it._) 
+could please submit a PR and include the make model of the device.  We believe that it's not
+required functionality any more and would like to remove it._)
 
 ## Component instance methods
 
@@ -345,6 +389,30 @@ The promise will be fulfilled with an object with some of the following properti
 #### `iOS` `getFOV(): Promise`
 
 Returns the camera's current field of view.
+
+#### `getSupportedISORange(): Promise`
+
+The promise returned by this method resolves to an object containing the keys `min` and `max` that define the minimum and maximum ISO values respectively.
+
+On iOS, any value in the returned range is valid.
+
+On Android, only some predetermined values are valid. The `getSupportedISOValues` method should be used in this case.
+
+#### `Android` `getSupportedISOValues(): Promise`
+
+The promise returned by this method resolves to an array of integers that are the ISO values accepted on the device. An empty array indicates that this setting is not supported by the device.
+
+#### `iOS` `getSupportedExposureDurationRange(): Promise`
+
+The promise returned by this method resolves to an object containing the keys `min` and `max` that define the minimum and maximum exposure times (in seconds) respectively.
+
+#### `getSupportedExposureCompensationRange(): Promise`
+
+The promise returned by this method resolves to an object containing the keys `min`, `max` and `step` that define the range of valid exposure compensation values.
+
+On iOS, any value between `min` and `max` is valid, therefore the `step` value will always be zero.
+
+On Android, the valid values are `min`, `min + step`, `min + 2*step`, ..., `max`, however, any value between `min` and `max` can be passed to `exposureCompensation`. The closest valid setting will be used.
 
 #### `hasFlash(): Promise`
 

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -345,6 +345,46 @@ public class RCTCamera {
         }
     }
 
+    public void setISO(int cameraType, int iso) {
+      Camera camera = this.acquireCameraInstance(cameraType);
+      if(null == camera) {
+        return;
+      }
+
+      Camera.Parameters parameters = camera.getParameters();
+      String key = RCTCameraUtils.findISOParameter(parameters);
+
+      if(null == key) {
+        return;
+      }
+
+      parameters.set(key, iso != -1 ? String.valueOf(iso) : "auto");
+      camera.setParameters(parameters);
+    }
+
+    public void setExposureCompensation(int cameraType, double exposureCompensation) {
+      Camera camera = this.acquireCameraInstance(cameraType);
+      if(null == camera) {
+        return;
+      }
+
+      Camera.Parameters parameters = camera.getParameters();
+      double step = parameters.getExposureCompensationStep();
+      parameters.setExposureCompensation((int) (exposureCompensation/step));
+      camera.setParameters(parameters);
+    }
+
+    public void setWhiteBalancePreset(int cameraType, String preset) {
+      Camera camera = this.acquireCameraInstance(cameraType);
+      if(null == camera) {
+        return;
+      }
+
+      Camera.Parameters parameters = camera.getParameters();
+      parameters.setWhiteBalance(preset != null ? preset : RCTCameraModule.RCT_CAMERA_WHITE_BALANCE_AUTO);
+      camera.setParameters(parameters);
+    }
+
     public void adjustCameraRotationToDeviceOrientation(int type, int deviceOrientation) {
         Camera camera = _cameras.get(type);
         if (null == camera) {

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraUtils.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraUtils.java
@@ -3,11 +3,16 @@ package com.lwansbrough.RCTCamera;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.hardware.Camera;
+import android.hardware.Camera.Parameters;
 import android.view.MotionEvent;
 
 public class RCTCameraUtils {
     private static final int FOCUS_AREA_MOTION_EVENT_EDGE_LENGTH = 100;
     private static final int FOCUS_AREA_WEIGHT = 1000;
+
+    //Some known property names that contain ISO information. Taken from https://stackoverflow.com/a/23567103/3489942:
+    private static final String[] ISO_KEYS = new String[] {"iso", "iso-speed", "nv-picture-iso"};
+    private static final String[] ISO_VALUES_KEYS = new String[] {"iso-values", "iso-speed-values", "iso-mode-values", "nv-picture-iso-values"};
 
     /**
      * Computes a Camera.Area corresponding to the new focus area to focus the camera on. This is
@@ -68,5 +73,35 @@ public class RCTCameraUtils {
         Rect focusAreaRectRounded = new Rect();
         focusAreaRect.round(focusAreaRectRounded);
         return new Camera.Area(focusAreaRectRounded, FOCUS_AREA_WEIGHT);
+    }
+
+    private static String searchParameters(Parameters parameters, String[] strs) {
+      String result = null;
+
+      for(int i = 0; i < strs.length; i++) {
+          result = parameters.get(strs[i]);
+
+          if(result != null) {
+              return strs[i];
+          }
+      }
+
+      return null;
+    }
+
+    /**
+     * Searches the camera parameters structure for some known keys that contain the ISO value.
+     * Returns null is none of the known keys is found.
+     */
+    protected static String findISOParameter(Parameters parameters) {
+        return searchParameters(parameters, ISO_KEYS);
+    }
+
+    /**
+     * Searches the camera parameters structure for some known keys that contain the available ISO values.
+     * Returns null is none of the known keys is found.
+     */
+    protected static String findISOValuesParameter(Parameters parameters) {
+        return searchParameters(parameters, ISO_VALUES_KEYS);
     }
 }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
@@ -10,7 +10,6 @@ import android.view.OrientationEventListener;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.View;
-
 import java.util.List;
 
 public class RCTCameraView extends ViewGroup {
@@ -23,6 +22,9 @@ public class RCTCameraView extends ViewGroup {
     private String _captureQuality = "high";
     private int _torchMode = -1;
     private int _flashMode = -1;
+    private int _iso = -1;
+    private double _exposureCompensation = 0;
+    private String _whiteBalancePreset = null;
 
     public RCTCameraView(Context context) {
         super(context);
@@ -76,6 +78,15 @@ public class RCTCameraView extends ViewGroup {
             if (-1 != this._torchMode) {
                 _viewFinder.setTorchMode(this._torchMode);
             }
+            if (-1 != this._iso) {
+                _viewFinder.setISO(this._iso);
+            }
+            if (0 != this._exposureCompensation) {
+                _viewFinder.setExposureCompensation(this._exposureCompensation);
+            }
+            if (null != this._whiteBalancePreset) {
+                _viewFinder.setWhiteBalancePreset(this._whiteBalancePreset);
+            }
             addView(_viewFinder);
         }
     }
@@ -112,6 +123,27 @@ public class RCTCameraView extends ViewGroup {
         RCTCamera.getInstance().setOrientation(orientation);
         if (this._viewFinder != null) {
             layoutViewFinder();
+        }
+    }
+
+    public void setISO(int iso) {
+        this._iso = iso;
+        if (this._viewFinder != null) {
+            this._viewFinder.setISO(iso);
+        }
+    }
+
+    public void setExposureCompensation(double exposureCompensation) {
+        this._exposureCompensation = exposureCompensation;
+        if (this._viewFinder != null) {
+            this._viewFinder.setExposureCompensation(exposureCompensation);
+        }
+    }
+
+    public void setWhiteBalancePreset(String preset) {
+        this._whiteBalancePreset = preset;
+        if (this._viewFinder != null) {
+            this._viewFinder.setWhiteBalancePreset(preset);
         }
     }
 

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
@@ -1,8 +1,7 @@
 package com.lwansbrough.RCTCamera;
 
-import android.support.annotation.Nullable;
-
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.*;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
@@ -85,5 +84,30 @@ public class RCTCameraViewManager extends ViewGroupManager<RCTCameraView> {
             result.add(barCodeTypes.getString(i));
         }
         view.setBarCodeTypes(result);
+    }
+
+    @ReactProp(name = "iso")
+    public void setISO(RCTCameraView view, int iso) {
+        view.setISO(iso);
+    }
+
+    @ReactProp(name = "exposureCompensation")
+    public void setExposureCompensation(RCTCameraView view, double exposureCompensation) {
+      view.setExposureCompensation(exposureCompensation);
+    }
+
+    @ReactProp(name = "exposureDuration")
+    public void setExposureDuration(RCTCameraView view, double exposureDuration) {
+      //Not supported on Android.
+    }
+
+    @ReactProp(name = "whiteBalancePreset")
+    public void setWhiteBalancePreset(RCTCameraView view, String preset) {
+      view.setWhiteBalancePreset(preset);
+    }
+
+    @ReactProp(name = "whiteBalance")
+    public void setWhiteBalance(RCTCameraView view, ReadableMap whiteBalance) {
+      //Not supported on Android.
     }
 }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
@@ -97,7 +97,7 @@ public class RCTCameraViewManager extends ViewGroupManager<RCTCameraView> {
     }
 
     @ReactProp(name = "exposureDuration")
-    public void setExposureDuration(RCTCameraView view, double exposureDuration) {
+    public void setExposureDuration(RCTCameraView view, ReadableMap exposureDuration) {
       //Not supported on Android.
     }
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,8 @@ export default class Camera extends Component {
     CaptureQuality: CameraManager.CaptureQuality,
     Orientation: CameraManager.Orientation,
     FlashMode: CameraManager.FlashMode,
-    TorchMode: CameraManager.TorchMode
+    TorchMode: CameraManager.TorchMode,
+    WhiteBalancePreset: CameraManager.WhiteBalancePreset
   };
 
   static propTypes = {
@@ -96,6 +97,17 @@ export default class Camera extends Component {
       PropTypes.string,
       PropTypes.number
     ]),
+    iso: PropTypes.number,
+    exposureCompensation: PropTypes.number,
+    exposureDuration: PropTypes.number,
+    whiteBalancePreset: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]),
+    whiteBalance: PropTypes.shape({
+      temperature: PropTypes.number.isRequired,
+      tint: PropTypes.number.isRequired
+    }),
     keepAwake: PropTypes.bool,
     onBarCodeRead: PropTypes.func,
     barcodeScannerEnabled: PropTypes.bool,
@@ -256,6 +268,48 @@ export default class Camera extends Component {
       });
     }
     return CameraManager.hasFlash();
+  }
+
+  getSupportedISOValues() {
+    if (Platform.OS === 'android') {
+      const props = convertNativeProps(this.props);
+      return CameraManager.getSupportedISOValues({
+        type: props.type
+      });
+    }
+
+    //On iOS we can use any value in a range.
+    return Promise.resolve([]);
+  }
+
+  getSupportedISORange() {
+    if (Platform.OS === 'android') {
+      const props = convertNativeProps(this.props);
+      return CameraManager.getSupportedISORange({
+        type: props.type
+      });
+    }
+
+    return CameraManager.getSupportedISORange();
+  }
+
+  getSupportedExposureCompensationRange() {
+    if (Platform.OS === 'android') {
+      const props = convertNativeProps(this.props);
+      return CameraManager.getSupportedExposureCompensationRange({
+        type: props.type
+      });
+    }
+    return CameraManager.getSupportedExposureCompensationRange();
+  }
+
+  getSupportedExposureDurationRange() {
+    if (Platform.OS === 'ios') {
+      return CameraManager.getSupportedExposureDurationRange();
+    }
+
+    //Not supported on Android:
+    return Promise.resolve({});
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -99,7 +99,10 @@ export default class Camera extends Component {
     ]),
     iso: PropTypes.number,
     exposureCompensation: PropTypes.number,
-    exposureDuration: PropTypes.number,
+    exposureDuration: PropTypes.shape({
+      value: PropTypes.number.isRequired,
+      scale: PropTypes.number.isRequired
+    }),
     whiteBalancePreset: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number

--- a/ios/RCTCameraManager.h
+++ b/ios/RCTCameraManager.h
@@ -56,6 +56,17 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
   RCTCameraTorchModeAuto = AVCaptureTorchModeAuto
 };
 
+typedef NS_ENUM(NSInteger, RCTCameraWhiteBalancePreset) {
+  RCTCameraWhiteBalanceAuto = 0,
+  RCTCameraWhiteBalanceCloudyDaylight = 1,
+  RCTCameraWhiteBalanceDaylight = 2,
+  RCTCameraWhiteBalanceFluorescent = 3,
+  RCTCameraWhiteBalanceIncandescent = 4,
+  RCTCameraWhiteBalanceShade = 5,
+  RCTCameraWhiteBalanceTwilight = 6,
+  RCTCameraWhiteBalanceWarmFluorescent = 7
+};
+
 @interface RCTCameraManager : RCTViewManager<AVCaptureMetadataOutputObjectsDelegate, AVCaptureFileOutputRecordingDelegate>
 
 @property (nonatomic, strong) dispatch_queue_t sessionQueue;
@@ -82,6 +93,9 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 - (void)capture:(NSDictionary*)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)getFOV:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)getSupportedISORange:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)getSupportedExposureDurationRange:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)getSupportedExposureCompensationRange:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)initializeCaptureSessionInput:(NSString*)type;
 - (void)stopCapture;
 - (void)startSession;

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -18,7 +18,7 @@
 @property (assign, nonatomic) NSInteger torchMode;
 @property (assign, nonatomic) NSInteger iso;
 @property (assign, nonatomic) double exposureCompensation;
-@property (assign, nonatomic) double exposureDuration;
+@property (assign, nonatomic) CMTime *exposureDuration;
 @property (assign, nonatomic) AVCaptureWhiteBalanceTemperatureAndTintValues *whiteBalance;
 
 @end
@@ -326,18 +326,33 @@ RCT_EXPORT_METHOD(getSupportedISORange:(RCTPromiseResolveBlock)resolve reject:(R
   if(self.iso != -1) {
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
-    
+
     if (![device lockForConfiguration:&error]) {
       NSLog(@"%@", error);
       return;
     }
-    [device setExposureModeCustomWithDuration:AVCaptureExposureDurationCurrent ISO:(float)self.iso completionHandler: nil];
+    [device setExposureModeCustomWithDuration:self.exposureDuration != nil ? *(self.exposureDuration) : AVCaptureExposureDurationCurrent ISO:(float)self.iso completionHandler: nil];
     [device unlockForConfiguration];
   }
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(exposureDuration, NSInteger, RCTCamera) {
-  self.exposureDuration = [RCTConvert double:json];
+RCT_CUSTOM_VIEW_PROPERTY(exposureDuration, NSDictionary, RCTCamera) {
+  if(json) {
+    NSDictionary *dict = [RCTConvert NSDictionary:json];
+    NSInteger value = [dict[@"value"] integerValue];
+    NSInteger scale = [dict[@"scale"] integerValue];
+
+    if(self.exposureDuration == nil) {
+      self.exposureDuration = malloc(sizeof(CMTime));
+    }
+
+    *(self.exposureDuration) = CMTimeMake(value, scale);
+  } else {
+    if(self.exposureDuration != nil) {
+      free(self.exposureDuration);
+      self.exposureDuration = nil;
+    }
+  }
   dispatch_async(self.sessionQueue, ^{
     [self setExposureDuration];
   });
@@ -353,20 +368,19 @@ RCT_EXPORT_METHOD(getSupportedExposureDurationRange:(RCTPromiseResolveBlock)reso
 }
 
 - (void)setExposureDuration {
-  if(self.exposureDuration != -1) {
+  if(self.exposureDuration != nil) {
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
-    
+
     if (![device lockForConfiguration:&error]) {
       NSLog(@"%@", error);
       return;
     }
-    
-    [device setExposureModeCustomWithDuration:CMTimeMakeWithSeconds(self.exposureDuration, NSEC_PER_SEC) ISO:AVCaptureISOCurrent completionHandler: nil];
+
+    [device setExposureModeCustomWithDuration: *(self.exposureDuration) ISO:self.iso != -1 ? self.iso : AVCaptureISOCurrent completionHandler: nil];
     [device unlockForConfiguration];
   }
 }
-
 
 RCT_CUSTOM_VIEW_PROPERTY(exposureCompensation, float, RCTCamera) {
   self.exposureCompensation = [RCTConvert float:json];
@@ -387,7 +401,7 @@ RCT_EXPORT_METHOD(getSupportedExposureCompensationRange:(RCTPromiseResolveBlock)
 - (void)setExposureCompensation {
   AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
   NSError *error = nil;
-  
+
   if(![device lockForConfiguration:&error]) {
     NSLog(@"%@", error);
     return;
@@ -398,7 +412,7 @@ RCT_EXPORT_METHOD(getSupportedExposureCompensationRange:(RCTPromiseResolveBlock)
 
 RCT_CUSTOM_VIEW_PROPERTY(whiteBalancePreset, NSInteger, RCTCamera) {
   NSInteger preset = json ? [RCTConvert NSInteger:json] : RCTCameraWhiteBalanceAuto;
-  
+
   if(preset == RCTCameraWhiteBalanceAuto) {
     if(self.whiteBalance != nil) {
       free(self.whiteBalance);
@@ -408,52 +422,52 @@ RCT_CUSTOM_VIEW_PROPERTY(whiteBalancePreset, NSInteger, RCTCamera) {
     if(self.whiteBalance == nil) {
       self.whiteBalance = malloc(sizeof(AVCaptureWhiteBalanceTemperatureAndTintValues));
     }
-    
+
     self.whiteBalance->tint = 0;
-    
+
     switch(preset) {
       case RCTCameraWhiteBalanceCloudyDaylight:
         self.whiteBalance->temperature = 6500;
         break;
-        
+
       case RCTCameraWhiteBalanceDaylight:
         self.whiteBalance->temperature = 6500;
         break;
-        
+
       case RCTCameraWhiteBalanceFluorescent:
         self.whiteBalance->temperature = 4200;
         break;
-        
+
       case RCTCameraWhiteBalanceIncandescent:
         self.whiteBalance->temperature = 2500;
         break;
-        
+
       case RCTCameraWhiteBalanceShade:
         self.whiteBalance->temperature = 9000;
         break;
-        
+
       case RCTCameraWhiteBalanceTwilight:
         self.whiteBalance->temperature = 2500;
         break;
-        
+
       case RCTCameraWhiteBalanceWarmFluorescent:
         self.whiteBalance->temperature = 3200;
         break;
     }
-    
+
     dispatch_async(self.sessionQueue, ^{
       [self setWhiteBalance];
     });
   }
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(whiteBalance, NSInteger, RCTCamera) {
+RCT_CUSTOM_VIEW_PROPERTY(whiteBalance, NSDictionary, RCTCamera) {
   if(json) {
     NSDictionary *dict = [RCTConvert NSDictionary:json];
     if(self.whiteBalance == nil) {
       self.whiteBalance = malloc(sizeof(AVCaptureWhiteBalanceTemperatureAndTintValues));
     }
-    
+
     self.whiteBalance->temperature = [dict[@"temperature"] floatValue];
     self.whiteBalance->tint = [dict[@"tint"] floatValue];
   } else {
@@ -471,12 +485,12 @@ RCT_CUSTOM_VIEW_PROPERTY(whiteBalance, NSInteger, RCTCamera) {
   dispatch_async(self.sessionQueue, ^{
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
-    
+
     if (![device lockForConfiguration:&error]) {
       NSLog(@"%@", error);
       return;
     }
-    
+
     if(self.whiteBalance == nil) {
       [device setWhiteBalanceMode:AVCaptureWhiteBalanceModeContinuousAutoWhiteBalance];
     } else {
@@ -523,13 +537,13 @@ RCT_CUSTOM_VIEW_PROPERTY(captureAudio, BOOL, RCTCamera) {
     self.sessionQueue = dispatch_queue_create("cameraManagerQueue", DISPATCH_QUEUE_SERIAL);
 
     self.sensorOrientationChecker = [RCTSensorOrientationChecker new];
-    
+
     self.iso = -1;
-    
+
     self.exposureCompensation = 0;
-    
-    self.exposureDuration = -1;
-    
+
+    self.exposureDuration = nil;
+
     self.whiteBalance = nil;
   }
   return self;
@@ -706,7 +720,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
         return;
       }
     }
-    
+
     [self.session beginConfiguration];
 
     NSError *error = nil;
@@ -744,7 +758,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
         self.videoCaptureDeviceInput = captureDeviceInput;
         [self setFlashMode];
       }
-      
+
       [self.metadataOutput setMetadataObjectTypes:self.metadataOutput.availableMetadataObjectTypes];
     }
 


### PR DESCRIPTION
This pull request provides access to manual controls for the camera: ISO, white balance and exposure compensation.

Exposure compensation maps to [setExposureCompensation](https://developer.android.com/reference/android/hardware/Camera.Parameters.html#setExposureCompensation(int)) on Android and [setExposureTargetBias](https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624637-setexposuretargetbias?language=objc) on iOS. On iOS it is also possible to set the exposure duration using [setExposureModeCustomWithDuration](https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624646-setexposuremodecustomwithduratio?language=objc).

White balance on Android can be set to any of the presets defined in the [API](https://developer.android.com/reference/android/hardware/Camera.Parameters.html#WHITE_BALANCE_AUTO) and I tried to reproduce those presets on iOS using color temperatures taken from some white balance table I found online. On iOS it is also possible to set the white balance directly using color temperature and tint. Those values are converted do device-specific gains using [deviceWhiteBalanceGainsForTemperatureAndTintValues](https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624628-devicewhitebalancegainsfortemper?language=objc).

ISO support on Android is somewhat hacky, since the API does not support it. So I search Camera.Parameters for some known ISO attributes and try to use them. I guess it's the best we can do without moving to the Camera2 API. On iOS it maps to [setExposureModeCustomWithDuration](https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624646-setexposuremodecustomwithduratio?language=objc).

If the maintainers are interested in merging this pull request, I'll be happy to make any changes you consider necessary.