### PR TITLE
The correct capture preset for photos is AVCaptureSessionPresetPhoto

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -776,8 +776,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [_faceDetectorManager maybeStartFaceDetectionOnSession:_session withPreviewLayer:_previewLayer];
 #endif
 
-    if (self.session.sessionPreset != AVCaptureSessionPresetHigh) {
-        [self updateSessionPreset:AVCaptureSessionPresetHigh];
+    if (self.session.sessionPreset != AVCaptureSessionPresetPhoto) {
+        [self updateSessionPreset:AVCaptureSessionPresetPhoto];
     }
 }
 


### PR DESCRIPTION
AVCaptureSessionPresetHigh sometimes means the camera is too zoomed in