### PR TITLE
add missing mirrorImage takePictureASync option to docs & types

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -245,6 +245,8 @@ Supported options:
  - `quality` (float between 0 to 1.0). This property is used to compress the output jpeg file with 1 meaning no jpeg compression will be applied. If no value is specified `quality:1` is used.
 
  - `base64` (boolean true or false) Use this with `true` if you want a base64 representation of the picture taken on the return data of your promise. If no value is specified `base64:false` is used.
+ 
+ - `mirrorImage` (boolean true or false). Use this with `true` if you want the resulting rendered picture to be mirrored (inverted in the vertical axis). If no value is specified `mirrorImage:false` is used.
 
  - `exif` (boolean true or false) Use this with `true` if you want a exif data map of the picture taken on the return data of your promise. If no value is specified `exif:false` is used.
  

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -117,6 +117,7 @@ interface TakePictureOptions {
     base64?: boolean;
     exif?: boolean;
     width?: number;
+    mirrorImage?: boolean;
 
     /** Android only */
     fixOrientation?: boolean;


### PR DESCRIPTION
I noticed there's a working option (at least for Android) to `takePictureAsync`: `mirrorImage`.

Why this isn't stated at the docs?
This PR adds it to the docs + add types