### PR TITLE
Add iOS support for start/stop preview in RNCamera

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -261,6 +261,8 @@ Supported options:
 
  - `forceUpOrientation` (iOS only, boolean true or false). This property allows to force portrait orientation based on actual data instead of exif data.
 
+ - `autoStopPreview` (iOS only, boolean, default=false). When true, the preview will be stopped automatically as soon as the image is captured (and prior to processing/storage as well as the resolving of the resulting promise). Call `startPreview` to resume the preview.
+
 The promise will be fulfilled with an object with some of the following properties:
 
  - `width`: returns the image's width (taking image orientation into account)
@@ -319,6 +321,14 @@ The promise will be fulfilled with an object with some of the following properti
  #### `Android` `getSupportedRatiosAsync(): Promise`
 
  Android only. Returns a promise. The promise will be fulfilled with an object with an array containing strings with all camera aspect ratios supported by the device.
+
+ #### `iOS` `stopPreview(): void`
+
+ iOS only. Stop/freeze the preview being displayed.
+
+ #### `iOS` `startPreview(): void`
+
+ iOS only. Start/unfreeze the preview being displayed.
 
 ## Subviews
 This component supports subviews, so if you wish to use the camera view as a background or if you want to layout buttons/images/etc. inside the camera then you can do that.

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -45,6 +45,8 @@
 - (void)updateFaceDetectionClassifications:(id)requestedClassifications;
 - (void)takePicture:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)record:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)startPreview;
+- (void)stopPreview;
 - (void)stopRecording;
 - (void)setupOrDisableBarcodeScanner;
 - (void)onReady:(NSDictionary *)event;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -310,8 +310,13 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 {
     AVCaptureConnection *connection = [self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
     [connection setVideoOrientation:[RNCameraUtils videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]]];
+    
     [self.stillImageOutput captureStillImageAsynchronouslyFromConnection:connection completionHandler: ^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
         if (imageSampleBuffer && !error) {
+            if ([options[@"autoStopPreview"] boolValue]) {
+                [self stopPreview];
+            }
+
             NSData *imageData = [AVCaptureStillImageOutput jpegStillImageNSDataRepresentation:imageSampleBuffer];
 
             UIImage *takenImage = [UIImage imageWithData:imageData];
@@ -433,6 +438,30 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];
         self.videoRecordedResolve = resolve;
         self.videoRecordedReject = reject;
+    });
+}
+
+- (void)stopPreview
+{
+#if TARGET_IPHONE_SIMULATOR
+    return;
+#endif
+    dispatch_async(self.sessionQueue, ^{
+        if ([self.session isRunning]) {
+            [self.session stopRunning];
+        }
+    });
+}
+
+- (void)startPreview
+{
+#if TARGET_IPHONE_SIMULATOR
+    return;
+#endif
+    dispatch_async(self.sessionQueue, ^{
+        if (![self.session isRunning]) {
+            [self.session startRunning];
+        }
     });
 }
 

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -236,7 +236,31 @@ RCT_REMAP_METHOD(record,
         }
     }];
 }
+    
+RCT_REMAP_METHOD(stopPreview, reactTag:(nonnull NSNumber *)reactTag)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNCamera *> *viewRegistry) {
+        RNCamera *view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[RNCamera class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting RNCamera, got: %@", view);
+        } else {
+            [view stopPreview];
+        }
+    }];
+}
 
+RCT_REMAP_METHOD(startPreview, reactTag:(nonnull NSNumber *)reactTag)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNCamera *> *viewRegistry) {
+        RNCamera *view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[RNCamera class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting RNCamera, got: %@", view);
+        } else {
+            [view startPreview];
+        }
+    }];
+}
+    
 RCT_REMAP_METHOD(stopRecording, reactTag:(nonnull NSNumber *)reactTag)
 {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNCamera *> *viewRegistry) {

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -248,6 +248,18 @@ export default class Camera extends React.Component<PropsType> {
     return await CameraManager.record(options, this._cameraHandle);
   }
 
+  stopPreview() {
+    if (Platform.OS === 'ios') {
+      CameraManager.stopPreview(this._cameraHandle);
+    }
+  }
+
+  startPreview() {
+    if (Platform.OS === 'ios') {
+      CameraManager.startPreview(this._cameraHandle);
+    }
+  }
+
   stopRecording() {
     CameraManager.stopRecording(this._cameraHandle);
   }


### PR DESCRIPTION
This is based on the work in #859. It adds only the iOS version of these because the Android API is now based on the preview of `android.cameraview.CameraView` ([fork](https://github.com/react-native-community/cameraview)) rather than the prior custom implementation. Hopefully someone else can work through adding an Android version in the future.

It also adds a flag to the `takePictureAsync` to stop the preview immediately once the still capture completes (and before any additional async activity occurs).

Test environment:

iOS 11.2.5
React Native 0.54.2
Node 9.5.0

Resolves #1438.