### PR TITLE
Issue #1099: takePictureAsync return { width, height, base64, exif }

### DIFF
--- a/android/src/main/java/org/reactnative/MutableImage.java
+++ b/android/src/main/java/org/reactnative/MutableImage.java
@@ -57,6 +57,14 @@ public class MutableImage {
         this.currentRepresentation = bitmap;
     }
 
+    public int getImageWidth() {
+        return currentRepresentation.getWidth();
+    }
+
+    public int getImageHeight() {
+        return currentRepresentation.getHeight();
+    }
+
     public void fixOrientation() throws ImageMutationFailedException {
         try {
             Metadata metadata = originalImageMetaData();

--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -33,6 +33,138 @@ import java.util.Locale;
 import java.util.UUID;
 
 public class RNCameraViewHelper {
+
+  public static final String[][] exifTags = new String[][]{
+          {"string", ExifInterface.TAG_ARTIST},
+          {"int", ExifInterface.TAG_BITS_PER_SAMPLE},
+          {"int", ExifInterface.TAG_COMPRESSION},
+          {"string", ExifInterface.TAG_COPYRIGHT},
+          {"string", ExifInterface.TAG_DATETIME},
+          {"string", ExifInterface.TAG_IMAGE_DESCRIPTION},
+          {"int", ExifInterface.TAG_IMAGE_LENGTH},
+          {"int", ExifInterface.TAG_IMAGE_WIDTH},
+          {"int", ExifInterface.TAG_JPEG_INTERCHANGE_FORMAT},
+          {"int", ExifInterface.TAG_JPEG_INTERCHANGE_FORMAT_LENGTH},
+          {"string", ExifInterface.TAG_MAKE},
+          {"string", ExifInterface.TAG_MODEL},
+          {"int", ExifInterface.TAG_ORIENTATION},
+          {"int", ExifInterface.TAG_PHOTOMETRIC_INTERPRETATION},
+          {"int", ExifInterface.TAG_PLANAR_CONFIGURATION},
+          {"double", ExifInterface.TAG_PRIMARY_CHROMATICITIES},
+          {"double", ExifInterface.TAG_REFERENCE_BLACK_WHITE},
+          {"int", ExifInterface.TAG_RESOLUTION_UNIT},
+          {"int", ExifInterface.TAG_ROWS_PER_STRIP},
+          {"int", ExifInterface.TAG_SAMPLES_PER_PIXEL},
+          {"string", ExifInterface.TAG_SOFTWARE},
+          {"int", ExifInterface.TAG_STRIP_BYTE_COUNTS},
+          {"int", ExifInterface.TAG_STRIP_OFFSETS},
+          {"int", ExifInterface.TAG_TRANSFER_FUNCTION},
+          {"double", ExifInterface.TAG_WHITE_POINT},
+          {"double", ExifInterface.TAG_X_RESOLUTION},
+          {"double", ExifInterface.TAG_Y_CB_CR_COEFFICIENTS},
+          {"int", ExifInterface.TAG_Y_CB_CR_POSITIONING},
+          {"int", ExifInterface.TAG_Y_CB_CR_SUB_SAMPLING},
+          {"double", ExifInterface.TAG_Y_RESOLUTION},
+          {"double", ExifInterface.TAG_APERTURE_VALUE},
+          {"double", ExifInterface.TAG_BRIGHTNESS_VALUE},
+          {"string", ExifInterface.TAG_CFA_PATTERN},
+          {"int", ExifInterface.TAG_COLOR_SPACE},
+          {"string", ExifInterface.TAG_COMPONENTS_CONFIGURATION},
+          {"double", ExifInterface.TAG_COMPRESSED_BITS_PER_PIXEL},
+          {"int", ExifInterface.TAG_CONTRAST},
+          {"int", ExifInterface.TAG_CUSTOM_RENDERED},
+          {"string", ExifInterface.TAG_DATETIME_DIGITIZED},
+          {"string", ExifInterface.TAG_DATETIME_ORIGINAL},
+          {"string", ExifInterface.TAG_DEVICE_SETTING_DESCRIPTION},
+          {"double", ExifInterface.TAG_DIGITAL_ZOOM_RATIO},
+          {"string", ExifInterface.TAG_EXIF_VERSION},
+          {"double", ExifInterface.TAG_EXPOSURE_BIAS_VALUE},
+          {"double", ExifInterface.TAG_EXPOSURE_INDEX},
+          {"int", ExifInterface.TAG_EXPOSURE_MODE},
+          {"int", ExifInterface.TAG_EXPOSURE_PROGRAM},
+          {"double", ExifInterface.TAG_EXPOSURE_TIME},
+          {"double", ExifInterface.TAG_F_NUMBER},
+          {"string", ExifInterface.TAG_FILE_SOURCE},
+          {"int", ExifInterface.TAG_FLASH},
+          {"double", ExifInterface.TAG_FLASH_ENERGY},
+          {"string", ExifInterface.TAG_FLASHPIX_VERSION},
+          {"double", ExifInterface.TAG_FOCAL_LENGTH},
+          {"int", ExifInterface.TAG_FOCAL_LENGTH_IN_35MM_FILM},
+          {"int", ExifInterface.TAG_FOCAL_PLANE_RESOLUTION_UNIT},
+          {"double", ExifInterface.TAG_FOCAL_PLANE_X_RESOLUTION},
+          {"double", ExifInterface.TAG_FOCAL_PLANE_Y_RESOLUTION},
+          {"int", ExifInterface.TAG_GAIN_CONTROL},
+          {"int", ExifInterface.TAG_ISO_SPEED_RATINGS},
+          {"string", ExifInterface.TAG_IMAGE_UNIQUE_ID},
+          {"int", ExifInterface.TAG_LIGHT_SOURCE},
+          {"string", ExifInterface.TAG_MAKER_NOTE},
+          {"double", ExifInterface.TAG_MAX_APERTURE_VALUE},
+          {"int", ExifInterface.TAG_METERING_MODE},
+          {"int", ExifInterface.TAG_NEW_SUBFILE_TYPE},
+          {"string", ExifInterface.TAG_OECF},
+          {"int", ExifInterface.TAG_PIXEL_X_DIMENSION},
+          {"int", ExifInterface.TAG_PIXEL_Y_DIMENSION},
+          {"string", ExifInterface.TAG_RELATED_SOUND_FILE},
+          {"int", ExifInterface.TAG_SATURATION},
+          {"int", ExifInterface.TAG_SCENE_CAPTURE_TYPE},
+          {"string", ExifInterface.TAG_SCENE_TYPE},
+          {"int", ExifInterface.TAG_SENSING_METHOD},
+          {"int", ExifInterface.TAG_SHARPNESS},
+          {"double", ExifInterface.TAG_SHUTTER_SPEED_VALUE},
+          {"string", ExifInterface.TAG_SPATIAL_FREQUENCY_RESPONSE},
+          {"string", ExifInterface.TAG_SPECTRAL_SENSITIVITY},
+          {"int", ExifInterface.TAG_SUBFILE_TYPE},
+          {"string", ExifInterface.TAG_SUBSEC_TIME},
+          {"string", ExifInterface.TAG_SUBSEC_TIME_DIGITIZED},
+          {"string", ExifInterface.TAG_SUBSEC_TIME_ORIGINAL},
+          {"int", ExifInterface.TAG_SUBJECT_AREA},
+          {"double", ExifInterface.TAG_SUBJECT_DISTANCE},
+          {"int", ExifInterface.TAG_SUBJECT_DISTANCE_RANGE},
+          {"int", ExifInterface.TAG_SUBJECT_LOCATION},
+          {"string", ExifInterface.TAG_USER_COMMENT},
+          {"int", ExifInterface.TAG_WHITE_BALANCE},
+          {"int", ExifInterface.TAG_GPS_ALTITUDE_REF},
+          {"string", ExifInterface.TAG_GPS_AREA_INFORMATION},
+          {"double", ExifInterface.TAG_GPS_DOP},
+          {"string", ExifInterface.TAG_GPS_DATESTAMP},
+          {"double", ExifInterface.TAG_GPS_DEST_BEARING},
+          {"string", ExifInterface.TAG_GPS_DEST_BEARING_REF},
+          {"double", ExifInterface.TAG_GPS_DEST_DISTANCE},
+          {"string", ExifInterface.TAG_GPS_DEST_DISTANCE_REF},
+          {"double", ExifInterface.TAG_GPS_DEST_LATITUDE},
+          {"string", ExifInterface.TAG_GPS_DEST_LATITUDE_REF},
+          {"double", ExifInterface.TAG_GPS_DEST_LONGITUDE},
+          {"string", ExifInterface.TAG_GPS_DEST_LONGITUDE_REF},
+          {"int", ExifInterface.TAG_GPS_DIFFERENTIAL},
+          {"double", ExifInterface.TAG_GPS_IMG_DIRECTION},
+          {"string", ExifInterface.TAG_GPS_IMG_DIRECTION_REF},
+          {"string", ExifInterface.TAG_GPS_LATITUDE_REF},
+          {"string", ExifInterface.TAG_GPS_LONGITUDE_REF},
+          {"string", ExifInterface.TAG_GPS_MAP_DATUM},
+          {"string", ExifInterface.TAG_GPS_MEASURE_MODE},
+          {"string", ExifInterface.TAG_GPS_PROCESSING_METHOD},
+          {"string", ExifInterface.TAG_GPS_SATELLITES},
+          {"double", ExifInterface.TAG_GPS_SPEED},
+          {"string", ExifInterface.TAG_GPS_SPEED_REF},
+          {"string", ExifInterface.TAG_GPS_STATUS},
+          {"string", ExifInterface.TAG_GPS_TIMESTAMP},
+          {"double", ExifInterface.TAG_GPS_TRACK},
+          {"string", ExifInterface.TAG_GPS_TRACK_REF},
+          {"string", ExifInterface.TAG_GPS_VERSION_ID},
+          {"string", ExifInterface.TAG_INTEROPERABILITY_INDEX},
+          {"int", ExifInterface.TAG_THUMBNAIL_IMAGE_LENGTH},
+          {"int", ExifInterface.TAG_THUMBNAIL_IMAGE_WIDTH},
+          {"int", ExifInterface.TAG_DNG_VERSION},
+          {"int", ExifInterface.TAG_DEFAULT_CROP_SIZE},
+          {"int", ExifInterface.TAG_ORF_PREVIEW_IMAGE_START},
+          {"int", ExifInterface.TAG_ORF_PREVIEW_IMAGE_LENGTH},
+          {"int", ExifInterface.TAG_ORF_ASPECT_FRAME},
+          {"int", ExifInterface.TAG_RW2_SENSOR_BOTTOM_BORDER},
+          {"int", ExifInterface.TAG_RW2_SENSOR_LEFT_BORDER},
+          {"int", ExifInterface.TAG_RW2_SENSOR_RIGHT_BORDER},
+          {"int", ExifInterface.TAG_RW2_SENSOR_TOP_BORDER},
+          {"int", ExifInterface.TAG_RW2_ISO},
+  };
   // Mount error event
 
   public static void emitMountErrorEvent(ViewGroup view) {
@@ -124,24 +256,23 @@ public class RNCameraViewHelper {
 
   public static WritableMap getExifData(ExifInterface exifInterface) {
     WritableMap exifMap = Arguments.createMap();
-    // TODO - fix this
-//    for (String[] tagInfo : ImagePickerModule.exifTags) {
-//      String name = tagInfo[1];
-//      if (exifInterface.getAttribute(name) != null) {
-//        String type = tagInfo[0];
-//        switch (type) {
-//          case "string":
-//            exifMap.putString(name, exifInterface.getAttribute(name));
-//            break;
-//          case "int":
-//            exifMap.putInt(name, exifInterface.getAttributeInt(name, 0));
-//            break;
-//          case "double":
-//            exifMap.putDouble(name, exifInterface.getAttributeDouble(name, 0));
-//            break;
-//        }
-//      }
-//    }
+    for (String[] tagInfo : exifTags) {
+      String name = tagInfo[1];
+      if (exifInterface.getAttribute(name) != null) {
+        String type = tagInfo[0];
+        switch (type) {
+          case "string":
+            exifMap.putString(name, exifInterface.getAttribute(name));
+            break;
+          case "int":
+            exifMap.putInt(name, exifInterface.getAttributeInt(name, 0));
+            break;
+          case "double":
+            exifMap.putDouble(name, exifInterface.getAttributeDouble(name, 0));
+            break;
+        }
+      }
+    }
 
     double[] latLong = exifInterface.getLatLong();
     if (latLong != null) {

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -3,8 +3,11 @@ package org.reactnative.camera.tasks;
 import android.content.res.Resources;
 import android.graphics.Matrix;
 import android.os.AsyncTask;
+import android.support.media.ExifInterface;
 
 import org.reactnative.MutableImage;
+import org.reactnative.camera.RNCameraViewHelper;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;
@@ -41,12 +44,25 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
       String encoded = mutableImage.toBase64(getQuality());
 
       response.putString("base64", encoded);
+      response.putInt("width", mutableImage.getImageWidth());
+      response.putInt("height", mutableImage.getImageHeight());
+      if (mOptions.hasKey("exif") && mOptions.getBoolean("exif")) {
+        ExifInterface exifInterface = new ExifInterface(inputStream);
+        WritableMap exifData = RNCameraViewHelper.getExifData(exifInterface);
+        response.putMap("exif", exifData);
+      }
+
+      //TODO: create local cache directory, save image to file and insert into response "uri" key
+      // with the path to the file
+      //response.putString("uri", outputPath);
 
       return response;
     } catch (Resources.NotFoundException e) {
       mPromise.reject(ERROR_TAG, "Documents directory of the app could not be found.", e);
       e.printStackTrace();
    } catch (MutableImage.ImageMutationFailedException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
       e.printStackTrace();
     } finally {
       try {


### PR DESCRIPTION
takePictureAsync should return { width, height, base64, exif, uri }, but uri still needs implementation of a local cache directory.

For now, takePictureAsync returns { width, height, base64, exif } correctly. To test it, with the RNCameraExample, take pictures and watch the log being printed. Rotate the camera and see that width and height are correct. Modify RNCamera.js to have have an option = {exif: true} when asking for a picture to see the exif on the return value.