### PR TITLE
Fixed missing declare Platform on handlePermissions

### DIFF
--- a/src/handlePermissions.js
+++ b/src/handlePermissions.js
@@ -1,4 +1,4 @@
-import { PermissionsAndroid } from 'react-native';
+import { PermissionsAndroid, Platform } from 'react-native';
 
 export const requestPermissions = async (hasVideoAndAudio, CameraManager, osType, permissionDialogTitle, permissionDialogMessage) => {
     if (osType === 'ios') {


### PR DESCRIPTION
Platform use at line 23 on handlePermissions.js, It's missing
```js
Platform.Version >= 23 ? granted === PermissionsAndroid.RESULTS.GRANTED : granted === true;
```