### PR TITLE
Width control and rotation fix

### DIFF
--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -62,7 +62,6 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
         try {
             if (inputStream != null) {
                 ExifInterface exifInterface = new ExifInterface(inputStream);
-
                 // Get orientation of the image from mImageData via inputStream
                 int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION,
                         ExifInterface.ORIENTATION_UNDEFINED);
@@ -71,9 +70,8 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
                     mBitmap = resizeBitmap(mBitmap, mOptions.getInt("width"));
                 }
 
-                // Rotate the bitmap to the proper orientation if needed and asked
-                if (mOptions.hasKey("fixOrientation") && mOptions.getBoolean("fixOrientation")
-                        && orientation != ExifInterface.ORIENTATION_UNDEFINED) {
+                // Rotate the bitmap to the proper orientation if needed
+                if (mOptions.hasKey("fixOrientation") && mOptions.getBoolean("fixOrientation") && orientation != ExifInterface.ORIENTATION_UNDEFINED) {
                     mBitmap = rotateBitmap(mBitmap, getImageRotation(orientation));
                 }
 
@@ -86,7 +84,6 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
                     WritableMap exifData = RNCameraViewHelper.getExifData(exifInterface);
                     response.putMap("exif", exifData);
                 }
-
             }
 
             // Upon rotating, write the image's dimensions to the response
@@ -146,7 +143,7 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
         int width = bm.getWidth();
         int height = bm.getHeight();
         float scaleRatio = (float) newWidth / (float) width;
