### PR TITLE
fixing android build error for missing return value

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java
@@ -219,7 +219,7 @@ public class MutableImage {
     // Even the value is formatted as double it is returned as a String because exif.setAttribute requires it.
     private String convertExposureTimeToDoubleFormat(String exposureTime) {
         if(!exposureTime.contains("/"))
-          return;
+          return "";
 
         String exposureFractions[]= exposureTime.split("/");
         double divider = Double.parseDouble(exposureFractions[1]);


### PR DESCRIPTION
Fixing issue for failing android build. was receiving error `react-native-camera/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java:222: error: incompatible types: missing return value`

Returning an empty string seems to work?