### PR TITLE
Support orientation option on ios

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -309,7 +309,13 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 - (void)takePicture:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
 {
     AVCaptureConnection *connection = [self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
-    [connection setVideoOrientation:[RNCameraUtils videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]]];
+    int orientation;
+    if ([options[@"orientation"] integerValue]) {
+        orientation = [options[@"orientation"] integerValue];
+    } else {
+        orientation = [RNCameraUtils videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]];
+    }
+    [connection setVideoOrientation:orientation];
     [self.stillImageOutput captureStillImageAsynchronouslyFromConnection:connection completionHandler: ^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
         if (imageSampleBuffer && !error) {
             NSData *imageData = [AVCaptureStillImageOutput jpegStillImageNSDataRepresentation:imageSampleBuffer];

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -456,6 +456,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             return;
         }
 
+        self.session.sessionPreset = AVCaptureSessionPresetPhoto;
+        
         AVCaptureStillImageOutput *stillImageOutput = [[AVCaptureStillImageOutput alloc] init];
         if ([self.session canAddOutput:stillImageOutput]) {
             stillImageOutput.outputSettings = @{AVVideoCodecKey : AVVideoCodecJPEG};

--- a/ios/RN/RNCameraManager.h
+++ b/ios/RN/RNCameraManager.h
@@ -18,6 +18,14 @@ typedef NS_ENUM(NSInteger, RNCameraFlashMode) {
     RNCameraFlashModeAuto = AVCaptureFlashModeAuto
 };
 
+typedef NS_ENUM(NSInteger, RNCameraOrientation) {
+    RNCameraOrientationAuto = 0,
+    RNCameraOrientationLandscapeLeft = AVCaptureVideoOrientationLandscapeLeft,
+    RNCameraOrientationLandscapeRight = AVCaptureVideoOrientationLandscapeRight,
+    RNCameraOrientationPortrait = AVCaptureVideoOrientationPortrait,
+    RNCameraOrientationPortraitUpsideDown = AVCaptureVideoOrientationPortraitUpsideDown
+};
+
 typedef NS_ENUM(NSInteger, RNCameraAutoFocus) {
     RNCameraAutoFocusOff = AVCaptureFocusModeLocked,
     RNCameraAutoFocusOn = AVCaptureFocusModeContinuousAutoFocus,

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -56,6 +56,13 @@ RCT_EXPORT_VIEW_PROPERTY(onFacesDetected, RCTDirectEventBlock);
                      @"4:3": @(RNCameraVideo4x3),
                      @"288p": @(RNCameraVideo288p),
                      },
+             @"Orientation": @{
+                     @"auto": @(RNCameraOrientationAuto),
+                     @"landscapeLeft": @(RNCameraOrientationLandscapeLeft),
+                     @"landscapeRight": @(RNCameraOrientationLandscapeRight),
+                     @"portrait": @(RNCameraOrientationPortrait),
+                     @"portraitUpsideDown": @(RNCameraOrientationPortraitUpsideDown)
+                     },
              @"VideoCodec": [[self class] validCodecTypes],
              @"BarCodeType" : [[self class] validBarCodeTypes],
              @"FaceDetection" : [[self  class] faceDetectorConstants]

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -30,8 +30,11 @@ const styles = StyleSheet.create({
   },
 });
 
+type Orientation = "auto"|"landscapeLeft"|"landscapeRight"|"portrait"|"portraitUpsideDown";
+
 type PictureOptions = {
   quality?: number,
+  orientation?: Orientation,
   base64?: boolean,
   mirrorImage?: boolean,
   exif?: boolean,
@@ -246,6 +249,9 @@ export default class Camera extends React.Component<PropsType, StateType> {
     }
     if (!options.quality) {
       options.quality = 1;
+    }
+    if (options.orientation) {
+      options.orientation = CameraManager.Orientation[options.orientation];
     }
     return await CameraManager.takePicture(options, this._cameraHandle);
   }


### PR DESCRIPTION
Added an orientation option to to takePhotoAsync, defaults to "auto" which is the current behavior so this isn't a breaking change. 

If you don't fix the orientation things can get a bit weird. I found that when taking a photo from a modal that's fixed to landscape the orientation check can still sometimes decide that the photo is being taken in landscape.

I'll probably also add support for Android soon. 

This PR also includes a bug fix to my previous PR. I set the "AVCaptureSessionPresetHigh" profile in one place but forgot it in another.