### PR TITLE
fix Android 5.1 scan qrcode very slowly issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
   compileOnly 'com.facebook.react:react-native:+'
   compileOnly 'com.facebook.infer.annotation:infer-annotation:+'
-  implementation "com.google.zxing:core:3.2.1"
+  implementation "com.google.zxing:core:3.3.0"
   implementation "com.drewnoakes:metadata-extractor:2.9.1"
   implementation "com.google.android.gms:play-services-vision:$googlePlayServicesVersion"
   implementation "com.android.support:exifinterface:$supportLibVersion"


### PR DESCRIPTION
zxing 3.2.1 perform so slow(about 10 seconds) in Android 5.1 to scan a qrcode and update to 3.3.0 fix this.