### PR TITLE
Fix camera issues.

### DIFF
--- a/android/src/main/java/org/reactnative/camera/CameraViewManager.java
+++ b/android/src/main/java/org/reactnative/camera/CameraViewManager.java
@@ -20,6 +20,7 @@ public class CameraViewManager extends ViewGroupManager<RNCameraView> {
     EVENT_ON_FACES_DETECTED("onFacesDetected"),
     EVENT_ON_BARCODES_DETECTED("onGoogleVisionBarcodesDetected"),
     EVENT_ON_FACE_DETECTION_ERROR("onFaceDetectionError"),
+    EVENT_ON_BARCODE_DETECTION_ERROR("onGoogleVisionBarcodeDetectionError"),
     EVENT_ON_TEXT_RECOGNIZED("onTextRecognized");
 
     private final String mName;

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -20,10 +20,10 @@ import com.google.zxing.BarcodeFormat;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.MultiFormatReader;
 import com.google.zxing.Result;
+import org.reactnative.barcodedetector.RNBarcodeDetector;
 import org.reactnative.camera.tasks.*;
 import org.reactnative.camera.utils.ImageDimensions;
 import org.reactnative.camera.utils.RNFileUtils;
-import org.reactnative.barcodedetector.RNBarcodeDetector;
 import org.reactnative.facedetector.RNFaceDetector;
 
 import java.io.File;
@@ -84,7 +84,7 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
 
       @Override
       public void onMountError(CameraView cameraView) {
-        RNCameraViewHelper.emitMountErrorEvent(cameraView);
+        RNCameraViewHelper.emitMountErrorEvent(cameraView, "Camera view threw an error - component could not be rendered.");
       }
 
       @Override
@@ -414,9 +414,7 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
         }
       }
     } else {
-      WritableMap error = Arguments.createMap();
-      error.putString("message", "Camera permissions not granted - component could not be rendered.");
-      RNCameraViewHelper.emitMountErrorEvent(this);
+      RNCameraViewHelper.emitMountErrorEvent(this, "Camera permissions not granted - component could not be rendered.");
     }
   }
 
@@ -433,6 +431,7 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
     mFaceDetector.release();
     mBarcodeDetector.release();
     stop();
+    mThemedReactContext.removeLifecycleEventListener(this);
   }
 
   private boolean hasCameraPermissions() {

--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -161,8 +161,8 @@ public class RNCameraViewHelper {
   };
   // Mount error event
 
-  public static void emitMountErrorEvent(ViewGroup view) {
-    CameraMountErrorEvent event = CameraMountErrorEvent.obtain(view.getId());
+  public static void emitMountErrorEvent(ViewGroup view, String error) {
+    CameraMountErrorEvent event = CameraMountErrorEvent.obtain(view.getId(), error);
     ReactContext reactContext = (ReactContext) view.getContext();
     reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
   }

--- a/android/src/main/java/org/reactnative/camera/events/BarcodeDetectionErrorEvent.java
+++ b/android/src/main/java/org/reactnative/camera/events/BarcodeDetectionErrorEvent.java
@@ -37,7 +37,7 @@ public class BarcodeDetectionErrorEvent extends Event<BarcodeDetectionErrorEvent
 
   @Override
   public String getEventName() {
-    return CameraViewManager.Events.EVENT_ON_MOUNT_ERROR.toString();
+    return CameraViewManager.Events.EVENT_ON_BARCODE_DETECTION_ERROR.toString();
   }
 
   @Override

--- a/android/src/main/java/org/reactnative/camera/events/CameraMountErrorEvent.java
+++ b/android/src/main/java/org/reactnative/camera/events/CameraMountErrorEvent.java
@@ -1,26 +1,31 @@
 package org.reactnative.camera.events;
 
 import android.support.v4.util.Pools;
-
-import org.reactnative.camera.CameraViewManager;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
-
-import java.util.Date;
+import org.reactnative.camera.CameraViewManager;
 
 public class CameraMountErrorEvent extends Event<CameraMountErrorEvent> {
   private static final Pools.SynchronizedPool<CameraMountErrorEvent> EVENTS_POOL = new Pools.SynchronizedPool<>(3);
-  private CameraMountErrorEvent() {}
+  private String mError;
 
-  public static CameraMountErrorEvent obtain(int viewTag) {
+  private CameraMountErrorEvent() {
+  }
+
+  public static CameraMountErrorEvent obtain(int viewTag, String error) {
     CameraMountErrorEvent event = EVENTS_POOL.acquire();
     if (event == null) {
       event = new CameraMountErrorEvent();
     }
-    event.init(viewTag);
+    event.init(viewTag, error);
     return event;
+  }
+
+  private void init(int viewTag, String error) {
+    super.init(viewTag);
+    mError = error;
   }
 
   @Override
@@ -39,6 +44,8 @@ public class CameraMountErrorEvent extends Event<CameraMountErrorEvent> {
   }
 
   private WritableMap serializeEventData() {
-    return Arguments.createMap();
+    WritableMap arguments = Arguments.createMap();
+    arguments.putString("message", mError);
+    return arguments;
   }
 }

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -268,9 +268,9 @@ export default class Camera extends React.Component<PropsType, StateType> {
     CameraManager.stopRecording(this._cameraHandle);
   }
 
-  _onMountError = () => {
+  _onMountError = ({ nativeEvent }: EventCallbackArgumentsType) => {
     if (this.props.onMountError) {
-      this.props.onMountError();
+      this.props.onMountError(nativeEvent);
     }
   };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,7 +53,9 @@ export interface RNCameraProps {
     useCamera2Api?: boolean;
 
     onCameraReady?(): void;
-    onMountError?(): void;
+    onMountError?(error: {
+        message: string
+    }): void;
 
     /** Value: float from 0 to 1.0 */
     zoom?: number;


### PR DESCRIPTION
Fixes a critical bug when the app is paused and resumed.

The camera view is removed from the view hierarchy but still keeps receiving lifecycle events like onResume etc. On the other hand, the view manager creates a new camera view when the app is resumed (Not sure why this works like that because the app is only paused and not closed completely). 
This way multiple views are trying to acquire the camera which results in a mount error + new camera view has no access to camera + views number start to grow.

Not sure if removing the old view as a lifecycle event listener solves the problem of propagating the views. But I suppose since we remove the last reference to it - it must be garbage collected. 

I am new in Android development so what do you think, guys?