### PR TITLE
Removed iOS label from on-focused-changed header

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Values:
 
 Use the `torchMode` property to specify the camera torch mode.
 
-#### `iOS` `onFocusChanged: Event { nativeEvent: { touchPoint: { x, y } }`
+#### `onFocusChanged: Event { nativeEvent: { touchPoint: { x, y } }`
 
 iOS: Called when a touch focus gesture has been made.
 By default, `onFocusChanged` is not defined and tap-to-focus is disabled.


### PR DESCRIPTION
Updated docs to reflect that `on-focus-changed` instructions are not limited to iOS. Follow-up to my misunderstanding on [this PR](https://github.com/react-native-community/react-native-camera/pull/1009).