### PR TITLE
Use AVMetadataObjectTypeCode128Code for code128 barcodeType

### DIFF
--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -74,7 +74,7 @@ RCT_EXPORT_VIEW_PROPERTY(onFacesDetected, RCTDirectEventBlock);
              @"ean13" : AVMetadataObjectTypeEAN13Code,
              @"ean8" : AVMetadataObjectTypeEAN8Code,
              @"code93" : AVMetadataObjectTypeCode93Code,
-             @"code138" : AVMetadataObjectTypeCode128Code,
+             @"code128" : AVMetadataObjectTypeCode128Code,
              @"pdf417" : AVMetadataObjectTypePDF417Code,
              @"qr" : AVMetadataObjectTypeQRCode,
              @"aztec" : AVMetadataObjectTypeAztecCode,


### PR DESCRIPTION
This must be a typo because on Android it is called code128.