### PR TITLE
feat(rn-camera): add codec option for ios

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -284,8 +284,13 @@ The promise will be fulfilled with an object with some of the following properti
      - `ios` Specifies capture settings suitable for VGA quality (640x480 pixel) video output. (Same as RNCamera.Constants.VideoQuality.480p).
      - `android` Quality level corresponding to the 480p (720 x 480) resolution but with video frame width set to 640.
 
-  If nothing is passed the device's highest camera quality will be used as default.
-
+    If nothing is passed the device's highest camera quality will be used as default.
+ - `iOS` `codec`. This option specifies the codec of the output video. Setting the codec is only supported on `iOS >= 10`. The possible values are:
+   - `RNCamera.Constants.VideoCodec['H264']`
+   - `RNCamera.Constants.VideoCodec['JPEG']`
+   - `RNCamera.Constants.VideoCodec['HVEC']` (`iOS >= 11`)
+   - `RNCamera.Constants.VideoCodec['AppleProRes422']` (`iOS >= 11`)
+   - `RNCamera.Constants.VideoCodec['AppleProRes4444']` (`iOS >= 11`)
  - `maxDuration` (float greater than 0). Specifies the maximum duration of the video to be recorded in seconds. If nothing is specified, no time limit will be used.
 
  - `maxFileSize` (int greater than 0). Specifies the maximum file size, in bytes, of the video to be recorded. For 1mb, for example, use 1*1024*1024. If nothing is specified, no size limit will be used.
@@ -295,6 +300,8 @@ The promise will be fulfilled with an object with some of the following properti
  The promise will be fulfilled with an object with some of the following properties:
 
  - `uri`: returns the path to the video saved on your app's cache directory.
+
+ - `iOS` `codec`: the codec of the recorded video. One of `RNCamera.Constants.VideoCodec`
 
  #### `stopRecording: void`
 

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -30,6 +30,7 @@
 @property (assign, nonatomic) float focusDepth;
 @property (assign, nonatomic) NSInteger whiteBalance;
 @property (nonatomic, assign, getter=isReadingBarCodes) BOOL barCodeReading;
+@property(assign, nonatomic) AVVideoCodecType videoCodecType;
 
 - (id)initWithBridge:(RCTBridge *)bridge;
 - (void)updateType;

--- a/ios/RN/RNCameraManager.h
+++ b/ios/RN/RNCameraManager.h
@@ -49,6 +49,7 @@ typedef NS_ENUM(NSInteger, RNCameraVideoResolution) {
 @interface RNCameraManager : RCTViewManager <RCTBridgeModule>
 
 + (NSDictionary *)validBarCodeTypes;
++ (NSDictionary *)validCodecTypes;
 
 @end
 

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -55,6 +55,7 @@ RCT_EXPORT_VIEW_PROPERTY(onFacesDetected, RCTDirectEventBlock);
                      @"480p": @(RNCameraVideo4x3),
                      @"4:3": @(RNCameraVideo4x3),
                      },
+             @"VideoCodec": [[self class] validCodecTypes],
              @"BarCodeType" : [[self class] validBarCodeTypes],
              @"FaceDetection" : [[self  class] faceDetectorConstants]
              };
@@ -63,6 +64,24 @@ RCT_EXPORT_VIEW_PROPERTY(onFacesDetected, RCTDirectEventBlock);
 - (NSArray<NSString *> *)supportedEvents
 {
     return @[@"onCameraReady", @"onMountError", @"onBarCodeRead", @"onFacesDetected"];
+}
+
++ (NSDictionary *)validCodecTypes
+{
+    if (@available(iOS 11, *)) {
+        return @{
+                 @"H264": AVVideoCodecTypeH264,
+                 @"HVEC": AVVideoCodecTypeHEVC,
+                 @"JPEG": AVVideoCodecTypeJPEG,
+                 @"AppleProRes422": AVVideoCodecTypeAppleProRes422,
+                 @"AppleProRes4444": AVVideoCodecTypeAppleProRes4444
+                 };
+    } else {
+        return @{
+                 @"H264": AVVideoCodecH264,
+                 @"JPEG": AVVideoCodecJPEG
+                 };
+    }
 }
 
 + (NSDictionary *)validBarCodeTypes

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -35,6 +35,7 @@ type RecordingOptions = {
   maxDuration?: number,
   maxFileSize?: number,
   quality?: number | string,
+  codec?: string,
   mute?: boolean,
 };
 
@@ -96,6 +97,7 @@ export default class Camera extends React.Component<PropsType> {
     AutoFocus: CameraManager.AutoFocus,
     WhiteBalance: CameraManager.WhiteBalance,
     VideoQuality: CameraManager.VideoQuality,
+    VideoCodec: CameraManager.VideoCodec,
     BarCodeType: CameraManager.BarCodeType,
     FaceDetection: CameraManager.FaceDetection,
   };


### PR DESCRIPTION
Implements #1330

This adds support for the `codec` option for `recordAsync` on `RNCamera` (**iOS only**).

The available constants are exported on `RNCamera.Constants.VideoCodec`.

Furthermore the Object that gets resolved by recordAsync also includes a codec property.

Example Code:

```js
const { uri, codec } = await this.camera
  .recordAsync({
    quality: RNCamera.Constants.VideoQuality["720p"],
    codec: RNCamera.Constants.VideoCodec["JPEG"]
  })
codec === RNCamera.Constants.VideoCodec["JPEG"] // true
console.log(uri)
```

