### PR TITLE
Make FaceDetection optional in iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,15 @@ pod 'react-native-camera', path: '../node_modules/react-native-camera'
 5. Click `RCTCamera.xcodeproj` in the project navigator and go the `Build Settings` tab. Make sure 'All' is toggled on (instead of 'Basic'). In the `Search Paths` section, look for `Header Search Paths` and make sure it contains both `$(SRCROOT)/../../react-native/React` and `$(SRCROOT)/../../../React` - mark both as `recursive`.
 5. Run your project (`Cmd+R`)
 
-### Installing GMV on iOS
+
+### Post install steps
+#### iOS
+
+Face Detecion (available on RNCamera on master branch) is optional. If you want it, you are going to need to install GMV, as mentioned in the next section.
+
+If you do not need it, open your app xcode project, on the Project Navigator, expand the RCTCamera project, right click on the FaceDetector folder and delete it (move to trash, if you want). If you keep that folder and do not follow the GMV installation setps, your project will not compile.
+
+#### Installing GMV on iOS (master branch only)
 GMV (Google Mobile Vision) is used for Face detection by the iOS RNCamera. You have to link the google frameworks to your project to successfully compile the RCTCamera project.
 
 1. Download:
@@ -101,11 +109,11 @@ Google Interchange Utilities: https://dl.google.com/dl/cpdc/1a7f7ba905b2c029/Goo
 
 2. Extract everything to one folder. Delete "BarcodeDetector" and "copy" folders from Google Mobile Vision.
 
-3.
-Open XCode, right click on your project and choose "New Group". Rename the new folder to "Frameworks". Right click on "Frameworks" and select "add files to 'YOUR_PROJECT'". Select all content from the folder of step 2, click on Options. Select "Copy items if needed", leave "Create groups" selected and choose all your targets on the "Add to targets" section. Then, click on "Add".
+3. Open XCode, right click on your project and choose "New Group". Rename the new folder to "Frameworks". Right click on "Frameworks" and select "add files to 'YOUR_PROJECT'". Select all content from the folder of step 2, click on Options. Select "Copy items if needed", leave "Create groups" selected and choose all your targets on the "Add to targets" section. Then, click on "Add".
 
 4. On your target -> Build Phases -> Link Binary with Libraries -> add AddressBook.framework
 5. On your target -> Build Settings -> Other Linker Flags -> add -lz, -ObjC and -lc++
+6. To force indexing and prevent erros, restart xcode and reopen your project again before compiling.
 
 #### Android
 1. `npm install react-native-camera --save`

--- a/ios/FaceDetector/RNFaceDetectorModule.m
+++ b/ios/FaceDetector/RNFaceDetectorModule.m
@@ -28,7 +28,7 @@ static NSDictionary *defaultDetectorOptions = nil;
     return self;
 }
 
-RCT_EXPORT_MODULE(ReactNativeFaceDetector);
+RCT_EXPORT_MODULE(RNFaceDetector);
 
 @synthesize bridge = _bridge;
 

--- a/ios/RCTCamera.xcodeproj/project.pbxproj
+++ b/ios/RCTCamera.xcodeproj/project.pbxproj
@@ -11,16 +11,17 @@
 		4107014D1ACB732B00C6AA39 /* RCTCamera.m in Sources */ = {isa = PBXBuildFile; fileRef = 410701481ACB732B00C6AA39 /* RCTCamera.m */; };
 		4107014E1ACB732B00C6AA39 /* RCTCameraManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4107014A1ACB732B00C6AA39 /* RCTCameraManager.m */; };
 		454EBCF41B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 454EBCF31B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m */; };
-		7147DBB32015319E003C59C3 /* RNFaceDetectorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBB22015319E003C59C3 /* RNFaceDetectorManager.m */; };
-		7147DBB620155340003C59C3 /* RNFaceDetectorModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBB520155340003C59C3 /* RNFaceDetectorModule.m */; };
-		7147DBB9201553EE003C59C3 /* RNFaceDetectorPointTransformCalculator.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBB8201553EE003C59C3 /* RNFaceDetectorPointTransformCalculator.m */; };
-		7147DBBC20155594003C59C3 /* RNFaceDetectorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBBB20155594003C59C3 /* RNFaceDetectorUtils.m */; };
-		7147DBBF20155694003C59C3 /* RNFaceEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBBE20155694003C59C3 /* RNFaceEncoder.m */; };
+		7103647B20195C53009691D1 /* RNFaceDetectorManagerStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 7103647A20195C53009691D1 /* RNFaceDetectorManagerStub.m */; };
 		7162BE672013EAA100FE51FF /* RNCamera.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFCC2013C7BF006EB75A /* RNCamera.m */; };
 		7162BE682013EAA400FE51FF /* RNCameraManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFC92013C7AE006EB75A /* RNCameraManager.m */; };
 		71C7FFD02013C7E5006EB75A /* RNCameraUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFCF2013C7E5006EB75A /* RNCameraUtils.m */; };
 		71C7FFD32013C817006EB75A /* RNImageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFD22013C817006EB75A /* RNImageUtils.m */; };
 		71C7FFD62013C824006EB75A /* RNFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFD52013C824006EB75A /* RNFileSystem.m */; };
