### PR TITLE
Add type definitions (For TypeScript or better autocomplete support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     ]
   },
   "main": "src/index.js",
+  "types": "types",
   "nativePackage": true,
   "pre-commit": "lint:staged",
   "repository": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,16 +12,16 @@
 import { Component } from 'react';
 import { ViewProperties } from "react-native";
 
-type AutoFocus = { on, off };
-type FlashMode = { on, off, torch, auto }
-type CameraType = { front, back }
-type WhiteBalance = { sunny, cloudy, shadow, incandescent, fluorescent, auto }
-type BarCodeType = { aztec, code128, code39, code39mod43, code93, ean13, ean8, pdf417, qr, upce, interleaved2of5, itf14, datamatrix }
-type VideoQuality = { '2160p', '1080p', '720p', '480p', '4:3' }
+type AutoFocus = { on: any, off: any };
+type FlashMode = { on: any, off: any, torch: any, auto: any };
+type CameraType = { front: any, back: any };
+type WhiteBalance = { sunny: any, cloudy: any, shadow: any, incandescent: any, fluorescent: any, auto: any };
+type BarCodeType = { aztec: any, code128: any, code39: any, code39mod43: any, code93: any, ean13: any, ean8: any, pdf417: any, qr: any, upce: any, interleaved2of5: any, itf14: any, datamatrix: any };
+type VideoQuality = { '2160p': any, '1080p': any, '720p': any, '480p': any, '4:3': any };
 
-type FaceDetectionClassifications = { all, none }
-type FaceDetectionLandmarks = { all, none }
-type FaceDetectionMode = { fast, accurate }
+type FaceDetectionClassifications = { all: any, none: any };
+type FaceDetectionLandmarks = { all: any, none: any };
+type FaceDetectionMode = { fast: any, accurate: any };
 
 export interface Constants {
     AutoFocus: AutoFocus;
@@ -37,7 +37,7 @@ export interface Constants {
     }
 }
 
