### PR TITLE
Issue #1120: Change dependencies on build.gradle from compile to api.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,11 +38,11 @@ repositories {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:+'
-  compile "com.google.zxing:core:3.2.1"
-  compile "com.drewnoakes:metadata-extractor:2.9.1"
-  compile 'com.google.android.gms:play-services-vision:+'
-  compile "com.android.support:exifinterface:26.0.2"
+  api 'com.facebook.react:react-native:+'
+  api "com.google.zxing:core:3.2.1"
+  api "com.drewnoakes:metadata-extractor:2.9.1"
+  api 'com.google.android.gms:play-services-vision:+'
+  api "com.android.support:exifinterface:26.0.2"
 
-  compile 'com.github.react-native-community:cameraview:df60b07573'
+  api 'com.github.react-native-community:cameraview:df60b07573'
 }


### PR DESCRIPTION
Used api instead of implementation because we do not know what is internal and what is external.

To learn the difference you may read: https://stackoverflow.com/questions/44493378/whats-the-difference-between-implementation-and-compile-in-gradle