### PR TITLE
Update build.gradle to support latest Gradle-plugin/wrapper

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,11 +38,11 @@ repositories {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:+'
-  compile "com.google.zxing:core:3.2.1"
-  compile "com.drewnoakes:metadata-extractor:2.9.1"
-  compile 'com.google.android.gms:play-services-vision:+'
-  compile "com.android.support:exifinterface:+"
+  api "com.facebook.react:react-native:+"
+  api "com.google.zxing:core:3.2.1"
+  api "com.drewnoakes:metadata-extractor:2.9.1"
+  api "com.google.android.gms:play-services-vision:+"
+  api "com.android.support:exifinterface:+"
 
-  compile 'com.github.react-native-community:cameraview:d5d9b0d925494ef451ce3eef3fdf14cc874d9baa'
+  api 'com.github.react-native-community:cameraview:d5d9b0d925494ef451ce3eef3fdf14cc874d9baa'
 }


### PR DESCRIPTION
Fixes the problem that occurs when an app with the latest gradle-wrapper and plugin tries to include the module.