+		71D5C728201B8A2A0030A15E /* RNFaceEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBBE20155694003C59C3 /* RNFaceEncoder.m */; };
+		71D5C729201B8A2D0030A15E /* RNFaceDetectorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBBB20155594003C59C3 /* RNFaceDetectorUtils.m */; };
+		71D5C72A201B8A2F0030A15E /* RNFaceDetectorPointTransformCalculator.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBB8201553EE003C59C3 /* RNFaceDetectorPointTransformCalculator.m */; };
+		71D5C72B201B8A320030A15E /* RNFaceDetectorModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBB520155340003C59C3 /* RNFaceDetectorModule.m */; };
+		71D5C72C201B8A360030A15E /* RNFaceDetectorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBB22015319E003C59C3 /* RNFaceDetectorManager.m */; };
 		9FE592B31CA3CBF500788287 /* RCTSensorOrientationChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FE592B21CA3CBF500788287 /* RCTSensorOrientationChecker.m */; };
 /* End PBXBuildFile section */
 
@@ -45,6 +46,8 @@
 		410701491ACB732B00C6AA39 /* RCTCameraManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTCameraManager.h; sourceTree = "<group>"; };
 		4107014A1ACB732B00C6AA39 /* RCTCameraManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTCameraManager.m; sourceTree = "<group>"; };
 		454EBCF31B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableDictionary+ImageMetadata.m"; sourceTree = "<group>"; };
+		7103647920195C53009691D1 /* RNFaceDetectorManagerStub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNFaceDetectorManagerStub.h; sourceTree = "<group>"; };
+		7103647A20195C53009691D1 /* RNFaceDetectorManagerStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNFaceDetectorManagerStub.m; sourceTree = "<group>"; };
 		7147DBB12015319E003C59C3 /* RNFaceDetectorManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNFaceDetectorManager.h; sourceTree = "<group>"; };
 		7147DBB22015319E003C59C3 /* RNFaceDetectorManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNFaceDetectorManager.m; sourceTree = "<group>"; };
 		7147DBB420155340003C59C3 /* RNFaceDetectorModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNFaceDetectorModule.h; sourceTree = "<group>"; };
@@ -127,6 +130,8 @@
 				71C7FFC92013C7AE006EB75A /* RNCameraManager.m */,
 				71C7FFCB2013C7BF006EB75A /* RNCamera.h */,
 				71C7FFCC2013C7BF006EB75A /* RNCamera.m */,
+				7103647920195C53009691D1 /* RNFaceDetectorManagerStub.h */,
+				7103647A20195C53009691D1 /* RNFaceDetectorManagerStub.m */,
 			);
 			path = RN;
 			sourceTree = "<group>";
@@ -204,20 +209,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				0314E39D1B661A460092D183 /* CameraFocusSquare.m in Sources */,
+				71D5C728201B8A2A0030A15E /* RNFaceEncoder.m in Sources */,
 				454EBCF41B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m in Sources */,
-				7147DBBC20155594003C59C3 /* RNFaceDetectorUtils.m in Sources */,
 				71C7FFD62013C824006EB75A /* RNFileSystem.m in Sources */,
-				7147DBB9201553EE003C59C3 /* RNFaceDetectorPointTransformCalculator.m in Sources */,
+				71D5C729201B8A2D0030A15E /* RNFaceDetectorUtils.m in Sources */,
 				4107014E1ACB732B00C6AA39 /* RCTCameraManager.m in Sources */,
+				71D5C72C201B8A360030A15E /* RNFaceDetectorManager.m in Sources */,
+				7103647B20195C53009691D1 /* RNFaceDetectorManagerStub.m in Sources */,
 				4107014D1ACB732B00C6AA39 /* RCTCamera.m in Sources */,
-				7147DBBF20155694003C59C3 /* RNFaceEncoder.m in Sources */,
+				71D5C72A201B8A2F0030A15E /* RNFaceDetectorPointTransformCalculator.m in Sources */,
 				71C7FFD02013C7E5006EB75A /* RNCameraUtils.m in Sources */,
 				7162BE682013EAA400FE51FF /* RNCameraManager.m in Sources */,
-				7147DBB32015319E003C59C3 /* RNFaceDetectorManager.m in Sources */,
-				7147DBB620155340003C59C3 /* RNFaceDetectorModule.m in Sources */,
 				7162BE672013EAA100FE51FF /* RNCamera.m in Sources */,
 				9FE592B31CA3CBF500788287 /* RCTSensorOrientationChecker.m in Sources */,
 				71C7FFD32013C817006EB75A /* RNImageUtils.m in Sources */,
