### PR TITLE
Fix startPreview and stopPreview on Android

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -697,28 +697,6 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
     }
 
     @ReactMethod
-    public void stopPreview(ReadableMap options) {
-        RCTCamera instance = RCTCamera.getInstance();
-        if (instance == null) return;
-
-        Camera camera = instance.acquireCameraInstance(options.getInt("type"));
-        if (camera == null) return;
-
-        camera.stopPreview();
-    }
-
-    @ReactMethod
-    public void startPreview(ReadableMap options) {
-        RCTCamera instance = RCTCamera.getInstance();
-        if (instance == null) return;
-
-        Camera camera = instance.acquireCameraInstance(options.getInt("type"));
-        if (camera == null) return;
-
-        camera.startPreview();
-    }
-
-    @ReactMethod
     public void hasFlash(ReadableMap options, final Promise promise) {
         Camera camera = RCTCamera.getInstance().acquireCameraInstance(options.getInt("type"));
         if (null == camera) {

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
@@ -6,7 +6,6 @@ package com.lwansbrough.RCTCamera;
 
 import android.content.Context;
 import android.hardware.SensorManager;
-import android.util.Log;
 import android.view.OrientationEventListener;
 import android.view.ViewGroup;
 import android.view.WindowManager;
@@ -142,6 +141,16 @@ public class RCTCameraView extends ViewGroup {
         if (this._viewFinder != null) {
             this._viewFinder.setClearWindowBackground(clearWindowBackground);
         }
+    }
+
+    public void stopPreview() {
+        if (_viewFinder == null) return;
+        _viewFinder.stopPreview();
+    }
+
+    public void startPreview() {
+        if (_viewFinder == null) return;
+        _viewFinder.startPreview();
     }
 
     private boolean setActualDeviceOrientation(Context context) {

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
@@ -135,13 +135,13 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
         RCTCamera.getInstance().setZoom(_cameraType, zoom);
    }
 
-    private void startPreview() {
+    public void startPreview() {
         if (_surfaceTexture != null) {
             startCamera();
         }
     }
 
-    private void stopPreview() {
+    public void stopPreview() {
         if (_camera != null) {
             stopCamera();
         }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
@@ -2,15 +2,21 @@ package com.lwansbrough.RCTCamera;
 
 import android.support.annotation.Nullable;
 
+import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.*;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Map;
 
 public class RCTCameraViewManager extends ViewGroupManager<RCTCameraView> {
     private static final String REACT_CLASS = "RCTCamera";
+
+    public static final int COMMAND_STOP_PREVIEW = 1;
+    public static final int COMMAND_START_PREVIEW = 2;
 
     @Override
     public String getName() {
@@ -20,6 +26,33 @@ public class RCTCameraViewManager extends ViewGroupManager<RCTCameraView> {
     @Override
     public RCTCameraView createViewInstance(ThemedReactContext context) {
         return new RCTCameraView(context);
+    }
+
+    @Override
+    public Map<String, Integer> getCommandsMap() {
+        return MapBuilder.of(
+                "stopPreview",
+                COMMAND_STOP_PREVIEW,
+                "startPreview",
+                COMMAND_START_PREVIEW);
+    }
+
+    @Override
+    public void receiveCommand(RCTCameraView view, int commandType, @Nullable ReadableArray args) {
+        Assertions.assertNotNull(view);
+        switch (commandType) {
+            case COMMAND_STOP_PREVIEW: {
+                view.stopPreview();
+                return;
+            }
+            case COMMAND_START_PREVIEW: {
+                view.startPreview();
+                return;
+            }
+            default:
+                throw new IllegalArgumentException(
+                        String.format("Unsupported command %d received by %s.", commandType, getClass().getSimpleName()));
+        }
     }
 
     @ReactProp(name = "aspect")

--- a/src/Camera.js
+++ b/src/Camera.js
@@ -6,12 +6,14 @@ import {
   NativeModules,
   Platform,
   StyleSheet,
+  findNodeHandle,
   requireNativeComponent,
   ViewPropTypes,
   PermissionsAndroid,
   ActivityIndicator,
   View,
   Text,
+  UIManager,
 } from 'react-native';
 
 const CameraManager = NativeModules.CameraManager || NativeModules.CameraModule;
@@ -300,10 +302,10 @@ export default class Camera extends Component {
 
   startPreview() {
     if (Platform.OS === 'android') {
-      const props = convertNativeProps(this.props);
-      CameraManager.startPreview({
-        type: props.type,
-      });
+      UIManager.dispatchViewManagerCommand(
+        findNodeHandle(this),
+        UIManager.RCTCamera.Commands.startPreview,
+      );
     } else {
       CameraManager.startPreview();
     }
@@ -311,10 +313,10 @@ export default class Camera extends Component {
 
   stopPreview() {
     if (Platform.OS === 'android') {
-      const props = convertNativeProps(this.props);
-      CameraManager.stopPreview({
-        type: props.type,
-      });
+      UIManager.dispatchViewManagerCommand(
+        findNodeHandle(this),
+        UIManager.RCTCamera.Commands.stopPreview,
+      );
     } else {
       CameraManager.stopPreview();
     }
@@ -342,16 +344,19 @@ export default class Camera extends Component {
     return CameraManager.hasFlash();
   }
 
-	setZoom(zoom) {
+  setZoom(zoom) {
     if (Platform.OS === 'android') {
       const props = convertNativeProps(this.props);
-      return CameraManager.setZoom({
-        type: props.type,
-      }, zoom);
+      return CameraManager.setZoom(
+        {
+          type: props.type,
+        },
+        zoom,
+      );
     }
 
-		return CameraManager.setZoom(zoom);
-	}
+    return CameraManager.setZoom(zoom);
+  }
 }
 
 export const constants = Camera.constants;

--- a/src/Camera.js
+++ b/src/Camera.js
@@ -17,7 +17,6 @@ import {
 } from 'react-native';
 
 const CameraManager = NativeModules.CameraManager || NativeModules.CameraModule;
-const CAMERA_REF = 'camera';
 
 function convertNativeProps(props) {
   const newProps = { ...props };
@@ -170,7 +169,7 @@ export default class Camera extends Component {
 
   setNativeProps(props) {
     // eslint-disable-next-line
-    this.refs[CAMERA_REF].setNativeProps(props);
+    this._cameraRef.setNativeProps(props);
   }
 
   constructor() {
@@ -180,6 +179,8 @@ export default class Camera extends Component {
       isAuthorizationChecked: false,
       isRecording: false,
     };
+    this._cameraRef = null;
+    this._cameraHandle = null;
   }
 
   async componentWillMount() {
@@ -251,6 +252,16 @@ export default class Camera extends Component {
     }
   }
 
+  _setReference = ref => {
+    if (ref) {
+      this._cameraRef = ref;
+      this._cameraHandle = findNodeHandle(ref);
+    } else {
+      this._cameraRef = null;
+      this._cameraHandle = null;
+    }
+  };
+
   render() {
     // TODO - style is not used, figure it out why
     // eslint-disable-next-line
@@ -258,7 +269,7 @@ export default class Camera extends Component {
     const nativeProps = convertNativeProps(this.props);
 
     if (this.state.isAuthorized) {
-      return <RCTCamera ref={CAMERA_REF} {...nativeProps} />;
+      return <RCTCamera ref={this._setReference} {...nativeProps} />;
     } else if (!this.state.isAuthorizationChecked) {
       return this.props.pendingAuthorizationView;
     } else {
@@ -303,7 +314,7 @@ export default class Camera extends Component {
   startPreview() {
     if (Platform.OS === 'android') {
       UIManager.dispatchViewManagerCommand(
-        findNodeHandle(this),
+        this._cameraHandle,
         UIManager.RCTCamera.Commands.startPreview,
       );
     } else {
@@ -314,7 +325,7 @@ export default class Camera extends Component {
   stopPreview() {
     if (Platform.OS === 'android') {
       UIManager.dispatchViewManagerCommand(
-        findNodeHandle(this),
+        this._cameraHandle,
         UIManager.RCTCamera.Commands.stopPreview,
       );
     } else {


### PR DESCRIPTION
Currently on Android, after calling `startPreview` the camera preview is not initialized correctly, leading to 2 bugs:

- After a capture, the preview is not displayed anymore and continue to show the last picture taken (the preview texture is set to null after capture, but not set back when calling `startPreview`)
- After calling `stopPreview` then `startPreview`, bar code detection does not work anymore (the preview callback is not set back by `startPreview`).

`stopPreview` and `startPreview` methods are called on the native module, and don't have access to camera view instance. Consequently, native camera methods `startPreview` and `stopPreview` are called, but important parts of code are missing, especially re-setting preview callback and preview texture to the current ViewFinder.
This PR use `UIManager.dispatchViewManagerCommand` to send `startPreview` and `stopPreview` commands to the current view instance, which delegates execution to the current ViewFinder instance methods that are called to start the camera initially and take care of the proper initialization.