### PR TITLE
Fix stream error and date format error

### DIFF
--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import java.io.ByteArrayOutputStream;
+
 import javax.annotation.Nullable;
 
 public class CameraModule extends ReactContextBaseJavaModule {
@@ -201,9 +203,12 @@ public class CameraModule extends ReactContextBaseJavaModule {
                 }
               } else {
                   Bitmap image = RNCameraViewHelper.generateSimulatorPhoto(cameraView.getWidth(), cameraView.getHeight());
-                  ByteBuffer byteBuffer = ByteBuffer.allocate(image.getRowBytes() * image.getHeight());
-                  image.copyPixelsToBuffer(byteBuffer);
-                  new ResolveTakenPictureAsyncTask(byteBuffer.array(), promise, options).execute();
+
+                  ByteArrayOutputStream stream = new ByteArrayOutputStream();
+                  image.compress(Bitmap.CompressFormat.JPEG, 100, stream);
+                  byte[] byteArray = stream.toByteArray();
+
+                  new ResolveTakenPictureAsyncTask(byteArray, promise, options, cacheDirectory).execute();
               }
         } catch (Exception e) {
           promise.reject("E_CAMERA_BAD_VIEWTAG", "takePictureAsync: Expected a Camera component");

--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -292,8 +292,12 @@ public class RNCameraViewHelper {
     textPaint.setColor(Color.YELLOW);
     textPaint.setTextSize(35);
     Calendar calendar = Calendar.getInstance();
-    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd.MM.YY HH:mm:ss", Locale.getDefault());
-    canvas.drawText(simpleDateFormat.format(calendar.getTime()), width * 0.1f, height * 0.9f, textPaint);
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy.MM.dd G '->' HH:mm:ss z");
+    canvas.drawText(simpleDateFormat.format(calendar.getTime()), width * 0.1f, height * 0.2f, textPaint);
+    canvas.drawText(simpleDateFormat.format(calendar.getTime()), width * 0.2f, height * 0.4f, textPaint);
+    canvas.drawText(simpleDateFormat.format(calendar.getTime()), width * 0.3f, height * 0.6f, textPaint);
+    canvas.drawText(simpleDateFormat.format(calendar.getTime()), width * 0.4f, height * 0.8f, textPaint);
+
     return fakePhoto;
   }
 }


### PR DESCRIPTION
## Fix date formatting error

There was an error with the date format, this new text string seems to work without error.

## Fix bitmap stream error

The ResolveTakenPictureAsyncTask doInBackground method was unable to decode the byte array that it was given by RNCameraViewHelper.generateSimulatorPhoto.  The decoding always returned null, which caused the app to crash when trying to getWidth on it.

This creates a byte array of the expected type (jpeg) and passes it to the ResolveTakenPictureAsyncTask constructor

Fixes #1220
