### PR TITLE
Project-wide Configuration Properties

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,10 +38,12 @@ repositories {
 }
 
 dependencies {
+  def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "+"
+
   compile 'com.facebook.react:react-native:+'
   compile "com.google.zxing:core:3.2.1"
   compile "com.drewnoakes:metadata-extractor:2.9.1"
-  compile 'com.google.android.gms:play-services-vision:+'
+  compile "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
   compile "com.android.support:exifinterface:+"
 
   compile 'com.github.react-native-community:cameraview:d529251d24c0a367a28eea28f0eac2269d12f772'


### PR DESCRIPTION
#### :information_source: Project-wide Configuration Properties

The technique of **defining project-wide properties** can be found in the **Android Developer Document** [Gradle Tip &amp; Tricks](https://developer.android.com/studio/build/gradle-tips.html) (see *Configure project-wide properties*) and another good explanation [here](https://segunfamisa.com/posts/android-gradle-extra-properties).  The React Native Camera library will now be aware of system wide configuration properties.

In order to use this in a project that uses react-native-camera it will now check for this example `googlePlayServicesVersion` (at the end of file /android/build.gradle):

```
ext {
    googlePlayServicesVersion = "11.8.0"
}
```

If it cant find a project-wide configuration it will fall back to original "+" latest version. This is now a standard most libraries are implementing and resolves the numerous conflicts.
