### PR TITLE
 Add ability to force portrait orientation on IOS

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -246,6 +246,8 @@ Supported options:
 
  - `exif` (boolean true or false) Use this with `true` if you want a exif data map of the picture taken on the return data of your promise. If no value is specified `exif:false` is used.
 
+ - `forceUpOrientation` (iOS only, boolean true or false). This property allows to force portrait orientation based on actual data instead of exif data.
+
 The promise will be fulfilled with an object with some of the following properties:
 
  - `width`: returns the image's width (taking image orientation into account)

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -324,6 +324,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             if ([options[@"mirrorImage"] boolValue]) {
                 takenImage = [RNImageUtils mirrorImage:takenImage];
             }
+            if ([options[@"forceUpOrientation"] boolValue]) {
+                takenImage = [RNImageUtils forceUpOrientation:takenImage];
+            }
             
             NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
             float quality = [options[@"quality"] floatValue];
@@ -336,6 +339,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             if ([options[@"base64"] boolValue]) {
                 response[@"base64"] = [takenImageData base64EncodedStringWithOptions:0];
             }
+
+            
             
             if ([options[@"exif"] boolValue]) {
                 int imageRotation;

--- a/ios/RN/RNImageUtils.h
+++ b/ios/RN/RNImageUtils.h
@@ -14,6 +14,7 @@
 + (UIImage *)generatePhotoOfSize:(CGSize)size;
 + (UIImage *)cropImage:(UIImage *)image toRect:(CGRect)rect;
 + (UIImage *)mirrorImage:(UIImage *)image;
++ (UIImage *)forceUpOrientation:(UIImage *)image;
 + (NSString *)writeImage:(NSData *)image toPath:(NSString *)path;
 + (void)updatePhotoMetadata:(CMSampleBufferRef)imageSampleBuffer withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response;
 

--- a/ios/RN/RNImageUtils.m
+++ b/ios/RN/RNImageUtils.m
@@ -68,6 +68,17 @@
     return [fileURL absoluteString];
 }
 
++ (UIImage *)forceUpOrientation:(UIImage *)image toRect:(CGRect)rect
+{
+    if (image.imageOrientation != UIImageOrientationUp) {
+        UIGraphicsBeginImageContextWithOptions(image.size, NO, image.scale);
+        [image drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];
+        image = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+    }
+    return image;
+} 
+
 + (void)updatePhotoMetadata:(CMSampleBufferRef)imageSampleBuffer withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response
 {
     CFDictionaryRef exifAttachments = CMGetAttachment(imageSampleBuffer, kCGImagePropertyExifDictionary, NULL);

--- a/ios/RN/RNImageUtils.m
+++ b/ios/RN/RNImageUtils.m
@@ -68,7 +68,7 @@
     return [fileURL absoluteString];
 }
 
-+ (UIImage *)forceUpOrientation:(UIImage *)image toRect:(CGRect)rect
++ (UIImage *)forceUpOrientation:(UIImage *)image
 {
     if (image.imageOrientation != UIImageOrientationUp) {
         UIGraphicsBeginImageContextWithOptions(image.size, NO, image.scale);


### PR DESCRIPTION
iOS uses exif based orientation, this causes orientation failure when displaying image on a web page.
Indeed web browsers don't read exif when displaying images and iOS images appear as landscape.

The forceUpOrientation boolean fixes this by rotating the actual image data and therefore does not rely on exif data.

This PR is a fix for https://github.com/react-native-community/react-native-camera/issues/1263