### PR TITLE
Reformat exposure time in exif data.

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java
@@ -190,14 +190,18 @@ public class MutableImage {
 
             // Add missing exif data from a sub directory
             ExifSubIFDDirectory directory = originalImageMetaData()
-                .getFirstDirectoryOfType(ExifSubIFDDirectory.class);
+               .getFirstDirectoryOfType(ExifSubIFDDirectory.class);
             for (Tag tag : directory.getTags()) {
                 int tagType = tag.getTagType();
                 // As some of exif data does not follow naming of the ExifInterface the names need
                 // to be transformed into Upper camel case format.
                 String tagName = tag.getTagName().replaceAll(" ", "");
                 Object object = directory.getObject(tagType);
-                exif.setAttribute(tagName, object.toString());
+                if (tagName.equals(ExifInterface.TAG_EXPOSURE_TIME)) {
+                    exif.setAttribute(tagName, convertExposureTimeToDoubleFormat(object.toString()));
+                } else {
+                    exif.setAttribute(tagName, object.toString());
+                }
             }
 
             writeLocationExifData(options, exif);
@@ -209,6 +213,18 @@ public class MutableImage {
         } catch (ImageProcessingException  | IOException e) {
             Log.e(TAG, "failed to save exif data", e);
         }
+    }
+
+    // Reformats exposure time value to match ExifInterface format. Example 1/11 -> 0.0909
+    // Even the value is formatted as double it is returned as a String because exif.setAttribute requires it.
+    private String convertExposureTimeToDoubleFormat(String exposureTime) {
+        if(!exposureTime.contains("/"))
+          return;
+
+        String exposureFractions[]= exposureTime.split("/");
+        double divider = Double.parseDouble(exposureFractions[1]);
+        double exposureTimeAsDouble = 1.0f / divider;
+        return Double.toString(exposureTimeAsDouble);
     }
 
     private void rewriteOrientation(ExifInterface exif) {


### PR DESCRIPTION
Exposure time is returned from camera as a string like 1/11.
ExifInterface on expects exposure time to be formatted as a string but
the string should contain decimal formatted number instead of fraction
format.