### PR TITLE
Add maven url for Google support libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Google Symbol Utilities: https://www.gstatic.com/cpdc/dbffca986f6337f8-GoogleSym
 allprojects {
     repositories {
         maven { url "https://jitpack.io" }
+        maven { url "https://maven.google.com" }
     }
 }
 ```


### PR DESCRIPTION
@sibelius  and @christocracy
PR to fix the Google support library not found error by adding the Google's own [maven server](https://dl.google.com/dl/android/maven2/index.html) to `android/build.gradle`