### PR TITLE
fixing imageSize parameter for saveImage method (ios)

### DIFF
--- a/ios/RCT/RCTCameraManager.m
+++ b/ios/RCT/RCTCameraManager.m
@@ -719,7 +719,7 @@ RCT_EXPORT_METHOD(setZoom:(CGFloat)zoomFactor) {
           }
           CFRelease(destination);
 
-          [self saveImage:rotatedImageData imageSize:viewportSize target:target metadata:imageMetadata resolve:resolve reject:reject];
+          [self saveImage:rotatedImageData imageSize:frameSize target:target metadata:imageMetadata resolve:resolve reject:reject];
 
           CGImageRelease(rotatedCGImage);
         }


### PR DESCRIPTION
It seems there was a regression during our rebasing.
The parameter send to saveImage in captureStill was incorrect.
Fixed it, now it is working properly.