### PR TITLE
Add Expo Camera implementation classes for future integration

### DIFF
--- a/ios/CandidateRCTCamera.h
+++ b/ios/CandidateRCTCamera.h
@@ -1,0 +1,57 @@
+#import <AVFoundation/AVFoundation.h>
+#import <React/RCTBridge.h>
+#import <React/RCTBridgeModule.h>
+#import <UIKit/UIKit.h>
+#import "CandidateRCTCamera.h"
+
+//#if __has_include("EXFaceDetectorManager.h")
+//#import "EXFaceDetectorManager.h"
+//#else
+//#import "EXFaceDetectorManagerStub.h"
+//#endif
+
+@class CandidateRCTCamera;
+
+//@interface CandidateRCTCamera : UIView <AVCaptureMetadataOutputObjectsDelegate, AVCaptureFileOutputRecordingDelegate, EXFaceDetectorDelegate>
+@interface CandidateRCTCamera : UIView <AVCaptureMetadataOutputObjectsDelegate, AVCaptureFileOutputRecordingDelegate>
+
+@property(nonatomic, strong) dispatch_queue_t sessionQueue;
+@property(nonatomic, strong) AVCaptureSession *session;
+@property(nonatomic, strong) AVCaptureDeviceInput *videoCaptureDeviceInput;
+@property(nonatomic, strong) AVCaptureStillImageOutput *stillImageOutput;
+@property(nonatomic, strong) AVCaptureMovieFileOutput *movieFileOutput;
+@property(nonatomic, strong) AVCaptureMetadataOutput *metadataOutput;
+@property(nonatomic, strong) id runtimeErrorHandlingObserver;
+@property(nonatomic, strong) AVCaptureVideoPreviewLayer *previewLayer;
+@property(nonatomic, strong) NSArray *barCodeTypes;
+
+@property(nonatomic, assign) NSInteger presetCamera;
+@property (assign, nonatomic) NSInteger flashMode;
+@property (assign, nonatomic) CGFloat zoom;
+@property (assign, nonatomic) NSInteger autoFocus;
+@property (assign, nonatomic) float focusDepth;
+@property (assign, nonatomic) NSInteger whiteBalance;
+@property (nonatomic, assign, getter=isReadingBarCodes) BOOL barCodeReading;
+
+- (id)initWithBridge:(RCTBridge *)bridge;
+- (void)updateType;
+- (void)updateFlashMode;
+- (void)updateFocusMode;
+- (void)updateFocusDepth;
+- (void)updateZoom;
+- (void)updateWhiteBalance;
+- (void)updateFaceDetecting:(id)isDetectingFaces;
+- (void)updateFaceDetectionMode:(id)requestedMode;
+- (void)updateFaceDetectionLandmarks:(id)requestedLandmarks;
+- (void)updateFaceDetectionClassifications:(id)requestedClassifications;
+- (void)takePicture:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)record:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)stopRecording;
+- (void)setupOrDisableBarcodeScanner;
+- (void)onReady:(NSDictionary *)event;
+- (void)onMountingError:(NSDictionary *)event;
+- (void)onCodeRead:(NSDictionary *)event;
+- (void)onFacesDetected:(NSDictionary *)event;
+
+@end
+

