### PR TITLE
Fix cropToPreview on Android

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java
@@ -85,24 +85,23 @@ public class MutableImage {
         }
     }
 
-    public void cropToPreview(int orientation, float xPercentage, float yPercentage) throws IllegalArgumentException {
-        int width = getWidth();
-        int height = getHeight();
+    public void cropToPreview(double previewRatio) throws IllegalArgumentException {
+        int pictureWidth = getWidth(), pictureHeight = getHeight();
+        int targetPictureWidth, targetPictureHeight;
 
-        int x = (int) Math.round(height * xPercentage);
-        int y = (int) Math.round(width * yPercentage);
-
-        if (orientation == Configuration.ORIENTATION_PORTRAIT) {
-            int cropWidth = width - (y*2);
-            int cropHeight =  height - (x*2);
-
-            this.currentRepresentation = Bitmap.createBitmap(this.currentRepresentation, y, x, cropWidth, cropHeight);
+        if (previewRatio * pictureHeight > pictureWidth) {
+            targetPictureWidth = pictureWidth;
+            targetPictureHeight = (int) (pictureWidth / previewRatio);
         } else {
-            int cropWidth = width - (x*2);
-            int cropHeight =  height - (y*2);
-
-            this.currentRepresentation = Bitmap.createBitmap(this.currentRepresentation, x, y, cropWidth, cropHeight);
+            targetPictureHeight = pictureHeight;
+            targetPictureWidth = (int) (pictureHeight * previewRatio);
         }
+        this.currentRepresentation = Bitmap.createBitmap(
+                this.currentRepresentation,
+                (pictureWidth - targetPictureWidth) / 2,
+                (pictureHeight - targetPictureHeight) / 2,
+                targetPictureWidth,
+                targetPictureHeight);
     }
 
     //see http://www.impulseadventure.com/photo/exif-orientation.html

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -74,20 +74,20 @@ public class RCTCamera {
         return cameraInfo.previewHeight;
     }
 
-    public float getPreviewPaddingHeight(int type) {
+    public int getPreviewVisibleHeight(int type) {
         CameraInfoWrapper cameraInfo = _cameraInfos.get(type);
         if (null == cameraInfo) {
             return 0;
         }
-        return cameraInfo.previewPaddingHeight;
+        return cameraInfo.previewVisibleHeight;
     }
 
-    public float getPreviewPaddingWidth(int type) {
+    public int getPreviewVisibleWidth(int type) {
         CameraInfoWrapper cameraInfo = _cameraInfos.get(type);
         if (null == cameraInfo) {
             return 0;
         }
-        return cameraInfo.previewPaddingWidth;
+        return cameraInfo.previewVisibleWidth;
     }
 
     public Camera.Size getBestSize(List<Camera.Size> supportedSizes, int maxWidth, int maxHeight) {
@@ -451,14 +451,14 @@ public class RCTCamera {
         }
     }
 
-    public void setPreviewPadding(int type, float width, float height) {
+    public void setPreviewVisibleSize(int type, int width, int height) {
         CameraInfoWrapper cameraInfo = _cameraInfos.get(type);
         if (cameraInfo == null) {
             return;
         }
 
-        cameraInfo.previewPaddingWidth = Math.abs(width);
-        cameraInfo.previewPaddingHeight = Math.abs(height);
+        cameraInfo.previewVisibleWidth = width;
+        cameraInfo.previewVisibleHeight = height;
     }
 
     private RCTCamera(int deviceOrientation) {
@@ -491,8 +491,8 @@ public class RCTCamera {
         public int rotation = 0;
         public int previewWidth = -1;
         public int previewHeight = -1;
-        public float previewPaddingHeight = -1;
-        public float previewPaddingWidth = -1;
+        public int previewVisibleWidth = -1;
+        public int previewVisibleHeight = -1;
 
         public CameraInfoWrapper(Camera.CameraInfo info) {
             this.info = info;

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
@@ -210,10 +210,7 @@ public class RCTCameraView extends ViewGroup {
         int viewFinderPaddingX = (int) ((width - viewfinderWidth) / 2);
         int viewFinderPaddingY = (int) ((height - viewfinderHeight) / 2);
 
-        float paddingXPercentage = (float)viewFinderPaddingX / (float)viewfinderWidth;
-        float paddingYPercentage = (float)viewFinderPaddingY / (float)viewfinderHeight;
-
-        RCTCamera.getInstance().setPreviewPadding(_viewFinder.getCameraType(), paddingXPercentage, paddingYPercentage);
+        RCTCamera.getInstance().setPreviewVisibleSize(_viewFinder.getCameraType(), (int) width, (int) height);
 
         this._viewFinder.layout(viewFinderPaddingX, viewFinderPaddingY, viewFinderPaddingX + viewfinderWidth, viewFinderPaddingY + viewfinderHeight);
         this.postInvalidate(this.getLeft(), this.getTop(), this.getRight(), this.getBottom());


### PR DESCRIPTION
There are currently 2 issues with cropToPreview on Android:

- Computation of cropping assume that aspect ratio of camera preview is the same as camera capture. This is not always the case (preview could be 16:9 while highest quality reported by camera correspond to 4:3 aspect ratio for example).
- Handling of portrait orientation is based on device orientation. Unfortunately the behavior of native camera implementation varies across device manufacturers (some phones add an Exif tag to indicate that picture should be rotated, but on on some other phones the captured picture is really rotated).

This PR fix this. 