### PR TITLE
Fine-grained podspec (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ cp node_modules/react-native-camera/postinstall_project/projectWithoutFaceDetect
 
 And add something like this to the `scripts` section in your `package.json`:
 
+*Note:* The face detection code is excluded by default for the **CocoaPods** installation.
 ```
 "postinstall": "./scripts/post.sh",
 ```
@@ -114,7 +115,21 @@ And add something like this to the `scripts` section in your `package.json`:
 ##### Installing GMV frameworks
 GMV (Google Mobile Vision) is used for Face detection by the iOS RNCamera. You have to link the google frameworks to your project to successfully compile the RNCamera project.
 
-1. Download:
+1. If using **CocoaPods** modify the dependency towards `react-native-camera` in your
+ `Podfile`, from 
+
+ ```
+ pod 'react-native-camera', path: '../node_modules/react-native-camera'
+```
+
+to 
+
+```
+pod 'react-native-camera', subspecs: ['RCT', 'RN', 'FaceDetector'], path: '../node_modules/react-native-camera'
+```
+
+
+2. Download:
 Google Symbol Utilities: https://www.gstatic.com/cpdc/dbffca986f6337f8-GoogleSymbolUtilities-1.1.1.tar.gz
 
     Google Utilities: https://dl.google.com/dl/cpdc/978f81964b50a7c0/GoogleUtilities-1.3.2.tar.gz
@@ -125,13 +140,13 @@ Google Symbol Utilities: https://www.gstatic.com/cpdc/dbffca986f6337f8-GoogleSym
 
     Google Interchange Utilities: https://dl.google.com/dl/cpdc/1a7f7ba905b2c029/GoogleInterchangeUtilities-1.2.2.tar.gz
 
-2. Extract everything to one folder. Delete "BarcodeDetector" and "copy" folders from Google Mobile Vision.
+3. Extract everything to one folder. Delete "BarcodeDetector" and "copy" folders from Google Mobile Vision.
 
-3. Open XCode, right click on your project and choose "New Group". Rename the new folder to "Frameworks". Right click on "Frameworks" and select "add files to 'YOUR_PROJECT'". Select all content from the folder of step 2, click on Options. Select "Copy items if needed", leave "Create groups" selected and choose all your targets on the "Add to targets" section. Then, click on "Add".
+4. Open XCode, right click on your project and choose "New Group". Rename the new folder to "Frameworks". Right click on "Frameworks" and select "add files to 'YOUR_PROJECT'". Select all content from the folder of step 2, click on Options. Select "Copy items if needed", leave "Create groups" selected and choose all your targets on the "Add to targets" section. Then, click on "Add".
 
-4. On your target -> Build Phases -> Link Binary with Libraries -> add AddressBook.framework
-5. On your target -> Build Settings -> Other Linker Flags -> add -lz, -ObjC and -lc++
-6. To force indexing and prevent erros, restart xcode and reopen your project again before compiling.
+5. On your target -> Build Phases -> Link Binary with Libraries -> add AddressBook.framework
+6. On your target -> Build Settings -> Other Linker Flags -> add -lz, -ObjC and -lc++
+7. To force indexing and prevent erros, restart xcode and reopen your project again before compiling.
 
 #### Android
 1. `npm install react-native-camera --save`

--- a/react-native-camera.podspec
+++ b/react-native-camera.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     ss.source_files = "ios/FaceDetector/**/*.{h,m}"
   end
 
-  s.default_subspec = "RN"
+  s.default_subspecs = "RN", "RCT"
 
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
 

--- a/react-native-camera.podspec
+++ b/react-native-camera.podspec
@@ -15,8 +15,21 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
   s.platform       = :ios, '8.0'
 
+  s.subspec "RCT" do |ss|
+    ss.source_files = "ios/RCT/**/*.{h,m}"
+  end
+
+  s.subspec "RN" do |ss|
+    ss.source_files = "ios/RN/**/*.{h,m}"
+  end
+
+  s.subspec "FaceDetector" do |ss|
+    ss.source_files = "ios/FaceDetector/**/*.{h,m}"
+  end
+
+  s.default_subspec = "RN"
+
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
-  s.source_files   = 'ios/**/*.{h,m}'
 
   s.dependency 'React'
 end


### PR DESCRIPTION
Due to the rather involved installation setup for the use of the face detector on iOS with cocoapods, it is perhaps better that it is turned off by default when using the library via cocoapods.

Users wanting to use the face detector, can opt-in to do so.

To achieve this, this PR introduces subspecs for the 3 major components within the library:
- RN
- RCT
- FaceDetector

When using just 

```
pod 'react-native-camera' path: ...
```

Only RN and RCT are included by default. 

To also include the FaceDetector code, one should use

```
pod 'react-native-camera', subspecs: ['RCT', 'RN', 'FaceDetector'], path: '../node_modules/react-native-camera'
```

Ideally, one should also use the [pod for google vision](https://cocoapods.org/?q=google%20vision) when using cocoapods, but I leave that to someone that needs the feature to improve it ;).