### PR TITLE
chore(gms): change default gms to 12.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.android.library'
 def DEFAULT_COMPILE_SDK_VERSION             = 26
 def DEFAULT_BUILD_TOOLS_VERSION             = "26.0.2"
 def DEFAULT_TARGET_SDK_VERSION              = 26
-def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "10.2.0"
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "12.0.1"
 def DEFAULT_SUPPORT_LIBRARY_VERSION         = "27.1.0"
 
 android {


### PR DESCRIPTION
try to close #1415

thought about putting `12.+` but I am afraid of putting stuff with + and leading to crashes :D 
Hope changing this version won't be a big deal.

If this is merged and stable, maybe we can release rncamera 1.1.0, since text recognition would be too much for a 1.0.4, in my opinion.