### PR TITLE
fix(cache): store video recordings in same directory as photos

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -428,7 +428,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
     dispatch_async(self.sessionQueue, ^{
         [self updateFlashMode];
-        NSString *path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingString:@"Camera"] withExtension:@".mov"];
+        NSString *path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".mov"];
         NSURL *outputURL = [[NSURL alloc] initFileURLWithPath:path];
         [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];
         self.videoRecordedResolve = resolve;


### PR DESCRIPTION
Currently, videos and photos are stored in two slightly different directories on the iOS file system.

It doesn't seem like this is intentional as the same `RNFileSystem generatePathInDirectory` function is used in both circumstances but with `stringByAppendingPathComponent` in one place and `stringByAppendingString` in another. This results to files being stored in two locations inside of the device app container:

Photos: `~/AppData/Library/Caches/Camera`
Videos: `~/AppData/Library/CachesCamera`

Super minor tweak to help my sanity when dumping the app container to debug issues :)