### PR TITLE
Fix issue with running on android. Add native props

### DIFF
--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -253,11 +253,18 @@ export const Constants = Camera.Constants;
 
 const RNCamera = requireNativeComponent('RNCamera', Camera, {
   nativeOnly: {
-    onCameraReady: true,
-    onMountError: true,
-    onBarCodeRead: true,
-    onFaceDetected: true,
-    faceDetectorEnabled: true,
+    accessibilityComponentType: true,
+    accessibilityLabel: true,
+    accessibilityLiveRegion: true,
     barCodeScannerEnabled: true,
+    faceDetectorEnabled: true,
+    importantForAccessibility: true,
+    onBarCodeRead: true,
+    onCameraReady: true,
+    onFaceDetected: true,
+    onLayout: true,
+    onMountError: true,
+    renderToHardwareTextureAndroid: true,
+    testID: true,
   },
 });


### PR DESCRIPTION
Running on android 7.0 with react-native 0.43.4 leads to an error that various props are not defined in js, but are present in the native implementation. After I complete the native only props for RNCamera it worked.