### PR TITLE
Incorrect placement of plugin.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,7 @@ dependencies {
   compile "com.google.zxing:core:3.2.1"
   compile "com.drewnoakes:metadata-extractor:2.9.1"
   compile 'com.google.android.gms:play-services-vision:+'
+  compile "com.android.support:exifinterface:+"
 
   compile 'com.github.react-native-community:cameraview:d5d9b0d925494ef451ce3eef3fdf14cc874d9baa'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,6 @@ dependencies {
   compile "com.google.zxing:core:3.2.1"
   compile "com.drewnoakes:metadata-extractor:2.9.1"
   compile 'com.google.android.gms:play-services-vision:+'
-  compile "com.android.support:exifinterface:26.0.2"
 
   compile 'com.github.react-native-community:cameraview:d5d9b0d925494ef451ce3eef3fdf14cc874d9baa'
 }


### PR DESCRIPTION
I believe this is incorrectly used here. This will cause various issues, especially using it with Android Studio. This is also the reason you have to specify the QA compile error. The plugin `com.android.support:exifinterface:+` should at the very least be used but then not even, rather have it as part of the installation process to include the dependency in the users build.gradle.