### PR TITLE
Adds bounds to barcodeReadEvent

### DIFF
--- a/android/src/main/java/org/reactnative/camera/events/BarCodeReadEvent.java
+++ b/android/src/main/java/org/reactnative/camera/events/BarCodeReadEvent.java
@@ -4,10 +4,12 @@ import android.support.v4.util.Pools;
 
 import org.reactnative.camera.CameraViewManager;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.google.zxing.Result;
+import com.google.zxing.ResultPoint;
 
 import java.util.Date;
 
@@ -62,7 +64,15 @@ public class BarCodeReadEvent extends Event<BarCodeReadEvent> {
     event.putInt("target", getViewTag());
     event.putString("data", mBarCode.getText());
     event.putString("type", mBarCode.getBarcodeFormat().toString());
-
+    WritableArray resultPoints = Arguments.createArray();
+    ResultPoint[] points = mBarCode.getResultPoints();
+    for (ResultPoint point: points) {
+      WritableMap newPoint = Arguments.createMap();
+      newPoint.putString("x", String.valueOf(point.getX()));
+      newPoint.putString("y", String.valueOf(point.getY()));
+      resultPoints.pushMap(newPoint);
+    }
+    event.putArray("bounds",resultPoints);
     return event;
   }
 }

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -702,10 +702,20 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             AVMetadataMachineReadableCodeObject *codeMetadata = (AVMetadataMachineReadableCodeObject *) metadata;
             for (id barcodeType in self.barCodeTypes) {
                 if ([metadata.type isEqualToString:barcodeType]) {
-
+                    AVMetadataMachineReadableCodeObject *transformed = (AVMetadataMachineReadableCodeObject *)[_previewLayer transformedMetadataObjectForMetadataObject:metadata];
                     NSDictionary *event = @{
                                             @"type" : codeMetadata.type,
-                                            @"data" : codeMetadata.stringValue
+                                            @"data" : codeMetadata.stringValue,
+                                            @"bounds": @{
+                                                @"origin": @{
+                                                    @"x": [NSString stringWithFormat:@"%f", transformed.bounds.origin.x],
+                                                    @"y": [NSString stringWithFormat:@"%f", transformed.bounds.origin.y]
+                                                },
+                                                @"size": @{
+                                                    @"height": [NSString stringWithFormat:@"%f", transformed.bounds.size.height],
+                                                    @"width": [NSString stringWithFormat:@"%f", transformed.bounds.size.width]
+                                                }
+                                            }
                                             };
 
                     [self onCodeRead:event];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -57,10 +57,11 @@ export interface RNCameraProps {
     // -- BARCODE PROPS
     barCodeTypes?: Array<keyof BarCodeType>;
     onBarCodeRead?(event: {
-        data: string
-        type: keyof BarCodeType
+        data: string,
+        type: keyof BarCodeType,
+        bounds:[{x:string,y:string}]|{origin:{x:string,y:string},size:{height:string,width:string}}
     }): void;
-
+    
     // -- FACE DETECTION PROPS
 
     onFacesDetected?(response: { faces: Face[] }): void;


### PR DESCRIPTION
#1307 
Adds bounds to barcodeReadEvent. Tested on Android and iOs. Same behaviour like the old bounds:
on iOS:
```
bounds:{
  size:{
     width:string,
     height:string
  }
  origin:{
     x:string,
     y:string
}}
```
onAndroid:
`bounds:[{x:string,y:string}]`
on Android it returns just resultPoints:
for barcodes:
bounds[0].x : left side of barcode.
bounds[1].x : right side of barcode
counting for QRcodes:
1    2
0  