### PR TITLE
Fix recursive header expansion falied

### DIFF
--- a/ios/RNCamera.xcodeproj/project.pbxproj
+++ b/ios/RNCamera.xcodeproj/project.pbxproj
@@ -262,8 +262,8 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/../../ios/**",
 					"${BUILT_PRODUCTS_DIR}/**",
-					"$(PROJECT_DIR)/../../../ios/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -279,9 +279,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/**";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../ios/**",
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/**";
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../../ios/**";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -312,8 +316,8 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/../../ios/**",
 					"${BUILT_PRODUCTS_DIR}/**",
-					"$(PROJECT_DIR)/../../../ios/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -322,9 +326,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/**";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../ios/**",
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/**";
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../../ios/**";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Use `SRCROOT` instead of `PROJECT_DIR` to fix the following error : 

```
Argument list too long: recursive header expansion failed
```

Fix https://github.com/react-native-community/react-native-camera/issues/1250.

Also adds `React` and `React Native` header search paths as mentioned in https://github.com/react-native-community/react-native-camera#ios step 5