--- a/ios/CandidateRCTCamera.m
+++ b/ios/CandidateRCTCamera.m
@@ -1,0 +1,744 @@
+#import "CandidateRCTCamera.h"
+#import "RCTCameraUtils.h"
+#import "RCTImageUtils.h"
+#import "CandidateRCTCameraManager.h"
+#import "RCTFileSystem.h"
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTLog.h>
+#import <React/RCTUtils.h>
+#import <React/UIView+React.h>
+#import <AVFoundation/AVFoundation.h>
+
+@interface CandidateRCTCamera ()
+
+@property (nonatomic, weak) RCTBridge *bridge;
+
+@property (nonatomic, assign, getter=isSessionPaused) BOOL paused;
+
+@property (nonatomic, strong) RCTPromiseResolveBlock videoRecordedResolve;
+@property (nonatomic, strong) RCTPromiseRejectBlock videoRecordedReject;
+@property (nonatomic, strong) id faceDetectorManager;
+
+@property (nonatomic, copy) RCTDirectEventBlock onCameraReady;
+@property (nonatomic, copy) RCTDirectEventBlock onMountError;
+@property (nonatomic, copy) RCTDirectEventBlock onBarCodeRead;
+@property (nonatomic, copy) RCTDirectEventBlock onFacesDetected;
+
+@end
+
+@implementation CandidateRCTCamera
+
+static NSDictionary *defaultFaceDetectorOptions = nil;
+
+- (id)initWithBridge:(RCTBridge *)bridge
+{
+    if ((self = [super init])) {
+        self.bridge = bridge;
+        self.session = [AVCaptureSession new];
+        self.sessionQueue = dispatch_queue_create("cameraQueue", DISPATCH_QUEUE_SERIAL);
+        self.faceDetectorManager = [self createFaceDetectorManager];
+#if !(TARGET_IPHONE_SIMULATOR)
+        self.previewLayer =
+        [AVCaptureVideoPreviewLayer layerWithSession:self.session];
+        self.previewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
+        self.previewLayer.needsDisplayOnBoundsChange = YES;
+#endif
+        self.paused = NO;
+        [self changePreviewOrientation:[UIApplication sharedApplication].statusBarOrientation];
+        [self initializeCaptureSessionInput];
+        [self startSession];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(orientationChanged:)
+                                                     name:UIDeviceOrientationDidChangeNotification
+                                                   object:nil];
+        //        [[NSNotificationCenter defaultCenter] addObserver:self
+        //                                                 selector:@selector(bridgeDidForeground:)
+        //                                                     name:EX_UNVERSIONED(@"EXKernelBridgeDidForegroundNotification")
+        //                                                   object:self.bridge];
+        //
+        //        [[NSNotificationCenter defaultCenter] addObserver:self
+        //                                                 selector:@selector(bridgeDidBackground:)
+        //                                                     name:EX_UNVERSIONED(@"EXKernelBridgeDidBackgroundNotification")
+        //                                                   object:self.bridge];
+        
+    }
+    return self;
+}
+
+- (void)onReady:(NSDictionary *)event
+{
+    if (_onCameraReady) {
+        _onCameraReady(nil);
+    }
+}
+
+- (void)onMountingError:(NSDictionary *)event
+{
+    if (_onMountError) {
+        _onMountError(event);
+    }
+}
+
+- (void)onCodeRead:(NSDictionary *)event
+{
+    if (_onBarCodeRead) {
+        _onBarCodeRead(event);
+    }
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    self.previewLayer.frame = self.bounds;
+    [self setBackgroundColor:[UIColor blackColor]];
+    [self.layer insertSublayer:self.previewLayer atIndex:0];
+}
+
+- (void)insertReactSubview:(UIView *)view atIndex:(NSInteger)atIndex
+{
+    [self insertSubview:view atIndex:atIndex + 1];
+    [super insertReactSubview:view atIndex:atIndex];
+    return;
+}
+
+- (void)removeReactSubview:(UIView *)subview
+{
+    [subview removeFromSuperview];
+    [super removeReactSubview:subview];
+    return;
+}
+
+- (void)removeFromSuperview
+{
+    [self stopSession];
+    [super removeFromSuperview];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
+}
+
+-(void)updateType
+{
+    dispatch_async(self.sessionQueue, ^{
+        [self initializeCaptureSessionInput];
+        if (!self.session.isRunning) {
+            [self startSession];
+        }
+    });
+}
+
+- (void)updateFlashMode
+{
+    AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
+    NSError *error = nil;
+    
+    if (self.flashMode == RCTCameraFlashModeTorch) {
+        if (![device hasTorch])
+            return;
+        if (![device lockForConfiguration:&error]) {
+            if (error) {
+                RCTLogError(@"%s: %@", __func__, error);
+            }
+            return;
+        }
+        if (device.hasTorch && [device isTorchModeSupported:AVCaptureTorchModeOn])
+        {
+            NSError *error = nil;
+            if ([device lockForConfiguration:&error]) {
+                [device setFlashMode:AVCaptureFlashModeOff];
+                [device setTorchMode:AVCaptureTorchModeOn];
+                [device unlockForConfiguration];
+            } else {
+                if (error) {
+                    RCTLogError(@"%s: %@", __func__, error);
+                }
+            }
+        }
+    } else {
+        if (![device hasFlash])
+            return;
+        if (![device lockForConfiguration:&error]) {
+            if (error) {
+                RCTLogError(@"%s: %@", __func__, error);
+            }
+            return;
+        }
+        if (device.hasFlash && [device isFlashModeSupported:self.flashMode])
+        {
+            NSError *error = nil;
+            if ([device lockForConfiguration:&error]) {
+                if ([device isTorchModeSupported:AVCaptureTorchModeOff]) {
+                    [device setTorchMode:AVCaptureTorchModeOff];
+                }
+                [device setFlashMode:self.flashMode];
+                [device unlockForConfiguration];
+            } else {
+                if (error) {
+                    RCTLogError(@"%s: %@", __func__, error);
+                }
+            }
+        }
+    }
+    
+    [device unlockForConfiguration];
+}
+
+- (void)updateFocusMode
+{
+    AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
+    NSError *error = nil;
+    
+    if (![device lockForConfiguration:&error]) {
+        if (error) {
+            RCTLogError(@"%s: %@", __func__, error);
+        }
+        return;
+    }
+    
+    if ([device isFocusModeSupported:self.autoFocus]) {
+        if ([device lockForConfiguration:&error]) {
+            [device setFocusMode:self.autoFocus];
+        } else {
+            if (error) {
+                RCTLogError(@"%s: %@", __func__, error);
+            }
+        }
+    }
+    
+    [device unlockForConfiguration];
+}
+
+- (void)updateFocusDepth
+{
+    AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
+    NSError *error = nil;
+    
+    if (device.focusMode != RCTCameraAutoFocusOff) {
+        return;
+    }
+    
+    if (![device respondsToSelector:@selector(isLockingFocusWithCustomLensPositionSupported)] || ![device isLockingFocusWithCustomLensPositionSupported]) {
+        RCTLogWarn(@"%s: Setting focusDepth isn't supported for this camera device", __func__);
+        return;
+    }
+    
+    if (![device lockForConfiguration:&error]) {
+        if (error) {
+            RCTLogError(@"%s: %@", __func__, error);
+        }
+        return;
+    }
+    
+    __weak __typeof__(device) weakDevice = device;
+    [device setFocusModeLockedWithLensPosition:self.focusDepth completionHandler:^(CMTime syncTime) {
+        [weakDevice unlockForConfiguration];
+    }];
+}
+
+- (void)updateZoom {
+    AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
+    NSError *error = nil;
+    
+    if (![device lockForConfiguration:&error]) {
+        if (error) {
+            RCTLogError(@"%s: %@", __func__, error);
+        }
+        return;
+    }
+    
+    device.videoZoomFactor = (device.activeFormat.videoMaxZoomFactor - 1.0) * self.zoom + 1.0;
+    
+    [device unlockForConfiguration];
+}
+
+- (void)updateWhiteBalance
+{
+    AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
+    NSError *error = nil;
+    
+    if (![device lockForConfiguration:&error]) {
+        if (error) {
+            RCTLogError(@"%s: %@", __func__, error);
+        }
+        return;
+    }
+    
+    if (self.whiteBalance == RCTCameraWhiteBalanceAuto) {
+        [device setWhiteBalanceMode:AVCaptureWhiteBalanceModeContinuousAutoWhiteBalance];
+        [device unlockForConfiguration];
+    } else {
+        AVCaptureWhiteBalanceTemperatureAndTintValues temperatureAndTint = {
+            .temperature = [RCTCameraUtils temperatureForWhiteBalance:self.whiteBalance],
+            .tint = 0,
+        };
+        AVCaptureWhiteBalanceGains rgbGains = [device deviceWhiteBalanceGainsForTemperatureAndTintValues:temperatureAndTint];
+        __weak __typeof__(device) weakDevice = device;
+        if ([device lockForConfiguration:&error]) {
+            [device setWhiteBalanceModeLockedWithDeviceWhiteBalanceGains:rgbGains completionHandler:^(CMTime syncTime) {
+                [weakDevice unlockForConfiguration];
+            }];
+        } else {
+            if (error) {
+                RCTLogError(@"%s: %@", __func__, error);
+            }
+        }
+    }
+    
+    [device unlockForConfiguration];
+}
+
+- (void)updateFaceDetecting:(id)faceDetecting
+{
+//    [_faceDetectorManager setIsEnabled:faceDetecting];
+}
+
+- (void)updateFaceDetectionMode:(id)requestedMode
+{
+//    [_faceDetectorManager setMode:requestedMode];
+}
+
+- (void)updateFaceDetectionLandmarks:(id)requestedLandmarks
+{
+//    [_faceDetectorManager setLandmarksDetected:requestedLandmarks];
+}
+
+- (void)updateFaceDetectionClassifications:(id)requestedClassifications
+{
+//    [_faceDetectorManager setClassificationsDetected:requestedClassifications];
+}
+
+- (void)takePicture:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
+{
+    AVCaptureConnection *connection = [self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
+    [connection setVideoOrientation:[RCTCameraUtils videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]]];
+    [self.stillImageOutput captureStillImageAsynchronouslyFromConnection:connection completionHandler: ^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
+        if (imageSampleBuffer && !error) {
+            NSData *imageData = [AVCaptureStillImageOutput jpegStillImageNSDataRepresentation:imageSampleBuffer];
+            
+            UIImage *takenImage = [UIImage imageWithData:imageData];
+            
+            CGRect frame = [_previewLayer metadataOutputRectOfInterestForRect:self.frame];
+            CGImageRef takenCGImage = takenImage.CGImage;
+            size_t width = CGImageGetWidth(takenCGImage);
+            size_t height = CGImageGetHeight(takenCGImage);
+            CGRect cropRect = CGRectMake(frame.origin.x * width, frame.origin.y * height, frame.size.width * width, frame.size.height * height);
+            takenImage = [RCTImageUtils cropImage:takenImage toRect:cropRect];
+            
+            NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
+            float quality = [options[@"quality"] floatValue];
+            NSData *takenImageData = UIImageJPEGRepresentation(takenImage, quality);
+//            NSString *path = [RCTFileSystem generatePathInDirectory:[self.bridge.scopedModules.fileSystem.cachesDirectory stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+//            response[@"uri"] = [RCTImageUtils writeImage:takenImageData toPath:path];
+            response[@"width"] = @(takenImage.size.width);
+            response[@"height"] = @(takenImage.size.height);
+            
+            if ([options[@"base64"] boolValue]) {
+                response[@"base64"] = [takenImageData base64EncodedStringWithOptions:0];
+            }
+            
+            if ([options[@"exif"] boolValue]) {
+                int imageRotation;
+                switch (takenImage.imageOrientation) {
+                    case UIImageOrientationLeft:
+                        imageRotation = 90;
+                        break;
+                    case UIImageOrientationRight:
+                        imageRotation = -90;
+                        break;
+                    case UIImageOrientationDown:
+                        imageRotation = 180;
+                        break;
+                    default:
+                        imageRotation = 0;
+                }
+                [RCTImageUtils updatePhotoMetadata:imageSampleBuffer withAdditionalData:@{ @"Orientation": @(imageRotation) } inResponse:response]; // TODO
+            }
+            
+            resolve(response);
+        } else {
+            reject(@"E_IMAGE_CAPTURE_FAILED", @"Image could not be captured", error);
+        }
+    }];
+}
+
+- (void)record:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
+{
+    if (_movieFileOutput == nil) {
+        // At the time of writing AVCaptureMovieFileOutput and AVCaptureVideoDataOutput (> GMVDataOutput)
+        // cannot coexist on the same AVSession (see: https://stackoverflow.com/a/4986032/1123156).
+        // We stop face detection here and restart it in when AVCaptureMovieFileOutput finishes recording.
+//        [_faceDetectorManager stopFaceDetection];
+        [self setupMovieFileCapture];
+    }
+    
+    if (self.movieFileOutput != nil && !self.movieFileOutput.isRecording && _videoRecordedResolve == nil && _videoRecordedReject == nil) {
+        if (options[@"maxDuration"]) {
+            Float64 maxDuration = [options[@"maxDuration"] floatValue];
+            self.movieFileOutput.maxRecordedDuration = CMTimeMakeWithSeconds(maxDuration, 30);
+        }
+        
+        if (options[@"maxFileSize"]) {
+            self.movieFileOutput.maxRecordedFileSize = [options[@"maxFileSize"] integerValue];
+        }
+        
+        if (options[@"quality"]) {
+            [self updateSessionPreset:[RCTCameraUtils captureSessionPresetForVideoResolution:(RCTCameraVideoResolution)[options[@"quality"] integerValue]]];
+        }
+        
+        [self updateSessionAudioIsMuted:!!options[@"mute"]];
+        
+        AVCaptureConnection *connection = [self.movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
+        [connection setVideoOrientation:[RCTCameraUtils videoOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation]]];
+        
+        dispatch_async(self.sessionQueue, ^{
+//            NSString *path = [RCTFileSystem generatePathInDirectory:[self.bridge.scopedModules.fileSystem.cachesDirectory stringByAppendingPathComponent:@"Camera"] withExtension:@".mov"];
+//            NSURL *outputURL = [[NSURL alloc] initFileURLWithPath:path];
+//            [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];
+            self.videoRecordedResolve = resolve;
+            self.videoRecordedReject = reject;
+        });
+    }
+}
+
+- (void)stopRecording
+{
+    [self.movieFileOutput stopRecording];
+}
+
+- (void)startSession
+{
+#if TARGET_IPHONE_SIMULATOR
+    return;
+#endif
+    //    NSDictionary *cameraPermissions = [EXCameraPermissionRequester permissions];
+    //    if (![cameraPermissions[@"status"] isEqualToString:@"granted"]) {
+    //        [self onMountingError:@{@"message": @"Camera permissions not granted - component could not be rendered."}];
+    //        return;
+    //    }
+    dispatch_async(self.sessionQueue, ^{
+        if (self.presetCamera == AVCaptureDevicePositionUnspecified) {
+            return;
+        }
+        
+        AVCaptureStillImageOutput *stillImageOutput = [[AVCaptureStillImageOutput alloc] init];
+        if ([self.session canAddOutput:stillImageOutput]) {
+            stillImageOutput.outputSettings = @{AVVideoCodecKey : AVVideoCodecJPEG};
+            [self.session addOutput:stillImageOutput];
+            [stillImageOutput setHighResolutionStillImageOutputEnabled:YES];
+            self.stillImageOutput = stillImageOutput;
+        }
+        
+//        [_faceDetectorManager maybeStartFaceDetectionOnSession:_session withPreviewLayer:_previewLayer];
+        [self setupOrDisableBarcodeScanner];
+        
+        __weak CandidateRCTCamera *weakSelf = self;
+        [self setRuntimeErrorHandlingObserver:
+         [NSNotificationCenter.defaultCenter addObserverForName:AVCaptureSessionRuntimeErrorNotification object:self.session queue:nil usingBlock:^(NSNotification *note) {
+            CandidateRCTCamera *strongSelf = weakSelf;
+            dispatch_async(strongSelf.sessionQueue, ^{
+                // Manually restarting the session since it must
+                // have been stopped due to an error.
+                [strongSelf.session startRunning];
+                [strongSelf onReady:nil];
+            });
+        }]];
+        
+        [self.session startRunning];
+        [self onReady:nil];
+    });
+}
+
+- (void)stopSession
+{
+#if TARGET_IPHONE_SIMULATOR
+    return;
+#endif
+    dispatch_async(self.sessionQueue, ^{
+//        [_faceDetectorManager stopFaceDetection];
+        [self.previewLayer removeFromSuperlayer];
+        [self.session commitConfiguration];
+        [self.session stopRunning];
+        for (AVCaptureInput *input in self.session.inputs) {
+            [self.session removeInput:input];
+        }
+        
+        for (AVCaptureOutput *output in self.session.outputs) {
+            [self.session removeOutput:output];
+        }
+    });
+}
+
+- (void)initializeCaptureSessionInput
+{
+    if (self.videoCaptureDeviceInput.device.position == self.presetCamera) {
+        return;
+    }
+    __block UIInterfaceOrientation interfaceOrientation;
+    
+    void (^statusBlock)(int) = ^() {
+        interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
+    };
+    if ([NSThread isMainThread]) {
+        statusBlock();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), statusBlock);
+    }
+    
+    AVCaptureVideoOrientation orientation = [RCTCameraUtils videoOrientationForInterfaceOrientation:interfaceOrientation];
+    dispatch_async(self.sessionQueue, ^{
+        [self.session beginConfiguration];
+        
+        NSError *error = nil;
+        AVCaptureDevice *captureDevice = [RCTCameraUtils deviceWithMediaType:AVMediaTypeVideo preferringPosition:self.presetCamera];
+        AVCaptureDeviceInput *captureDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:captureDevice error:&error];
+        
+        if (error || captureDeviceInput == nil) {
+            RCTLog(@"%s: %@", __func__, error);
+            return;
+        }
+        
+        [self.session removeInput:self.videoCaptureDeviceInput];
+        if ([self.session canAddInput:captureDeviceInput]) {
+            [self.session addInput:captureDeviceInput];
+            
+            self.videoCaptureDeviceInput = captureDeviceInput;
+            [self updateFlashMode];
+            [self updateZoom];
+            [self updateFocusMode];
+            [self updateFocusDepth];
+            [self updateWhiteBalance];
+            [self.previewLayer.connection setVideoOrientation:orientation];
+            [self _updateMetadataObjectsToRecognize];
+        }
+        
+        [self.session commitConfiguration];
+    });
+}
+
+#pragma mark - internal
+
+- (void)updateSessionPreset:(NSString *)preset
+{
+#if !(TARGET_IPHONE_SIMULATOR)
+    if (preset) {
+        dispatch_async(self.sessionQueue, ^{
+            [self.session beginConfiguration];
+            if ([self.session canSetSessionPreset:preset]) {
+                self.session.sessionPreset = preset;
+            }
+            [self.session commitConfiguration];
+        });
+    }
+#endif
+}
+
+- (void)updateSessionAudioIsMuted:(BOOL)isMuted
+{
+    dispatch_async(self.sessionQueue, ^{
+        [self.session beginConfiguration];
+        
+        for (AVCaptureDeviceInput* input in [self.session inputs]) {
+            if ([input.device hasMediaType:AVMediaTypeAudio]) {
+                if (isMuted) {
+                    [self.session removeInput:input];
+                }
+                [self.session commitConfiguration];
+                return;
+            }
+        }
+        
+        if (!isMuted) {
+            NSError *error = nil;
+            
+            AVCaptureDevice *audioCaptureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
+            AVCaptureDeviceInput *audioDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:audioCaptureDevice error:&error];
+            
+            if (error || audioDeviceInput == nil) {
+                RCTLogWarn(@"%s: %@", __func__, error);
+                return;
+            }
+            
+            if ([self.session canAddInput:audioDeviceInput]) {
+                [self.session addInput:audioDeviceInput];
+            }
+        }
+        
+        [self.session commitConfiguration];
+    });
+}
+
+- (void)bridgeDidForeground:(NSNotification *)notification
+{
+    
+    if (![self.session isRunning] && [self isSessionPaused]) {
+        self.paused = NO;
+        dispatch_async( self.sessionQueue, ^{
+            [self.session startRunning];
+        });
+    }
+}
+
+- (void)bridgeDidBackground:(NSNotification *)notification
+{
+    if ([self.session isRunning] && ![self isSessionPaused]) {
+        self.paused = YES;
+        dispatch_async( self.sessionQueue, ^{
+            [self.session stopRunning];
+        });
+    }
+}
+
+- (void)orientationChanged:(NSNotification *)notification
+{
+    UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
+    [self changePreviewOrientation:orientation];
+}
+
+- (void)changePreviewOrientation:(UIInterfaceOrientation)orientation
+{
+    __weak typeof(self) weakSelf = self;
+    AVCaptureVideoOrientation videoOrientation = [RCTCameraUtils videoOrientationForInterfaceOrientation:orientation];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(self) strongSelf = weakSelf;
+        if (strongSelf && strongSelf.previewLayer.connection.isVideoOrientationSupported) {
+            [strongSelf.previewLayer.connection setVideoOrientation:videoOrientation];
+        }
+    });
+}
+
+# pragma mark - AVCaptureMetadataOutput
+
+- (void)setupOrDisableBarcodeScanner
+{
+    [self _setupOrDisableMetadataOutput];
+    [self _updateMetadataObjectsToRecognize];
+}
+
+- (void)_setupOrDisableMetadataOutput
+{
+    if ([self isReadingBarCodes] && (_metadataOutput == nil || ![self.session.outputs containsObject:_metadataOutput])) {
+        AVCaptureMetadataOutput *metadataOutput = [[AVCaptureMetadataOutput alloc] init];
+        if ([self.session canAddOutput:metadataOutput]) {
+            [metadataOutput setMetadataObjectsDelegate:self queue:self.sessionQueue];
+            [self.session addOutput:metadataOutput];
+            self.metadataOutput = metadataOutput;
+        }
+    } else if (_metadataOutput != nil && ![self isReadingBarCodes]) {
+        [self.session removeOutput:_metadataOutput];
+        _metadataOutput = nil;
+    }
+}
+
+- (void)_updateMetadataObjectsToRecognize
+{
+    if (_metadataOutput == nil) {
+        return;
+    }
+    
+    NSArray<AVMetadataObjectType> *availableRequestedObjectTypes = [[NSArray alloc] init];
+    NSArray<AVMetadataObjectType> *requestedObjectTypes = [NSArray arrayWithArray:self.barCodeTypes];
+    NSArray<AVMetadataObjectType> *availableObjectTypes = _metadataOutput.availableMetadataObjectTypes;
+    
+    for(AVMetadataObjectType objectType in requestedObjectTypes) {
+        if ([availableObjectTypes containsObject:objectType]) {
+            availableRequestedObjectTypes = [availableRequestedObjectTypes arrayByAddingObject:objectType];
+        }
+    }
+    
+    [_metadataOutput setMetadataObjectTypes:availableRequestedObjectTypes];
+}
+
+- (void)captureOutput:(AVCaptureOutput *)captureOutput didOutputMetadataObjects:(NSArray *)metadataObjects
+       fromConnection:(AVCaptureConnection *)connection
+{
+    for(AVMetadataObject *metadata in metadataObjects) {
+        if([metadata isKindOfClass:[AVMetadataMachineReadableCodeObject class]]) {
+            AVMetadataMachineReadableCodeObject *codeMetadata = (AVMetadataMachineReadableCodeObject *) metadata;
+            for (id barcodeType in self.barCodeTypes) {
+                if ([metadata.type isEqualToString:barcodeType]) {
+                    
+                    NSDictionary *event = @{
+                                            @"type" : codeMetadata.type,
+                                            @"data" : codeMetadata.stringValue
+                                            };
+                    
+                    [self onCodeRead:event];
+                }
+            }
+        }
+    }
+}
+
+# pragma mark - AVCaptureMovieFileOutput
+
+- (void)setupMovieFileCapture
+{
+    AVCaptureMovieFileOutput *movieFileOutput = [[AVCaptureMovieFileOutput alloc] init];
+    
+    if ([self.session canAddOutput:movieFileOutput]) {
+        [self.session addOutput:movieFileOutput];
+        self.movieFileOutput = movieFileOutput;
+    }
+}
+
+- (void)cleanupMovieFileCapture
+{
+    if ([_session.outputs containsObject:_movieFileOutput]) {
+        [_session removeOutput:_movieFileOutput];
+        _movieFileOutput = nil;
+    }
+}
+
+- (void)captureOutput:(AVCaptureFileOutput *)captureOutput didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL fromConnections:(NSArray *)connections error:(NSError *)error
+{
+    BOOL success = YES;
+    if ([error code] != noErr) {
+        NSNumber *value = [[error userInfo] objectForKey:AVErrorRecordingSuccessfullyFinishedKey];
+        if (value) {
+            success = [value boolValue];
+        }
+    }
+    if (success && self.videoRecordedResolve != nil) {
+        self.videoRecordedResolve(@{ @"uri": outputFileURL.absoluteString });
+    } else if (self.videoRecordedReject != nil) {
+        self.videoRecordedReject(@"E_RECORDING_FAILED", @"An error occurred while recording a video.", error);
+    }
+    self.videoRecordedResolve = nil;
+    self.videoRecordedReject = nil;
+    
+    [self cleanupMovieFileCapture];
+    // If face detection has been running prior to recording to file
+    // we reenable it here (see comment in -record).
+//    [_faceDetectorManager maybeStartFaceDetectionOnSession:_session withPreviewLayer:_previewLayer];
+    
+    if (self.session.sessionPreset != AVCaptureSessionPresetHigh) {
+        [self updateSessionPreset:AVCaptureSessionPresetHigh];
+    }
+}
+
+# pragma mark - Face detector
+
+- (id)createFaceDetectorManager
+{
+//    Class faceDetectorManagerClass = NSClassFromString(@"EXFaceDetectorManager"); //ruim
+//    Class faceDetectorManagerStubClass = NSClassFromString(@"EXFaceDetectorManagerStub"); //ruim
+//
+//    if (faceDetectorManagerClass) {
+//        return [[faceDetectorManagerClass alloc] initWithSessionQueue:_sessionQueue delegate:self];
+//    } else if (faceDetectorManagerStubClass) {
+//        return [[faceDetectorManagerStubClass alloc] init];
+//    }
+    
+    return nil;
+}
+
+- (void)onFacesDetected:(NSArray<NSDictionary *> *)faces
+{
+    if (_onFacesDetected) {
+        _onFacesDetected(@{
+                           @"type": @"face",
+                           @"faces": faces
+                           });
+    }
+}
+
+@end
+

