### PR TITLE
Fix failing iOS build #1612

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -441,7 +441,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [self updateSessionAudioIsMuted:!!options[@"mute"]];
 
     AVCaptureConnection *connection = [self.movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
-    if (self.videoStabilizationMode != nil) {
+    if (self.videoStabilizationMode != 0) {
         if (connection.isVideoStabilizationSupported == NO) {
             RCTLogWarn(@"%s: Video Stabilization is not supported on this device.", __func__);
         } else {

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -97,10 +97,10 @@ RCT_EXPORT_VIEW_PROPERTY(onPictureSaved, RCTDirectEventBlock);
 + (NSDictionary *)validVideoStabilizationModes
 {
     return @{
-             @"off": AVCaptureVideoStabilizationModeOff,
-             @"standard": AVCaptureVideoStabilizationModeStandard,
-             @"cinematic": AVCaptureVideoStabilizationModeCinematic,
-             @"auto": AVCaptureVideoStabilizationModeAuto
+             @"off": @(AVCaptureVideoStabilizationModeOff),
+             @"standard": @(AVCaptureVideoStabilizationModeStandard),
+             @"cinematic": @(AVCaptureVideoStabilizationModeCinematic),
+             @"auto": @(AVCaptureVideoStabilizationModeAuto)
              };
 }
 

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -97,7 +97,7 @@ type PropsType = typeof View.props & {
   captureAudio?: boolean,
   useCamera2Api?: boolean,
   playSoundOnCapture?: boolean,
-  videoStabilizationMode?: string,
+  videoStabilizationMode?: number | string,
   pictureSize?: string,
 };
 
@@ -157,7 +157,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     GoogleVisionBarcodeDetection: CameraManager.GoogleVisionBarcodeDetection,
     FaceDetection: CameraManager.FaceDetection,
     CameraStatus,
-    VideoStabilization: CameraManager.VideoStabilization || {},
+    VideoStabilization: CameraManager.VideoStabilization,
   };
 
   // Values under keys from this object will be transformed to native options
@@ -170,6 +170,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     faceDetectionLandmarks: (CameraManager.FaceDetection || {}).Landmarks,
     faceDetectionClassifications: (CameraManager.FaceDetection || {}).Classifications,
     googleVisionBarcodeType: (CameraManager.GoogleVisionBarcodeDetection || {}).BarcodeType,
+    videoStabilizationMode: CameraManager.VideoStabilization || {},
   };
 
   static propTypes = {
@@ -200,7 +201,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     captureAudio: PropTypes.bool,
     useCamera2Api: PropTypes.bool,
     playSoundOnCapture: PropTypes.bool,
-    videoStabilizationMode: PropTypes.string,
+    videoStabilizationMode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     pictureSize: PropTypes.string,
   };
 
@@ -234,6 +235,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     useCamera2Api: false,
     playSoundOnCapture: false,
     pictureSize: '1920x1080',
+    videoStabilizationMode: 0,
   };
 
   _cameraRef: ?Object;


### PR DESCRIPTION
This PR fixes the issues introduced in #1606 (and makes the application compilable again).

However `react-native-camera` seems still to be in a broken state after #1600 (Details in #1613).