### PR TITLE
Crops Preview on Android

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -164,10 +164,22 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
     if (null == preview) {
       return;
     }
+    float width = right - left;
+    float height = bottom - top;
+    float ratio = getAspectRatio().toFloat();
+    int correctHeight;
+    int correctWidth;
     this.setBackgroundColor(Color.BLACK);
-    int width = right - left;
-    int height = bottom - top;
-    preview.layout(0, 0, width, height);
+    if (height / width > ratio) {
+      correctHeight = (int) (width * ratio);
+      correctWidth = (int) width;
+    } else {
+      correctHeight = (int) height;
+      correctWidth = (int)(height*ratio);
+    }
+    int paddingX = (int) ((width - correctWidth) / 2);
+    int paddingY = (int) ((height - correctHeight) / 2);
+    preview.layout(paddingX, paddingY, correctWidth+paddingX, correctHeight+paddingY);
   }
 
   @Override


### PR DESCRIPTION
Works fine with useCamera2Api=false, but with useCamera2Api=true it cuts to 4:3 on first rendering and only after the screen has been rotated once it works right. This happens because 4:3 is the default ratio and camera2 only sets the custom aspect ratio after onLayout is called for the first time. I have already tried force/requestLayout but it doesn't work. I will try to fix it in cameraview the next days.
#1343
#1267