### PR TITLE
Emulator crash fix #1234

### DIFF
--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -203,12 +203,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
                 }
               } else {
                   Bitmap image = RNCameraViewHelper.generateSimulatorPhoto(cameraView.getWidth(), cameraView.getHeight());
-
                   ByteArrayOutputStream stream = new ByteArrayOutputStream();
                   image.compress(Bitmap.CompressFormat.JPEG, 100, stream);
-                  byte[] byteArray = stream.toByteArray();
-
-                  new ResolveTakenPictureAsyncTask(byteArray, promise, options, cacheDirectory).execute();
+                  new ResolveTakenPictureAsyncTask(stream.toByteArray(), promise, options, cacheDirectory).execute();
               }
         } catch (Exception e) {
           promise.reject("E_CAMERA_BAD_VIEWTAG", "takePictureAsync: Expected a Camera component");


### PR DESCRIPTION
On the emulator it crashed because the image byte array was incorrect and no cache directory was defined so it could not be written