### PR TITLE
Fix performance issue on Android: add option to clear window background when camera starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,14 @@ from javascript.
 
 If set to `true`, the device will not sleep while the camera preview is visible. This mimics the behavior of the default camera app, which keeps the device awake while open.
 
+#### `Android` `clearWindowBackground`
+
+Values:
+`true`
+`false` (default)
+
+If you encounter performance issue while using a window background drawable (typically defined in theme to emulate splashscreen behavior), set this to true to automatically clear window background once camera is started.
+
 #### `Android` `permissionDialogTitle`
 
 Starting on android M individual permissions must be granted for certain services, the camera is one of them, you can use this to change the title of the dialog prompt requesting permissions.

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
@@ -24,6 +24,7 @@ public class RCTCameraView extends ViewGroup {
     private String _captureQuality = "high";
     private int _torchMode = -1;
     private int _flashMode = -1;
+    private boolean _clearWindowBackground = false;
 
     public RCTCameraView(Context context) {
         super(context);
@@ -77,6 +78,7 @@ public class RCTCameraView extends ViewGroup {
             if (-1 != this._torchMode) {
                 _viewFinder.setTorchMode(this._torchMode);
             }
+            _viewFinder.setClearWindowBackground(this._clearWindowBackground);
             addView(_viewFinder);
         }
     }
@@ -122,6 +124,13 @@ public class RCTCameraView extends ViewGroup {
 
     public void setBarCodeTypes(List<String> types) {
         RCTCamera.getInstance().setBarCodeTypes(types);
+    }
+
+    public void setClearWindowBackground(boolean clearWindowBackground) {
+        this._clearWindowBackground = clearWindowBackground;
+        if (this._viewFinder != null) {
+            this._viewFinder.setClearWindowBackground(clearWindowBackground);
+        }
     }
 
     private boolean setActualDeviceOrientation(Context context) {

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
@@ -86,4 +86,9 @@ public class RCTCameraViewManager extends ViewGroupManager<RCTCameraView> {
         }
         view.setBarCodeTypes(result);
     }
+
+    @ReactProp(name = "clearWindowBackground")
+    public void setClearWindowBackground(RCTCameraView view, boolean clearWindowBackground) {
+        view.setClearWindowBackground(clearWindowBackground);
+    }
 }

--- a/src/Camera.js
+++ b/src/Camera.js
@@ -87,6 +87,7 @@ export default class Camera extends Component {
     onBarCodeRead: PropTypes.func,
     barcodeScannerEnabled: PropTypes.bool,
     cropToPreview: PropTypes.bool,
+    clearWindowBackground: PropTypes.bool,
     onFocusChanged: PropTypes.func,
     onZoomChanged: PropTypes.func,
     mirrorImage: PropTypes.bool,
@@ -117,6 +118,7 @@ export default class Camera extends Component {
     torchMode: CameraManager.TorchMode.off,
     mirrorImage: false,
     cropToPreview: false,
+    clearWindowBackground: false,
     barCodeTypes: Object.values(CameraManager.BarCodeType),
     permissionDialogTitle: '',
     permissionDialogMessage: '',
@@ -191,18 +193,16 @@ export default class Camera extends Component {
         message: this.props.permissionDialogMessage,
       });
 
-      // On devices before SDK version 23, the permissions are automatically granted if they appear in the manifest, 
+      // On devices before SDK version 23, the permissions are automatically granted if they appear in the manifest,
       // so check and request should always be true.
       // https://github.com/facebook/react-native-website/blob/master/docs/permissionsandroid.md
-      const isAuthorized = Platform.Version >= 23
-		      ? granted === PermissionsAndroid.RESULTS.GRANTED
-          : granted === true;
-      
+      const isAuthorized =
+        Platform.Version >= 23 ? granted === PermissionsAndroid.RESULTS.GRANTED : granted === true;
+
       this.setState({
-	      isAuthorized,
-		    isAuthorizationChecked: true
+        isAuthorized,
+        isAuthorizationChecked: true,
       });
-      
     } else {
       this.setState({ isAuthorized: true, isAuthorizationChecked: true });
     }
@@ -276,7 +276,7 @@ export default class Camera extends Component {
       mirrorImage: props.mirrorImage,
       fixOrientation: props.fixOrientation,
       cropToPreview: props.cropToPreview,
-      ...options
+      ...options,
     };
 
     if (options.mode === Camera.constants.CaptureMode.video) {


### PR DESCRIPTION
I encountered a big performance issue on Android (frame rate dropping from 60 to 10 FPS) while using a window background drawable to display as splash screen until the app is loaded.
The problem doesn't occur on all devices, but it occurs on Samsung Galaxy S6 for example.

This PR adds a clearWindowBackground prop, if set to true window background drawable will be set to null once the camera is started, hence fixing the performance issue.
By default, the prop is set to false to preserve current behavior.