### PR TITLE
reenable camera on android emulator

### DIFF
--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -190,18 +190,11 @@ public class CameraModule extends ReactContextBaseJavaModule {
       public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
           RNCameraView cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
           try {
-              if (!Build.FINGERPRINT.contains("generic")) {
-                if (cameraView.isCameraOpened()) {
-                  cameraView.takePicture(options, promise, cacheDirectory);
-                } else {
-                  promise.reject("E_CAMERA_UNAVAILABLE", "Camera is not running");
-                }
-              } else {
-                  Bitmap image = RNCameraViewHelper.generateSimulatorPhoto(cameraView.getWidth(), cameraView.getHeight());
-                  ByteArrayOutputStream stream = new ByteArrayOutputStream();
-                  image.compress(Bitmap.CompressFormat.JPEG, 100, stream);
-                  new ResolveTakenPictureAsyncTask(stream.toByteArray(), promise, options, cacheDirectory).execute();
-              }
+            if (cameraView.isCameraOpened()) {
+              cameraView.takePicture(options, promise, cacheDirectory);
+            } else {
+              promise.reject("E_CAMERA_UNAVAILABLE", "Camera is not running");
+            }
         } catch (Exception e) {
           promise.reject("E_CAMERA_BAD_VIEWTAG", "takePictureAsync: Expected a Camera component");
         }

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -442,9 +442,7 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
       if ((mIsPaused && !isCameraOpened()) || mIsNew) {
         mIsPaused = false;
         mIsNew = false;
-        if (!Build.FINGERPRINT.contains("generic")) {
-          start();
-        }
+        start();
       }
     } else {
       RNCameraViewHelper.emitMountErrorEvent(this, "Camera permissions not granted - component could not be rendered.");


### PR DESCRIPTION
This fixes #1234 
The camera is disabled on android emulator for no good reason (or the reason may have fixed itself since). This PR brings it back.

I am able to use the camera on emulators with no problem using this fix. No more black screen, Yay!