### PR TITLE
Fix onBarCodeRead definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,7 +54,10 @@ export interface RNCameraProps {
 
     // -- BARCODE PROPS
     barCodeTypes?: Array<keyof BarCodeType>;
-    onBarCodeRead?(data: string, type: keyof BarCodeType): void;
+    onBarCodeRead?(event: {
+        data: string
+        type: keyof BarCodeType
+    }): void;
 
     // -- FACE DETECTION PROPS
 


### PR DESCRIPTION
I noticed that I actually wrote `RNCameraProps.onBarCodeRead` typings wrong. Just fixing it