### PR TITLE
Fix java.lang.ArrayIndexOutOfBoundsException with image rotation on Android

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -108,7 +108,11 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
         byte[] rotated = new byte[imageData.length];
         for (int y = 0; y < width; y++) {
           for (int x = 0; x < height; x++) {
-            rotated[x * width + width - y - 1] = imageData[x + y * height];
+            int sourceIx = x + y * height;
+            int destIx = x * width + width - y - 1;
+            if (sourceIx >= 0 && sourceIx < imageData.length && destIx >= 0 && destIx < imageData.length) {
+              rotated[destIx] = imageData[sourceIx];
+            }
           }
         }
         return rotated;


### PR DESCRIPTION
This Fixes the issue https://github.com/react-native-community/react-native-camera/issues/1486. It happens to me every time I open  a camera view for a second time.

Solution was taken from here https://github.com/react-native-community/react-native-camera/issues/1486 and it was suggested by @nijolas.