### PR TITLE
Types: update types for video recording codec

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,6 +18,7 @@ type CameraType = { front: any, back: any };
 type WhiteBalance = { sunny: any, cloudy: any, shadow: any, incandescent: any, fluorescent: any, auto: any };
 type BarCodeType = { aztec: any, code128: any, code39: any, code39mod43: any, code93: any, ean13: any, ean8: any, pdf417: any, qr: any, upce: any, interleaved2of5: any, itf14: any, datamatrix: any };
 type VideoQuality = { '2160p': any, '1080p': any, '720p': any, '480p': any, '4:3': any };
+type VideoCodec = { 'H264': symbol, 'JPEG': symbol, 'HVEC': symbol, 'AppleProRes422': symbol, 'AppleProRes4444': symbol };
 
 type FaceDetectionClassifications = { all: any, none: any };
 type FaceDetectionLandmarks = { all: any, none: any };
@@ -26,6 +27,7 @@ type FaceDetectionMode = { fast: any, accurate: any };
 export interface Constants {
     AutoFocus: AutoFocus;
     FlashMode: FlashMode;
+    VideoCodec: VideoCodec;
     Type: CameraType;
     WhiteBalance: WhiteBalance;
     VideoQuality: VideoQuality;
@@ -142,11 +144,16 @@ interface RecordOptions {
     maxDuration?: number;
     maxFileSize?: number;
     mute?: boolean;
+
+    /** iOS only */
+    codec?: keyof VideoCodec | VideoCodec[keyof VideoCodec];
 }
 
 interface RecordResponse {
     /** Path to the video saved on your app's cache directory. */
     uri: string;
+    /** iOS only */
+    codec: VideoCodec[keyof VideoCodec];
 }
 
 export class RNCamera extends Component<RNCameraProps & ViewProperties> {


### PR DESCRIPTION
Update types according to #1339 

Just one thing:
if you have a `const camera: RNCamera;`...
```typescript
camera.recordAsync().then((response) => {
    if (response.codec === 'H264') { // This will result in an error, You can't compare 'symbol' to 'string'
        // CODE
    }
    if (response.codec === RNCamera.Constants.VideoCodec['H264']) { // This won't
        // CODE
    }
})
```
I don't know if it should behave like that. Because I don't know if `response.codec` really comes as a `keyof VideoCodec` (`string`). Because of that, I made this safe comparison which shouldn't give any errors in runtime.