+				71D5C72B201B8A320030A15E /* RNFaceDetectorModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -3,7 +3,12 @@
 #import <React/RCTBridgeModule.h>
 #import <UIKit/UIKit.h>
 #import "RNCamera.h"
+
+#if __has_include("RNFaceDetectorManager.h")
 #import "RNFaceDetectorManager.h"
+#else
+#import "RNFaceDetectorManagerStub.h"
+#endif
 
 @class RNCamera;
 

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -17,7 +17,7 @@
 
 @property (nonatomic, strong) RCTPromiseResolveBlock videoRecordedResolve;
 @property (nonatomic, strong) RCTPromiseRejectBlock videoRecordedReject;
-@property (nonatomic, strong) RNFaceDetectorManager *faceDetectorManager;
+@property (nonatomic, strong) id faceDetectorManager;
 
 @property (nonatomic, copy) RCTDirectEventBlock onCameraReady;
 @property (nonatomic, copy) RCTDirectEventBlock onMountError;
@@ -716,9 +716,18 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
 # pragma mark - Face detector
 
-- (RNFaceDetectorManager*)createFaceDetectorManager
+- (id)createFaceDetectorManager
 {
-    return [[RNFaceDetectorManager alloc] initWithSessionQueue:_sessionQueue delegate:self];
+    Class faceDetectorManagerClass = NSClassFromString(@"RNFaceDetectorManager");
+    Class faceDetectorManagerStubClass = NSClassFromString(@"RNFaceDetectorManagerStub");
+    
+    if (faceDetectorManagerClass) {
+        return [[faceDetectorManagerClass alloc] initWithSessionQueue:_sessionQueue delegate:self];
+    } else if (faceDetectorManagerStubClass) {
+        return [[faceDetectorManagerStubClass alloc] init];
+    }
+    
+    return nil;
 }
 
 - (void)onFacesDetected:(NSArray<NSDictionary *> *)faces

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -86,7 +86,11 @@ RCT_EXPORT_VIEW_PROPERTY(onFacesDetected, RCTDirectEventBlock);
 
 + (NSDictionary *)faceDetectorConstants
 {
+#if __has_include("RNFaceDetectorManager.h")
     return [RNFaceDetectorManager constants];
+#else
+    return [RNFaceDetectorManagerStub constants];
+#endif
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(type, NSInteger, RNCamera)

--- a/ios/RN/RNFaceDetectorManagerStub.h
+++ b/ios/RN/RNFaceDetectorManagerStub.h
@@ -1,0 +1,30 @@
+//
+//  RNFaceDetectorStub.h
+//  RCTCamera
+//
+//  Created by Joao Guilherme Daros Fidelis on 24/01/18.
+//
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+@protocol RNFaceDetectorDelegate
+- (void)onFacesDetected:(NSArray<NSDictionary *> *)faces;
+@end
+
+@interface RNFaceDetectorManagerStub : NSObject
+
+- (NSDictionary *)constantsToExport;
++ (NSDictionary *)constants;
+
+- (instancetype)initWithSessionQueue:(dispatch_queue_t)sessionQueue delegate:(id <RNFaceDetectorDelegate>)delegate;
+
+- (void)setIsEnabled:(id)json;
+- (void)setLandmarksDetected:(id)json;
+- (void)setClassificationsDetected:(id)json;
+- (void)setMode:(id)json;
+
+- (void)maybeStartFaceDetectionOnSession:(AVCaptureSession *)session withPreviewLayer:(AVCaptureVideoPreviewLayer *)previewLayer;
+- (void)stopFaceDetection;
+
+@end

--- a/ios/RN/RNFaceDetectorManagerStub.m
+++ b/ios/RN/RNFaceDetectorManagerStub.m
@@ -1,0 +1,39 @@
+//
+//  RNFaceDetectorStub.m
+//  RCTCamera
+//
+//  Created by Joao Guilherme Daros Fidelis on 24/01/18.
+//
+
+#import "RNFaceDetectorManagerStub.h"
+#import <React/RCTLog.h>
+
+@implementation RNFaceDetectorManagerStub
+
+- (NSDictionary *)constantsToExport {
+    return [[self class] constants];
+}
+
++ (NSDictionary *)constants {
+    return @{@"Mode" : @{},
+             @"Landmarks" : @{},
+             @"Classifications" : @{}};
+}
+
+- (instancetype)initWithSessionQueue:(dispatch_queue_t)sessionQueue delegate:(id <RNFaceDetectorDelegate>)delegate {
+    self = [super init];
+    return self;
+}
+
+- (void)setIsEnabled:(id)json { }
+- (void)setLandmarksDetected:(id)json { }
+- (void)setClassificationsDetected:(id)json { }
+- (void)setMode:(id)json { }
+
+- (void)maybeStartFaceDetectionOnSession:(AVCaptureSession *)session withPreviewLayer:(AVCaptureVideoPreviewLayer *)previewLayer {
+    RCTLogWarn(@"FaceDetector not integrated, stub used!");
+}
+- (void)stopFaceDetection { }
+
+@end
+


### PR DESCRIPTION
On iOS, importing google frameworks is now optional.

You can follow the steps on the readme.md to install.

After linking, if you do not need to use Face Detection, just erase the FaceDetector folder of the RCTCamera project.

If you need it, you can install like before, by importing the frameworks.