-
+    
         return Bitmap.createScaledBitmap(bm, newWidth, (int) (height * scaleRatio), true);
     }
 

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -61,6 +61,9 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
 
       try {
           if (inputStream != null) {
+              if (mOptions.hasKey("width") && mOptions.hasKey("height")) {
+                  mBitmap = resizeBitmap(mBitmap, mOptions.getInteger("width"), mOptions.getInteger("height"));
+              }
               ExifInterface exifInterface = new ExifInterface(inputStream);
               // Get orientation of the image from mImageData via inputStream
               int orientation = exifInterface.getAttributeInt(
@@ -135,6 +138,20 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
         Matrix matrix = new Matrix();
         matrix.postRotate(angle);
         return Bitmap.createBitmap(source, 0, 0, source.getWidth(), source.getHeight(), matrix, true);
+    }
+
+    public Bitmap resizeBitmap(Bitmap bm, int newWidth, int newHeight) {
+        int width = bm.getWidth();
+        int height = bm.getHeight();
+        float scaleWidth = ((float) newWidth) / width;
+        float scaleHeight = ((float) newHeight) / height;
+
+        Matrix matrix = new Matrix();
+        matrix.postScale(scaleWidth, scaleHeight);
+
+        Bitmap resizedBitmap = Bitmap.createBitmap(bm, 0, 0, width, height, matrix, false);
+        bm.recycle();
+        return resizedBitmap;
     }
 
     private Bitmap flipHorizontally(Bitmap source) {

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -24,18 +24,18 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, WritableMap> {
-  private static final String ERROR_TAG = "E_TAKING_PICTURE_FAILED";
-  private Promise mPromise;
-  private byte[] mImageData;
-  private ReadableMap mOptions;
-  private File mCacheDirectory;
-  private Bitmap mBitmap;
+    private static final String ERROR_TAG = "E_TAKING_PICTURE_FAILED";
+    private Promise mPromise;
+    private byte[] mImageData;
+    private ReadableMap mOptions;
+    private File mCacheDirectory;
+    private Bitmap mBitmap;
 
-  public ResolveTakenPictureAsyncTask(byte[] imageData, Promise promise, ReadableMap options) {
-    mPromise = promise;
-    mOptions = options;
-    mImageData = imageData;
-  }
+    public ResolveTakenPictureAsyncTask(byte[] imageData, Promise promise, ReadableMap options) {
+        mPromise = promise;
+        mOptions = options;
+        mImageData = imageData;
+    }
 
     public ResolveTakenPictureAsyncTask(byte[] imageData, Promise promise, ReadableMap options, File cacheDirectory) {
         mPromise = promise;
@@ -44,95 +44,97 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
         mCacheDirectory = cacheDirectory;
     }
 
-  private int getQuality() {
-    return (int) (mOptions.getDouble("quality") * 100);
-  }
+    private int getQuality() {
+        return (int) (mOptions.getDouble("quality") * 100);
+    }
 
-  @Override
-  protected WritableMap doInBackground(Void... voids) {
-    WritableMap response = Arguments.createMap();
-    ByteArrayInputStream inputStream = null;
+    @Override
+    protected WritableMap doInBackground(Void... voids) {
+        WritableMap response = Arguments.createMap();
+        ByteArrayInputStream inputStream = null;
 
-      // we need the stream only for photos from a device
-      if (mBitmap == null) {
-          mBitmap = BitmapFactory.decodeByteArray(mImageData, 0, mImageData.length);
-          inputStream = new ByteArrayInputStream(mImageData);
-      }
+        // we need the stream only for photos from a device
+        if (mBitmap == null) {
+            mBitmap = BitmapFactory.decodeByteArray(mImageData, 0, mImageData.length);
+            inputStream = new ByteArrayInputStream(mImageData);
+        }
 
-      try {
-          if (inputStream != null) {
-              if (mOptions.hasKey("width") && mOptions.hasKey("height")) {
-                  mBitmap = resizeBitmap(mBitmap, mOptions.getInteger("width"), mOptions.getInteger("height"));
-              }
-              ExifInterface exifInterface = new ExifInterface(inputStream);
-              // Get orientation of the image from mImageData via inputStream
-              int orientation = exifInterface.getAttributeInt(
-                      ExifInterface.TAG_ORIENTATION,
-                      ExifInterface.ORIENTATION_UNDEFINED
-              );
+        try {
+            if (inputStream != null) {
+                ExifInterface exifInterface = new ExifInterface(inputStream);
 
-              // Rotate the bitmap to the proper orientation if needed
-              if (orientation != ExifInterface.ORIENTATION_UNDEFINED) {
-                  mBitmap = rotateBitmap(mBitmap, getImageRotation(orientation));
-              }
+                // Get orientation of the image from mImageData via inputStream
+                int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION,
+                        ExifInterface.ORIENTATION_UNDEFINED);
 
-              if (mOptions.hasKey("mirrorImage") && mOptions.getBoolean("mirrorImage")) {
-                  mBitmap = flipHorizontally(mBitmap);
-              }
+                if (mOptions.hasKey("width")) {
+                    mBitmap = resizeBitmap(mBitmap, mOptions.getInt("width"));
+                }
 
-              // Write Exif data to the response if requested
-              if (mOptions.hasKey("exif") && mOptions.getBoolean("exif")) {
-                  WritableMap exifData = RNCameraViewHelper.getExifData(exifInterface);
-                  response.putMap("exif", exifData);
-              }
-          }
+                // Rotate the bitmap to the proper orientation if needed and asked
+                if (mOptions.hasKey("fixOrientation") && mOptions.getBoolean("fixOrientation")
+                        && orientation != ExifInterface.ORIENTATION_UNDEFINED) {
+                    mBitmap = rotateBitmap(mBitmap, getImageRotation(orientation));
+                }
 
-          // Upon rotating, write the image's dimensions to the response
-          response.putInt("width", mBitmap.getWidth());
-          response.putInt("height", mBitmap.getHeight());
+                if (mOptions.hasKey("mirrorImage") && mOptions.getBoolean("mirrorImage")) {
+                    mBitmap = flipHorizontally(mBitmap);
+                }
 
-          // Cache compressed image in imageStream
-          ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
-          mBitmap.compress(Bitmap.CompressFormat.JPEG, getQuality(), imageStream);
+                // Write Exif data to the response if requested
+                if (mOptions.hasKey("exif") && mOptions.getBoolean("exif")) {
+                    WritableMap exifData = RNCameraViewHelper.getExifData(exifInterface);
+                    response.putMap("exif", exifData);
+                }
 
-          // Write compressed image to file in cache directory
-          String filePath = writeStreamToFile(imageStream);
-          File imageFile = new File(filePath);
-          String fileUri = Uri.fromFile(imageFile).toString();
-          response.putString("uri", fileUri);
+            }
 
-          // Write base64-encoded image to the response if requested
-          if (mOptions.hasKey("base64") && mOptions.getBoolean("base64")) {
-              response.putString("base64", Base64.encodeToString(imageStream.toByteArray(), Base64.DEFAULT));
-          }
+            // Upon rotating, write the image's dimensions to the response
+            response.putInt("width", mBitmap.getWidth());
+            response.putInt("height", mBitmap.getHeight());
 
-          // Cleanup
-          imageStream.close();
-          if (inputStream != null) {
-              inputStream.close();
-              inputStream = null;
-          }
+            // Cache compressed image in imageStream
+            ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
+            mBitmap.compress(Bitmap.CompressFormat.JPEG, getQuality(), imageStream);
 
-          return response;
-      } catch (Resources.NotFoundException e) {
-          mPromise.reject(ERROR_TAG, "Documents directory of the app could not be found.", e);
-          e.printStackTrace();
-      } catch (IOException e) {
-          mPromise.reject(ERROR_TAG, "An unknown I/O exception has occurred.", e);
-          e.printStackTrace();
-      } finally {
-          try {
-              if (inputStream != null) {
-                  inputStream.close();
-              }
-          } catch (IOException e) {
-              e.printStackTrace();
-          }
-      }
+            // Write compressed image to file in cache directory
+            String filePath = writeStreamToFile(imageStream);
+            File imageFile = new File(filePath);
+            String fileUri = Uri.fromFile(imageFile).toString();
+            response.putString("uri", fileUri);
 
-    // An exception had to occur, promise has already been rejected. Do not try to resolve it again.
-    return null;
-  }
+            // Write base64-encoded image to the response if requested
+            if (mOptions.hasKey("base64") && mOptions.getBoolean("base64")) {
+                response.putString("base64", Base64.encodeToString(imageStream.toByteArray(), Base64.DEFAULT));
+            }
+
+            // Cleanup
+            imageStream.close();
+            if (inputStream != null) {
+                inputStream.close();
+                inputStream = null;
+            }
+
+            return response;
+        } catch (Resources.NotFoundException e) {
+            mPromise.reject(ERROR_TAG, "Documents directory of the app could not be found.", e);
+            e.printStackTrace();
+        } catch (IOException e) {
+            mPromise.reject(ERROR_TAG, "An unknown I/O exception has occurred.", e);
+            e.printStackTrace();
+        } finally {
+            try {
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        // An exception had to occur, promise has already been rejected. Do not try to resolve it again.
+        return null;
+    }
 
     private Bitmap rotateBitmap(Bitmap source, int angle) {
         Matrix matrix = new Matrix();
@@ -140,18 +142,12 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
         return Bitmap.createBitmap(source, 0, 0, source.getWidth(), source.getHeight(), matrix, true);
     }
 
-    public Bitmap resizeBitmap(Bitmap bm, int newWidth, int newHeight) {
+    private Bitmap resizeBitmap(Bitmap bm, int newWidth) {
         int width = bm.getWidth();
         int height = bm.getHeight();
-        float scaleWidth = ((float) newWidth) / width;
-        float scaleHeight = ((float) newHeight) / height;
+        float scaleRatio = (float) newWidth / (float) width;
 
-        Matrix matrix = new Matrix();
-        matrix.postScale(scaleWidth, scaleHeight);
-
-        Bitmap resizedBitmap = Bitmap.createBitmap(bm, 0, 0, width, height, matrix, false);
-        bm.recycle();
-        return resizedBitmap;
+        return Bitmap.createScaledBitmap(bm, newWidth, (int) (height * scaleRatio), true);
     }
 
     private Bitmap flipHorizontally(Bitmap source) {
@@ -165,56 +161,56 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
     private int getImageRotation(int orientation) {
         int rotationDegrees = 0;
         switch (orientation) {
-            case ExifInterface.ORIENTATION_ROTATE_90:
-                rotationDegrees = 90;
-                break;
-            case ExifInterface.ORIENTATION_ROTATE_180:
-                rotationDegrees = 180;
-                break;
-            case ExifInterface.ORIENTATION_ROTATE_270:
-                rotationDegrees = 270;
-                break;
+        case ExifInterface.ORIENTATION_ROTATE_90:
+            rotationDegrees = 90;
+            break;
+        case ExifInterface.ORIENTATION_ROTATE_180:
+            rotationDegrees = 180;
+            break;
+        case ExifInterface.ORIENTATION_ROTATE_270:
+            rotationDegrees = 270;
+            break;
         }
         return rotationDegrees;
     }
 
-  private String writeStreamToFile(ByteArrayOutputStream inputStream) throws IOException {
-    String outputPath = null;
-    IOException exception = null;
-    FileOutputStream outputStream = null;
+    private String writeStreamToFile(ByteArrayOutputStream inputStream) throws IOException {
+        String outputPath = null;
+        IOException exception = null;
+        FileOutputStream outputStream = null;
 
-    try {
-        outputPath = RNFileUtils.getOutputFilePath(mCacheDirectory, ".jpg");
-        outputStream = new FileOutputStream(outputPath);
-        inputStream.writeTo(outputStream);
-    } catch (IOException e) {
-        e.printStackTrace();
-        exception = e;
-    } finally {
         try {
-            if (outputStream != null) {
-                outputStream.close();
-            }
+            outputPath = RNFileUtils.getOutputFilePath(mCacheDirectory, ".jpg");
+            outputStream = new FileOutputStream(outputPath);
+            inputStream.writeTo(outputStream);
         } catch (IOException e) {
             e.printStackTrace();
+            exception = e;
+        } finally {
+            try {
+                if (outputStream != null) {
+                    outputStream.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (exception != null) {
+            throw exception;
+        }
+
+        return outputPath;
+    }
+
+    @Override
+    protected void onPostExecute(WritableMap response) {
+        super.onPostExecute(response);
+
+        // If the response is not null everything went well and we can resolve the promise.
+        if (response != null) {
+            mPromise.resolve(response);
         }
     }
-
-    if (exception != null) {
-        throw exception;
-    }
-
-    return outputPath;
-}
-
-  @Override
-  protected void onPostExecute(WritableMap response) {
-    super.onPostExecute(response);
-
-    // If the response is not null everything went well and we can resolve the promise.
-    if (response != null) {
-      mPromise.resolve(response);
-    }
-  }
 
 }

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -247,6 +247,8 @@ Supported options:
  - `base64` (boolean true or false) Use this with `true` if you want a base64 representation of the picture taken on the return data of your promise. If no value is specified `base64:false` is used.
 
  - `exif` (boolean true or false) Use this with `true` if you want a exif data map of the picture taken on the return data of your promise. If no value is specified `exif:false` is used.
+ 
+ - `fixOrientation` (android only, boolean true or false) Use this with `true` if you want to fix incorrect image orientation (can take up to 5 seconds on some devices). Do not provide this if you only need EXIF based orientation.
 
 The promise will be fulfilled with an object with some of the following properties:
 

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -240,6 +240,8 @@ Takes a picture, saves in your app's cache directory and returns a promise.
 
 Supported options:
 
+ - `width` (integer). This property allows to specify the width that the returned image should have. If no value is specified the maximum image size is used (capture may take longer).
+
  - `quality` (float between 0 to 1.0). This property is used to compress the output jpeg file with 1 meaning no jpeg compression will be applied. If no value is specified `quality:1` is used.
 
  - `base64` (boolean true or false) Use this with `true` if you want a base64 representation of the picture taken on the return data of your promise. If no value is specified `base64:false` is used.

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -240,7 +240,7 @@ Takes a picture, saves in your app's cache directory and returns a promise.
 
 Supported options:
 
- - `width` (integer). This property allows to specify the width that the returned image should have. If no value is specified the maximum image size is used (capture may take longer).
+ - `width` (integer). This property allows to specify the width that the returned image should have, image ratio will not be affected. If no value is specified the maximum image size is used (capture may take longer).
 
  - `quality` (float between 0 to 1.0). This property is used to compress the output jpeg file with 1 meaning no jpeg compression will be applied. If no value is specified `quality:1` is used.
 

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -324,17 +324,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             if ([options[@"mirrorImage"] boolValue]) {
                 takenImage = [RNImageUtils mirrorImage:takenImage];
             }
-<<<<<<< HEAD
-=======
             
             if ([options[@"width"] integerValue]) {
                 takenImage = [RNImageUtils scaleImage:takenImage toWidth:[options[@"width"] integerValue]];
             }
-            
-            if ([options[@"forceUpOrientation"] boolValue]) {
-                takenImage = [RNImageUtils forceUpOrientation:takenImage];
-            }
->>>>>>> c03db73... Add width property on iOS. Allows to specify an image width on capture
             
             NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
             float quality = [options[@"quality"] floatValue];

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -324,6 +324,17 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             if ([options[@"mirrorImage"] boolValue]) {
                 takenImage = [RNImageUtils mirrorImage:takenImage];
             }
+<<<<<<< HEAD
+=======
+            
+            if ([options[@"width"] integerValue]) {
+                takenImage = [RNImageUtils scaleImage:takenImage toWidth:[options[@"width"] integerValue]];
+            }
+            
+            if ([options[@"forceUpOrientation"] boolValue]) {
+                takenImage = [RNImageUtils forceUpOrientation:takenImage];
+            }
+>>>>>>> c03db73... Add width property on iOS. Allows to specify an image width on capture
             
             NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
             float quality = [options[@"quality"] floatValue];

--- a/ios/RN/RNImageUtils.h
+++ b/ios/RN/RNImageUtils.h
@@ -15,6 +15,7 @@
 + (UIImage *)cropImage:(UIImage *)image toRect:(CGRect)rect;
 + (UIImage *)mirrorImage:(UIImage *)image;
 + (NSString *)writeImage:(NSData *)image toPath:(NSString *)path;
++ (UIImage *) scaleImage:(UIImage*)image toWidth:(NSInteger)width;
 + (void)updatePhotoMetadata:(CMSampleBufferRef)imageSampleBuffer withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response;
 
 @end

--- a/ios/RN/RNImageUtils.m
+++ b/ios/RN/RNImageUtils.m
@@ -68,8 +68,6 @@
     return [fileURL absoluteString];
 }
 
-<<<<<<< HEAD
-=======
 + (UIImage *) scaleImage:(UIImage*)image toWidth:(NSInteger)width
 {
     width /= [UIScreen mainScreen].scale; // prevents image from being incorrectly resized on retina displays
@@ -83,18 +81,6 @@
     return [UIImage imageWithCGImage:[newImage CGImage]  scale:1.0 orientation:(newImage.imageOrientation)];
 }
 
-+ (UIImage *)forceUpOrientation:(UIImage *)image
-{
-    if (image.imageOrientation != UIImageOrientationUp) {
-        UIGraphicsBeginImageContextWithOptions(image.size, NO, image.scale);
-        [image drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];
-        image = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
-    }
-    return image;
-} 
-
->>>>>>> c03db73... Add width property on iOS. Allows to specify an image width on capture
 + (void)updatePhotoMetadata:(CMSampleBufferRef)imageSampleBuffer withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response
 {
     CFDictionaryRef exifAttachments = CMGetAttachment(imageSampleBuffer, kCGImagePropertyExifDictionary, NULL);

--- a/ios/RN/RNImageUtils.m
+++ b/ios/RN/RNImageUtils.m
@@ -68,6 +68,33 @@
     return [fileURL absoluteString];
 }
 
+<<<<<<< HEAD
+=======
++ (UIImage *) scaleImage:(UIImage*)image toWidth:(NSInteger)width
+{
+    width /= [UIScreen mainScreen].scale; // prevents image from being incorrectly resized on retina displays
+    float scaleRatio = (float) width / (float) image.size.width;
+    CGSize size = CGSizeMake(width, (int) (image.size.height * scaleRatio));
+    
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
+    [image drawInRect:CGRectMake(0, 0, size.width, size.height)];
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return [UIImage imageWithCGImage:[newImage CGImage]  scale:1.0 orientation:(newImage.imageOrientation)];
+}
+
++ (UIImage *)forceUpOrientation:(UIImage *)image
+{
+    if (image.imageOrientation != UIImageOrientationUp) {
+        UIGraphicsBeginImageContextWithOptions(image.size, NO, image.scale);
+        [image drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];
+        image = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+    }
+    return image;
+} 
+
+>>>>>>> c03db73... Add width property on iOS. Allows to specify an image width on capture
 + (void)updatePhotoMetadata:(CMSampleBufferRef)imageSampleBuffer withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response
 {
     CFDictionaryRef exifAttachments = CMGetAttachment(imageSampleBuffer, kCGImagePropertyExifDictionary, NULL);


### PR DESCRIPTION
Following on this issue #768 I propose the following changes : 

- Controlling returned image size on IOS and Android by providing `width` option in `takePictureAsync`

I think that width option is a great addition to this lib, indeed, apart from reducing picture taking time, it removes the obligation to resize image after capture

- Ability to enable/disable the orientation fix (that takes up to 6 seconds on Android) by providing `fixOrientation` option (android only, not needed on iOS) 

Note that reducing the image size with the new `width` property allows to reduce orientation fixing time exponantially : 

For an image with a size of 4000x3000, providing `width: 1000` reduces picture taking time from 6 seconds to 1.7seconds on a Samsung Galaxy A3.
