### PR TITLE
 Base Video Orientation on Device Orientation - IOS

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -416,7 +416,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [self updateSessionAudioIsMuted:!!options[@"mute"]];
 
     AVCaptureConnection *connection = [self.movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
-    [connection setVideoOrientation:[RNCameraUtils videoOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation]]];
+    [connection setVideoOrientation:[RNCameraUtils videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]]];
 
     if (options[@"codec"]) {
       AVVideoCodecType videoCodecType = options[@"codec"];


### PR DESCRIPTION
## Base Video Orientation on Device Orientation

(Rather than StatusBar Orientation)

In the pre 1.x version of react-native-camera, passing an orientation prop was supported. This PR makes the camera behave similarly to how it used to if AUTO was passed for orientation. The significance is that if the screen orientation is locked (incl UI elements like the StatusBar), the video orientation metadata is still based on the actual device orientation rather than the StatusBar orientation.

I believe this makes more sense as a default behavior (until passing an explicit orientation is supported), as I think there are few cases where: (for example) if the UI is locked to portrait mode, and you rotate the camera to record in landscape, you would expect the video to then be recorded in portrait mode. Also I would guess it is probably a pretty common practice to lock the orientation of the screen (and status bar, which is what large parts of this component base it's own orientation on) given the challenges of rotating the preview once already mounted.

Also, this is the same behavior as has been recently implemented for the photo orientation if no orientation option is passed (line 316)  