### PR TITLE
Fix: Bigger Bounds than Screen on some Android devices

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -400,8 +400,9 @@ public class RCTCamera {
 
         // set preview size
         // defaults to highest resolution available for screen
-        int maxWidth= (_screen.heightPixels>_screen.widthPixels)?_screen.widthPixels:_screen.heightPixels;
-        int maxHeight= (_screen.heightPixels>_screen.widthPixels)?_screen.heightPixels:_screen.widthPixels;
+        // swap width and height, because getSupportedPreviewSizes returns landscape values
+        int maxHeight= (_screen.heightPixels>_screen.widthPixels)?(_screen.widthPixels):(_screen.heightPixels);
+        int maxWidth= (_screen.heightPixels>_screen.widthPixels)?(_screen.heightPixels):(_screen.widthPixels);
         Camera.Size optimalPreviewSize = getBestSize(parameters.getSupportedPreviewSizes(), maxWidth, maxHeight);
         int width = optimalPreviewSize.width;
         int height = optimalPreviewSize.height;

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -6,6 +6,7 @@ package com.lwansbrough.RCTCamera;
 
 import android.hardware.Camera;
 import android.media.CamcorderProfile;
+import android.util.DisplayMetrics;
 import android.util.Log;
 
 import java.util.HashMap;
@@ -26,12 +27,13 @@ public class RCTCamera {
     private int _orientation = -1;
     private int _actualDeviceOrientation = 0;
     private int _adjustedDeviceOrientation = 0;
+    private DisplayMetrics _screen = null;
 
     public static RCTCamera getInstance() {
         return ourInstance;
     }
-    public static void createInstance(int deviceOrientation) {
-        ourInstance = new RCTCamera(deviceOrientation);
+    public static void createInstance(int deviceOrientation,DisplayMetrics displayMetrics) {
+        ourInstance = new RCTCamera(deviceOrientation,displayMetrics);
     }
 
 
@@ -397,8 +399,10 @@ public class RCTCamera {
         parameters.setRotation(cameraInfo.rotation);
 
         // set preview size
-        // defaults to highest resolution available
-        Camera.Size optimalPreviewSize = getBestSize(parameters.getSupportedPreviewSizes(), Integer.MAX_VALUE, Integer.MAX_VALUE);
+        // defaults to highest resolution available for screen
+        int maxWidth= (_screen.heightPixels>_screen.widthPixels)?_screen.widthPixels:_screen.heightPixels;
+        int maxHeight= (_screen.heightPixels>_screen.widthPixels)?_screen.heightPixels:_screen.widthPixels;
+        Camera.Size optimalPreviewSize = getBestSize(parameters.getSupportedPreviewSizes(), maxWidth, maxHeight);
         int width = optimalPreviewSize.width;
         int height = optimalPreviewSize.height;
 
@@ -418,12 +422,13 @@ public class RCTCamera {
         }
     }
 
-    private RCTCamera(int deviceOrientation) {
+    private RCTCamera(int deviceOrientation,DisplayMetrics displayMetrics) {
         _cameras = new HashMap<>();
         _cameraInfos = new HashMap<>();
         _cameraTypeToIndex = new HashMap<>();
 
         _actualDeviceOrientation = deviceOrientation;
+        _screen=displayMetrics;
 
         // map camera types to camera indexes and collect cameras properties
         for (int i = 0; i < Camera.getNumberOfCameras(); i++) {

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
@@ -28,7 +28,7 @@ public class RCTCameraView extends ViewGroup {
     public RCTCameraView(Context context) {
         super(context);
         this._context = context;
-        RCTCamera.createInstance(getDeviceOrientation(context));
+        RCTCamera.createInstance(getDeviceOrientation(context),getScreenSize());
 
         _orientationListener = new OrientationEventListener(context, SensorManager.SENSOR_DELAY_NORMAL) {
             @Override

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
@@ -6,6 +6,7 @@ package com.lwansbrough.RCTCamera;
 
 import android.content.Context;
 import android.hardware.SensorManager;
+import android.util.DisplayMetrics;
 import android.view.OrientationEventListener;
 import android.view.ViewGroup;
 import android.view.WindowManager;
@@ -122,7 +123,11 @@ public class RCTCameraView extends ViewGroup {
     public void setBarCodeTypes(List<String> types) {
         RCTCamera.getInstance().setBarCodeTypes(types);
     }
-
+    public DisplayMetrics getScreenSize(){
+        DisplayMetrics metrics = new DisplayMetrics();
+        ((WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(metrics);
+        return metrics;
+    }
     private boolean setActualDeviceOrientation(Context context) {
         int actualDeviceOrientation = getDeviceOrientation(context);
         if (_actualDeviceOrientation != actualDeviceOrientation) {


### PR DESCRIPTION
Fixes the problem, that the returned bounds from onBarcodeScan are bigger than the screen resolution on some Android devices.
This problem was caused by using the biggest supported preview size as default, because some Android devices support preview sizes which are bigger than the devices screen resolution.