-export interface RNCameraProps extends ViewProperties {
+export interface RNCameraProps {
     autoFocus?: keyof AutoFocus;
     type?: keyof CameraType;
     flashMode?: keyof FlashMode;
@@ -139,7 +139,7 @@ interface RecordResponse {
     uri: string;
 }
 
-export class RNCamera extends Component<RNCameraProps> {
+export class RNCamera extends Component<RNCameraProps & ViewProperties> {
     static Constants: Constants;
 
     takePictureAsync(options?: TakePictureOptions): Promise<TakePictureResponse>;
@@ -148,6 +148,18 @@ export class RNCamera extends Component<RNCameraProps> {
 
     /** Android only */
     getSupportedRatiosAsync(): Promise<string[]>;
+}
+
+interface DetectionOptions {
+    mode?: keyof FaceDetectionMode,
+    detectLandmarks?: keyof FaceDetectionLandmarks,
+    runClassifications?: keyof FaceDetectionClassifications
+}
+
+export class FaceDetector {
+    private constructor();
+    static Constants: Constants['FaceDetection'];
+    static detectFacesAsync(uri: string, options?: DetectionOptions): Promise<Face[]>;
 }
 
 // -- DEPRECATED CONTENT BELOW

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,160 @@
+// Type definitions for react-native-camera 1.0
+// Definitions by Felipe Constantino <https://github.com/fconstant>
+// If you modify this file, put your GitHub info here as well (for easy contacting purposes)
+
+/*
+ * Author notes:
+ * I've tried to find a easy tool to convert from Flow to Typescript definition files (.d.ts).
+ * So we woudn't have to do it manually... Sadly, I haven't found it.
+ * 
+ * If you are seeing this from the future, please, send us your cutting-edge technology :) (if it exists)
+ */
+import { Component } from 'react';
+import { ViewProperties } from "react-native";
+
+type AutoFocus = { on, off };
+type FlashMode = { on, off, torch, auto }
+type CameraType = { front, back }
+type WhiteBalance = { sunny, cloudy, shadow, incandescent, fluorescent, auto }
+type BarCodeType = { aztec, code128, code39, code39mod43, code93, ean13, ean8, pdf417, qr, upce, interleaved2of5, itf14, datamatrix }
+type VideoQuality = { '2160p', '1080p', '720p', '480p', '4:3' }
+
+type FaceDetectionClassifications = { all, none }
+type FaceDetectionLandmarks = { all, none }
+type FaceDetectionMode = { fast, accurate }
+
+export interface Constants {
+    AutoFocus: AutoFocus;
+    FlashMode: FlashMode;
+    Type: CameraType;
+    WhiteBalance: WhiteBalance;
+    VideoQuality: VideoQuality;
+    BarCodeType: BarCodeType;
+    FaceDetection: {
+        Classifications: FaceDetectionClassifications;
+        Landmarks: FaceDetectionLandmarks;
+        Mode: FaceDetectionMode;
+    }
+}
+
+export interface RNCameraProps extends ViewProperties {
+    autoFocus?: keyof AutoFocus;
+    type?: keyof CameraType;
+    flashMode?: keyof FlashMode;
+    notAuthorizedView?: JSX.Element;
+    pendingAuthorizationView?: JSX.Element;
+
+    onCameraReady?(): void;
+    onMountError?(): void;
+
+    /** Value: float from 0 to 1.0 */
+    zoom?: number;
+    /** Value: float from 0 to 1.0 */
+    focusDepth?: number;
+
+    // -- BARCODE PROPS
+    barCodeTypes?: Array<keyof BarCodeType>;
+    onBarCodeRead?(data: string, type: keyof BarCodeType): void;
+
+    // -- FACE DETECTION PROPS
+
+    onFacesDetected?(response: { faces: Face[] }): void;
+    onFaceDetectionError?(response: { isOperational: boolean }): void;
+    faceDetectionMode?: keyof FaceDetectionMode;
+    faceDetectionLandmarks?: keyof FaceDetectionLandmarks;
+    faceDetectionClassifications?: keyof FaceDetectionClassifications;
+
+    // -- ANDROID ONLY PROPS
+
+    /** Android only */
+    ratio?: number;
+    /** Android only */
+    permissionDialogTitle?: string;
+    /** Android only */
+    permissionDialogMessage?: string;
+
+    // -- IOS ONLY PROPS
+    
+    /** iOS Only */
+    captureAudio?: boolean;
+
+}
+
+interface Point {
+    x: number,
+    y: number
+}
+
+interface Face {
+    faceID?: number,
+    bounds: {
+        size: {
+            width: number;
+            height: number;
+        };
+        origin: Point;
+    };
+    smilingProbability?: number;
+    leftEarPosition?: Point;
+    rightEarPosition?: Point;
+    leftEyePosition?: Point;
+    leftEyeOpenProbability?: number;
+    rightEyePosition?: Point;
+    rightEyeOpenProbability?: number;
+    leftCheekPosition?: Point;
+    rightCheekPosition?: Point;
+    leftMouthPosition?: Point;
+    mouthPosition?: Point;
+    rightMouthPosition?: Point;
+    bottomMouthPosition?: Point;
+    noseBasePosition?: Point;
+    yawAngle?: number;
+    rollAngle?: number;
+}
+
+interface TakePictureOptions {
+    quality?: number;
+    base64?: boolean;
+    exif?: boolean;
+}
+
+interface TakePictureResponse {
+    width: number;
+    height: number;
+    uri: string;
+    base64?: string;
+    exif?: { [name: string]: any };
+}
+
+
+interface RecordOptions {
+    quality?: keyof VideoQuality;
+    maxDuration?: number;
+    maxFileSize?: number;
+    mute?: boolean;
+}
+
+interface RecordResponse {
+    /** Path to the video saved on your app's cache directory. */
+    uri: string;
+}
+
+export class RNCamera extends Component<RNCameraProps> {
+    static Constants: Constants;
+
+    takePictureAsync(options?: TakePictureOptions): Promise<TakePictureResponse>;
+    recordAsync(options?: RecordOptions): Promise<RecordResponse>;
+    stopRecording(): void;
+
+    /** Android only */
+    getSupportedRatiosAsync(): Promise<string[]>;
+}
+
+// -- DEPRECATED CONTENT BELOW
+
+/**
+ * @deprecated As of 1.0.0 release, RCTCamera is deprecated. Please use RNCamera for the latest fixes and improvements.
+ */
+export default class RCTCamera extends Component<any> {
+    static constants: any;
+}


### PR DESCRIPTION
Resolves #785.

I made a [simple RN project](https://github.com/Fconstant/TestDTSCamera) that you can test.

Some of the declarations were copied out from Flow types.
Most from the official docs.

The deprecated `RCTCamera` Component has a simple default export with `static constants: any`. I don't find a reason to add complex type declarations to a deprecated component.

This PR adds a `"types"` flag to the `package.json` as well, this tells the TS Compiler where to find all the type declarations for this module.