### PR TITLE
Clarify that location is a property of metadata

### DIFF
--- a/docs/RCTCamera.md
+++ b/docs/RCTCamera.md
@@ -278,7 +278,7 @@ Supported options:
 - `mode` (See  `captureMode` under Properties)
 - `target` (See `captureTarget` under Properties)
 - `metadata` This is metadata to be added to the captured image.
-- `location` This is the object returned from `navigator.geolocation.getCurrentPosition()` (React Native's geolocation polyfill). It will add GPS metadata to the image.
+- `metadata.location` This is the object returned from `navigator.geolocation.getCurrentPosition()` (React Native's geolocation polyfill). It will add GPS metadata to the image.
 - `rotation` This will rotate the image by the number of degrees specified.
 - `jpegQuality` (integer between 1 and 100) This property is used to compress the output jpeg file with 100% meaning no jpeg compression will be applied.
 - `totalSeconds` This will limit video length by number of seconds specified. Only works in video capture mode.


### PR DESCRIPTION
Currently this property appears in the docs like it's a key of the `options`, but it appears to actually be a key on `metadata` both in the code and from the prior example in the docs.