### PR TITLE
fix: issue #1246 - torch will be disabled when starting the record

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -424,6 +424,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         }
 
         dispatch_async(self.sessionQueue, ^{
+            [self updateFlashMode];
             NSString *path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingString:@"Camera"] withExtension:@".mov"];
             NSURL *outputURL = [[NSURL alloc] initFileURLWithPath:path];
             [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];


### PR DESCRIPTION
As the preview (https://github.com/react-native-community/react-native-camera/issues/1249), also the torch will shortly be turned off, when starting the record.

Though with this fix/workaround the torch is reactivated and is present while recording.

Fixes https://github.com/react-native-community/react-native-camera/issues/1246