--- a/ios/CandidateRCTCameraManager.h
+++ b/ios/CandidateRCTCameraManager.h
@@ -1,0 +1,54 @@
+#import <React/RCTViewManager.h>
+#import <React/RCTBridgeModule.h>
+#import <AVFoundation/AVFoundation.h>
+
+@class CandidateRCTCameraManager;
+
+static const int RCTFlashModeTorch = 3;
+
+typedef NS_ENUM(NSInteger, RCTCameraType) {
+    RCTCameraTypeFront = AVCaptureDevicePositionFront,
+    RCTCameraTypeBack = AVCaptureDevicePositionBack
+};
+
+typedef NS_ENUM(NSInteger, RCTCameraFlashMode) {
+    RCTCameraFlashModeOff = AVCaptureFlashModeOff,
+    RCTCameraFlashModeOn = AVCaptureFlashModeOn,
+    RCTCameraFlashModeTorch = RCTFlashModeTorch,
+    RCTCameraFlashModeAuto = AVCaptureFlashModeAuto
+};
+
+typedef NS_ENUM(NSInteger, RCTCameraAutoFocus) {
+    RCTCameraAutoFocusOff = AVCaptureFocusModeLocked,
+    RCTCameraAutoFocusOn = AVCaptureFocusModeContinuousAutoFocus,
+};
+
+typedef NS_ENUM(NSInteger, RCTCameraWhiteBalance) {
+    RCTCameraWhiteBalanceAuto = 0,
+    RCTCameraWhiteBalanceSunny = 1,
+    RCTCameraWhiteBalanceCloudy = 2,
+    RCTCameraWhiteBalanceFlash = 3,
+    RCTCameraWhiteBalanceShadow = 4,
+    RCTCameraWhiteBalanceIncandescent = 5,
+    RCTCameraWhiteBalanceFluorescent = 6,
+};
+
+typedef NS_ENUM(NSInteger, RCTCameraExposureMode) {
+    RCTCameraExposureLocked = AVCaptureExposureModeLocked,
+    RCTCameraExposureAuto = AVCaptureExposureModeContinuousAutoExposure,
+    RCTCameraExposureCustom = AVCaptureExposureModeCustom,
+};
+
+typedef NS_ENUM(NSInteger, RCTCameraVideoResolution) {
+    RCTCameraVideo2160p = 0,
+    RCTCameraVideo1080p = 1,
+    RCTCameraVideo720p = 2,
+    RCTCameraVideo4x3 = 3,
+};
+
+@interface CandidateRCTCameraManager : RCTViewManager <RCTBridgeModule>
+
++ (NSDictionary *)validBarCodeTypes;
+
+@end
+

--- a/ios/CandidateRCTCameraManager.m
+++ b/ios/CandidateRCTCameraManager.m
@@ -1,0 +1,239 @@
+#import "CandidateRCTCamera.h"
+#import "CandidateRCTCameraManager.h"
+#import "RCTFileSystem.h"
+#import "RCTImageUtils.h"
+#import <React/RCTBridge.h>
+#import <React/RCTUIManager.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTLog.h>
+#import <React/RCTUtils.h>
+#import <React/UIView+React.h>
+
+//#if __has_include("EXFaceDetectorManager.h")
+//#import "EXFaceDetectorManager.h"
+//#else
+//#import "EXFaceDetectorManagerStub.h"
+//#endif
+
+@implementation CandidateRCTCameraManager
+
+RCT_EXPORT_MODULE(CandidateRCTCameraManager);
+RCT_EXPORT_VIEW_PROPERTY(onCameraReady, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onMountError, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onBarCodeRead, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onFacesDetected, RCTDirectEventBlock);
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
+- (UIView *)view
+{
+    return [[CandidateRCTCameraManager alloc] initWithBridge:self.bridge];
+}
+
+- (NSDictionary *)constantsToExport
+{
+    return @{
+             @"Type" :
+                 @{@"front" : @(RCTCameraTypeFront), @"back" : @(RCTCameraTypeBack)},
+             @"FlashMode" : @{
+                     @"off" : @(RCTCameraFlashModeOff),
+                     @"on" : @(RCTCameraFlashModeOn),
+                     @"auto" : @(RCTCameraFlashModeAuto),
+                     @"torch" : @(RCTCameraFlashModeTorch)
+                     },
+             @"AutoFocus" :
+                 @{@"on" : @(RCTCameraAutoFocusOn), @"off" : @(RCTCameraAutoFocusOff)},
+             @"WhiteBalance" : @{
+                     @"auto" : @(RCTCameraWhiteBalanceAuto),
+                     @"sunny" : @(RCTCameraWhiteBalanceSunny),
+                     @"cloudy" : @(RCTCameraWhiteBalanceCloudy),
+                     @"shadow" : @(RCTCameraWhiteBalanceShadow),
+                     @"incandescent" : @(RCTCameraWhiteBalanceIncandescent),
+                     @"fluorescent" : @(RCTCameraWhiteBalanceFluorescent)
+                     },
+             @"VideoQuality": @{
+                     @"2160p": @(RCTCameraVideo2160p),
+                     @"1080p": @(RCTCameraVideo1080p),
+                     @"720p": @(RCTCameraVideo720p),
+                     @"480p": @(RCTCameraVideo4x3),
+                     @"4:3": @(RCTCameraVideo4x3),
+                     },
+             @"BarCodeType" : [[self class] validBarCodeTypes]
+             //             @"FaceDetection" : [[self  class] faceDetectorConstants]
+             };
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+//    return @[@"onCameraReady", @"onMountError", @"onBarCodeRead", @"onFacesDetected"];
+    return @[@"onCameraReady", @"onMountError", @"onBarCodeRead"];
+}
+
++ (NSDictionary *)validBarCodeTypes
+{
+    return @{
+             @"upc_e" : AVMetadataObjectTypeUPCECode,
+             @"code39" : AVMetadataObjectTypeCode39Code,
+             @"code39mod43" : AVMetadataObjectTypeCode39Mod43Code,
+             @"ean13" : AVMetadataObjectTypeEAN13Code,
+             @"ean8" : AVMetadataObjectTypeEAN8Code,
+             @"code93" : AVMetadataObjectTypeCode93Code,
+             @"code138" : AVMetadataObjectTypeCode128Code,
+             @"pdf417" : AVMetadataObjectTypePDF417Code,
+             @"qr" : AVMetadataObjectTypeQRCode,
+             @"aztec" : AVMetadataObjectTypeAztecCode,
+             @"interleaved2of5" : AVMetadataObjectTypeInterleaved2of5Code,
+             @"itf14" : AVMetadataObjectTypeITF14Code,
+             @"datamatrix" : AVMetadataObjectTypeDataMatrixCode
+             };
+}
+
++ (NSDictionary *)faceDetectorConstants
+{
+//#if __has_include("EXFaceDetectorManager.h")
+//    return [EXFaceDetectorManager constants];
+//#elif __has_include("EXFaceDetectorManagerStub.h")
+//    return [EXFaceDetectorManagerStub constants];
+//#endif
+    
+    return nil;
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(type, NSInteger, CandidateRCTCameraManager)
+{
+    if (view.presetCamera != [RCTConvert NSInteger:json]) {
+        [view setPresetCamera:[RCTConvert NSInteger:json]];
+        [view updateType];
+    }
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(flashMode, NSInteger, CandidateRCTCameraManager)
+{
+    [view setFlashMode:[RCTConvert NSInteger:json]];
+    [view updateFlashMode];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(autoFocus, NSInteger, CandidateRCTCameraManager)
+{
+    [view setAutoFocus:[RCTConvert NSInteger:json]];
+    [view updateFocusMode];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(focusDepth, NSNumber, CandidateRCTCameraManager)
+{
+    [view setFocusDepth:[RCTConvert float:json]];
+    [view updateFocusDepth];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(zoom, NSNumber, CandidateRCTCameraManager)
+{
+    [view setZoom:[RCTConvert CGFloat:json]];
+    [view updateZoom];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(whiteBalance, NSInteger, CandidateRCTCameraManager)
+{
+    [view setWhiteBalance: [RCTConvert NSInteger:json]];
+    [view updateWhiteBalance];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(faceDetectorEnabled, BOOL, CandidateRCTCameraManager)
+{
+    [view updateFaceDetecting:json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(faceDetectionMode, NSInteger, CandidateRCTCameraManager)
+{
+    [view updateFaceDetectionMode:json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(faceDetectionLandmarks, NSString, CandidateRCTCameraManager)
+{
+    [view updateFaceDetectionLandmarks:json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(faceDetectionClassifications, NSString, CandidateRCTCameraManager)
+{
+    [view updateFaceDetectionClassifications:json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(barCodeScannerEnabled, BOOL, CandidateRCTCameraManager)
+{
+    
+    view.barCodeReading = [RCTConvert BOOL:json];
+    [view setupOrDisableBarcodeScanner];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(barCodeTypes, NSArray, CandidateRCTCameraManager)
+{
+    [view setBarCodeTypes:[RCTConvert NSArray:json]];
+}
+
+RCT_REMAP_METHOD(takePicture,
+                 options:(NSDictionary *)options
+                 reactTag:(nonnull NSNumber *)reactTag
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+#if TARGET_IPHONE_SIMULATOR
+    NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
+    float quality = [options[@"quality"] floatValue];
+//    NSString *path = [RCTFileSystem generatePathInDirectory:[self.bridge.scopedModules.fileSystem.cachesDirectory stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+    UIImage *generatedPhoto = [RCTImageUtils generatePhotoOfSize:CGSizeMake(200, 200)];
+    NSData *photoData = UIImageJPEGRepresentation(generatedPhoto, quality);
+//    response[@"uri"] = [RCTImageUtils writeImage:photoData toPath:path];
+    response[@"width"] = @(generatedPhoto.size.width);
+    response[@"height"] = @(generatedPhoto.size.height);
+    if ([options[@"base64"] boolValue]) {
+        response[@"base64"] = [photoData base64EncodedStringWithOptions:0];
+    }
+    resolve(response);
+#else
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, CandidateRCTCameraManager *> *viewRegistry) {
+        CandidateRCTCameraManager *view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[CandidateRCTCameraManager class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting RCTCamera, got: %@", view);
+        } else {
+            [view takePicture:options resolve:resolve reject:reject];
+        }
+    }];
+#endif
+}
+
+RCT_REMAP_METHOD(record,
+                 withOptions:(NSDictionary *)options
+                 reactTag:(nonnull NSNumber *)reactTag
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+#if TARGET_IPHONE_SIMULATOR
+    reject(@"E_RECORDING_FAILED", @"Video recording is not supported on a simulator.", nil);
+    return;
+#endif
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, CandidateRCTCameraManager *> *viewRegistry) {
+        CandidateRCTCameraManager *view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[CandidateRCTCameraManager class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting RCTCamera, got: %@", view);
+        } else {
+            [view record:options resolve:resolve reject:reject];
+        }
+    }];
+}
+
+RCT_REMAP_METHOD(stopRecording, reactTag:(nonnull NSNumber *)reactTag)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, CandidateRCTCameraManager *> *viewRegistry) {
+        CandidateRCTCameraManager *view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[CandidateRCTCameraManager class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting RCTCamera, got: %@", view);
+        } else {
+            [view stopRecording];
+        }
+    }];
+}
+
+@end
+

--- a/ios/RCTCamera.xcodeproj/project.pbxproj
+++ b/ios/RCTCamera.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		4107014D1ACB732B00C6AA39 /* RCTCamera.m in Sources */ = {isa = PBXBuildFile; fileRef = 410701481ACB732B00C6AA39 /* RCTCamera.m */; };
 		4107014E1ACB732B00C6AA39 /* RCTCameraManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4107014A1ACB732B00C6AA39 /* RCTCameraManager.m */; };
 		454EBCF41B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 454EBCF31B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m */; };
+		71C7FFD02013C7E5006EB75A /* RCTCameraUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFCF2013C7E5006EB75A /* RCTCameraUtils.m */; };
+		71C7FFD32013C817006EB75A /* RCTImageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFD22013C817006EB75A /* RCTImageUtils.m */; };
+		71C7FFD62013C824006EB75A /* RCTFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFD52013C824006EB75A /* RCTFileSystem.m */; };
 		9FE592B31CA3CBF500788287 /* RCTSensorOrientationChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FE592B21CA3CBF500788287 /* RCTSensorOrientationChecker.m */; };
 /* End PBXBuildFile section */
 
@@ -35,6 +38,16 @@
 		410701491ACB732B00C6AA39 /* RCTCameraManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTCameraManager.h; sourceTree = "<group>"; };
 		4107014A1ACB732B00C6AA39 /* RCTCameraManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTCameraManager.m; sourceTree = "<group>"; };
 		454EBCF31B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableDictionary+ImageMetadata.m"; sourceTree = "<group>"; };
+		71C7FFC82013C7AE006EB75A /* CandidateRCTCameraManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CandidateRCTCameraManager.h; sourceTree = "<group>"; };
+		71C7FFC92013C7AE006EB75A /* CandidateRCTCameraManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CandidateRCTCameraManager.m; sourceTree = "<group>"; };
+		71C7FFCB2013C7BF006EB75A /* CandidateRCTCamera.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CandidateRCTCamera.h; sourceTree = "<group>"; };
+		71C7FFCC2013C7BF006EB75A /* CandidateRCTCamera.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CandidateRCTCamera.m; sourceTree = "<group>"; };
+		71C7FFCE2013C7E5006EB75A /* RCTCameraUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTCameraUtils.h; sourceTree = "<group>"; };
+		71C7FFCF2013C7E5006EB75A /* RCTCameraUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTCameraUtils.m; sourceTree = "<group>"; };
+		71C7FFD12013C817006EB75A /* RCTImageUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTImageUtils.h; sourceTree = "<group>"; };
+		71C7FFD22013C817006EB75A /* RCTImageUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTImageUtils.m; sourceTree = "<group>"; };
+		71C7FFD42013C824006EB75A /* RCTFileSystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTFileSystem.h; sourceTree = "<group>"; };
+		71C7FFD52013C824006EB75A /* RCTFileSystem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTFileSystem.m; sourceTree = "<group>"; };
 		9FE592B11CA3CBF500788287 /* RCTSensorOrientationChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTSensorOrientationChecker.h; sourceTree = "<group>"; };
 		9FE592B21CA3CBF500788287 /* RCTSensorOrientationChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTSensorOrientationChecker.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -53,6 +66,12 @@
 		410701241ACB719800C6AA39 = {
 			isa = PBXGroup;
 			children = (
+				71C7FFD42013C824006EB75A /* RCTFileSystem.h */,
+				71C7FFD52013C824006EB75A /* RCTFileSystem.m */,
+				71C7FFD12013C817006EB75A /* RCTImageUtils.h */,
+				71C7FFD22013C817006EB75A /* RCTImageUtils.m */,
+				71C7FFCE2013C7E5006EB75A /* RCTCameraUtils.h */,
+				71C7FFCF2013C7E5006EB75A /* RCTCameraUtils.m */,
 				9FE592B11CA3CBF500788287 /* RCTSensorOrientationChecker.h */,
 				9FE592B21CA3CBF500788287 /* RCTSensorOrientationChecker.m */,
 				0314E39C1B661A460092D183 /* CameraFocusSquare.m */,
@@ -62,6 +81,10 @@
 				410701481ACB732B00C6AA39 /* RCTCamera.m */,
 				410701491ACB732B00C6AA39 /* RCTCameraManager.h */,
 				4107014A1ACB732B00C6AA39 /* RCTCameraManager.m */,
+				71C7FFC82013C7AE006EB75A /* CandidateRCTCameraManager.h */,
+				71C7FFC92013C7AE006EB75A /* CandidateRCTCameraManager.m */,
+				71C7FFCB2013C7BF006EB75A /* CandidateRCTCamera.h */,
+				71C7FFCC2013C7BF006EB75A /* CandidateRCTCamera.m */,
 				410701301ACB723B00C6AA39 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -131,9 +154,12 @@
 			files = (
 				0314E39D1B661A460092D183 /* CameraFocusSquare.m in Sources */,
 				454EBCF41B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m in Sources */,
+				71C7FFD62013C824006EB75A /* RCTFileSystem.m in Sources */,
 				4107014E1ACB732B00C6AA39 /* RCTCameraManager.m in Sources */,
 				4107014D1ACB732B00C6AA39 /* RCTCamera.m in Sources */,
+				71C7FFD02013C7E5006EB75A /* RCTCameraUtils.m in Sources */,
 				9FE592B31CA3CBF500788287 /* RCTSensorOrientationChecker.m in Sources */,
+				71C7FFD32013C817006EB75A /* RCTImageUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RCTCameraUtils.h
+++ b/ios/RCTCameraUtils.h
@@ -1,0 +1,24 @@
+//
+//  RCTCameraUtils.h
+//  RCTCamera
+//
+//  Created by Joao Guilherme Daros Fidelis on 19/01/18.
+//
+
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
+#import "CandidateRCTCameraManager.h"
+
+@interface RCTCameraUtils : NSObject
+
+// Camera utilities
++ (AVCaptureDevice *)deviceWithMediaType:(NSString *)mediaType preferringPosition:(AVCaptureDevicePosition)position;
+
+// Enum conversions
++ (float)temperatureForWhiteBalance:(RCTCameraWhiteBalance)whiteBalance;
++ (NSString *)captureSessionPresetForVideoResolution:(RCTCameraVideoResolution)resolution;
++ (AVCaptureVideoOrientation)videoOrientationForDeviceOrientation:(UIDeviceOrientation)orientation;
++ (AVCaptureVideoOrientation)videoOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation;
+
+@end
+

--- a/ios/RCTCameraUtils.m
+++ b/ios/RCTCameraUtils.m
@@ -1,0 +1,97 @@
+//
+//  RCTCameraUtils.m
+//  Exponent
+//
+//  Created by Stanisław Chmiela on 23.10.2017.
+//  Copyright © 2017 650 Industries. All rights reserved.
+//
+
+#import "RCTCameraUtils.h"
+
+@implementation RCTCameraUtils
+
+# pragma mark - Camera utilities
+
++ (AVCaptureDevice *)deviceWithMediaType:(AVMediaType)mediaType preferringPosition:(AVCaptureDevicePosition)position
+{
+    NSArray *devices = [AVCaptureDevice devicesWithMediaType:mediaType];
+    AVCaptureDevice *captureDevice = [devices firstObject];
+    
+    for (AVCaptureDevice *device in devices) {
+        if ([device position] == position) {
+            captureDevice = device;
+            break;
+        }
+    }
+    
+    return captureDevice;
+}
+
+# pragma mark - Enum conversion
+
++ (AVCaptureVideoOrientation)videoOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation
+{
+    switch (orientation) {
+        case UIInterfaceOrientationPortrait:
+            return AVCaptureVideoOrientationPortrait;
+        case UIInterfaceOrientationPortraitUpsideDown:
+            return AVCaptureVideoOrientationPortraitUpsideDown;
+        case UIInterfaceOrientationLandscapeRight:
+            return AVCaptureVideoOrientationLandscapeRight;
+        case UIInterfaceOrientationLandscapeLeft:
+            return AVCaptureVideoOrientationLandscapeLeft;
+        default:
+            return 0;
+    }
+}
+
++ (AVCaptureVideoOrientation)videoOrientationForDeviceOrientation:(UIDeviceOrientation)orientation
+{
+    switch (orientation) {
+        case UIDeviceOrientationPortrait:
+            return AVCaptureVideoOrientationPortrait;
+        case UIDeviceOrientationPortraitUpsideDown:
+            return AVCaptureVideoOrientationPortraitUpsideDown;
+        case UIDeviceOrientationLandscapeLeft:
+            return AVCaptureVideoOrientationLandscapeRight;
+        case UIDeviceOrientationLandscapeRight:
+            return AVCaptureVideoOrientationLandscapeLeft;
+        default:
+            return AVCaptureVideoOrientationPortrait;
+    }
+}
+
++ (float)temperatureForWhiteBalance:(RCTCameraWhiteBalance)whiteBalance
+{
+    switch (whiteBalance) {
+        case RCTCameraWhiteBalanceSunny: default:
+            return 5200;
+        case RCTCameraWhiteBalanceCloudy:
+            return 6000;
+        case RCTCameraWhiteBalanceShadow:
+            return 7000;
+        case RCTCameraWhiteBalanceIncandescent:
+            return 3000;
+        case RCTCameraWhiteBalanceFluorescent:
+            return 4200;
+    }
+}
+
++ (NSString *)captureSessionPresetForVideoResolution:(RCTCameraVideoResolution)resolution
+{
+    switch (resolution) {
+        case RCTCameraVideo2160p:
+            return AVCaptureSessionPreset3840x2160;
+        case RCTCameraVideo1080p:
+            return AVCaptureSessionPreset1920x1080;
+        case RCTCameraVideo720p:
+            return AVCaptureSessionPreset1280x720;
+        case RCTCameraVideo4x3:
+            return AVCaptureSessionPreset640x480;
+        default:
+            return AVCaptureSessionPresetHigh;
+    }
+}
+
+@end
+

--- a/ios/RCTFileSystem.h
+++ b/ios/RCTFileSystem.h
@@ -1,0 +1,16 @@
+//
+//  RCTFileSystem.h
+//  RCTCamera
+//
+//  Created by Joao Guilherme Daros Fidelis on 19/01/18.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface RCTFileSystem : NSObject
+
++ (BOOL)ensureDirExistsWithPath:(NSString *)path;
++ (NSString *)generatePathInDirectory:(NSString *)directory withExtension:(NSString *)extension;
+
+@end
+

--- a/ios/RCTFileSystem.m
+++ b/ios/RCTFileSystem.m
@@ -1,0 +1,34 @@
+//
+//  RCTFileSystem.m
+//  RCTCamera
+//
+//  Created by Joao Guilherme Daros Fidelis on 19/01/18.
+//
+
+#import "RCTFileSystem.h"
+
+@implementation RCTFileSystem
+
++ (BOOL)ensureDirExistsWithPath:(NSString *)path
+{
+    BOOL isDir = NO;
+    NSError *error;
+    BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDir];
+    if (!(exists && isDir)) {
+        [[NSFileManager defaultManager] createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:&error];
+        if (error) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
++ (NSString *)generatePathInDirectory:(NSString *)directory withExtension:(NSString *)extension
+{
+    NSString *fileName = [[[NSUUID UUID] UUIDString] stringByAppendingString:extension];
+    [RCTFileSystem ensureDirExistsWithPath:directory];
+    return [directory stringByAppendingPathComponent:fileName];
+}
+
+@end
+

--- a/ios/RCTImageUtils.h
+++ b/ios/RCTImageUtils.h
@@ -1,0 +1,20 @@
+//
+//  RCTImageUtils.h
+//  RCTCamera
+//
+//  Created by Joao Guilherme Daros Fidelis on 19/01/18.
+//
+
+#import <UIKit/UIKit.h>
+#import <CoreMedia/CoreMedia.h>
+#import <Foundation/Foundation.h>
+
+@interface RCTImageUtils : NSObject
+
++ (UIImage *)generatePhotoOfSize:(CGSize)size;
++ (UIImage *)cropImage:(UIImage *)image toRect:(CGRect)rect;
++ (NSString *)writeImage:(NSData *)image toPath:(NSString *)path;
++ (void)updatePhotoMetadata:(CMSampleBufferRef)imageSampleBuffer withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response;
+
+@end
+

--- a/ios/RCTImageUtils.m
+++ b/ios/RCTImageUtils.m
@@ -1,0 +1,71 @@
+//
+//  RCTImageUtils.m
+//  RCTCamera
+//
+//  Created by Joao Guilherme Daros Fidelis on 19/01/18.
+//
+
+#import "RCTImageUtils.h"
+
+@implementation RCTImageUtils
+
++ (UIImage *)generatePhotoOfSize:(CGSize)size
+{
+    CGRect rect = CGRectMake(0, 0, size.width, size.height);
+    UIImage *image;
+    UIGraphicsBeginImageContextWithOptions(size, YES, 0);
+    UIColor *color = [UIColor blackColor];
+    [color setFill];
+    UIRectFill(rect);
+    NSDate *currentDate = [NSDate date];
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"dd.MM.YY HH:mm:ss"];
+    NSString *text = [dateFormatter stringFromDate:currentDate];
+    NSDictionary *attributes = [NSDictionary dictionaryWithObjects: @[[UIFont systemFontOfSize:18.0], [UIColor orangeColor]]
+                                                           forKeys: @[NSFontAttributeName, NSForegroundColorAttributeName]];
+    [text drawAtPoint:CGPointMake(size.width * 0.1, size.height * 0.9) withAttributes:attributes];
+    image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+
++ (UIImage *)cropImage:(UIImage *)image toRect:(CGRect)rect
+{
+    CGImageRef takenCGImage = image.CGImage;
+    CGImageRef cropCGImage = CGImageCreateWithImageInRect(takenCGImage, rect);
+    image = [UIImage imageWithCGImage:cropCGImage scale:image.scale orientation:image.imageOrientation];
+    CGImageRelease(cropCGImage);
+    return image;
+}
+
++ (NSString *)writeImage:(NSData *)image toPath:(NSString *)path
+{
+    [image writeToFile:path atomically:YES];
+    NSURL *fileURL = [NSURL fileURLWithPath:path];
+    return [fileURL absoluteString];
+}
+
++ (void)updatePhotoMetadata:(CMSampleBufferRef)imageSampleBuffer withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response
+{
+    CFDictionaryRef exifAttachments = CMGetAttachment(imageSampleBuffer, kCGImagePropertyExifDictionary, NULL);
+    NSMutableDictionary *metadata = (__bridge NSMutableDictionary *)exifAttachments;
+    metadata[(NSString *)kCGImagePropertyExifPixelYDimension] = response[@"width"];
+    metadata[(NSString *)kCGImagePropertyExifPixelXDimension] = response[@"height"];
+    
+    for (id key in additionalData) {
+        metadata[key] = additionalData[key];
+    }
+    
+    NSDictionary *gps = metadata[(NSString *)kCGImagePropertyGPSDictionary];
+    
+    if (gps) {
+        for (NSString *gpsKey in gps) {
+            metadata[[@"GPS" stringByAppendingString:gpsKey]] = gps[gpsKey];
+        }
+    }
+    
+    response[@"exif"] = metadata;
+}
+
+@end
+


### PR DESCRIPTION
Candidate classes are not build targets right now. In the future, replace RCTCameraManager and RCTCamera by Candidate classes.

Code related to face detection and other classes related to Expo that could not be ported right now are also commented.
