### PR TITLE
Change README making clear what is android-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 # React Native Camera [![Backers on Open Collective](https://opencollective.com/react-native-camera/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/react-native-camera/sponsors/badge.svg)](#sponsors) [![npm version](https://badge.fury.io/js/react-native-camera.svg)](http://badge.fury.io/js/react-native-camera) [![npm downloads](https://img.shields.io/npm/dm/react-native-camera.svg)](https://www.npmjs.com/package/react-native-camera)
 
-The comprehensive camera module for React Native. Including photographs, videos, face detection, barcode scanning and text recognition (Android only)!
+The comprehensive camera module for React Native. 
 
-`import { RNCamera, FaceDetector } from 'react-native-camera';`
+Supports:
+
+- photographs.
+- videos
+- face detection
+- barcode scanning
+- text recognition (Android only)
+
+
+### Example import
+
+```jsx
+import { RNCamera, FaceDetector } from 'react-native-camera';
+```
 
 #### How to use master branch?
 Inside your package.json, use this


### PR DESCRIPTION
@sibelius thanks for the [clarification](https://github.com/react-native-community/react-native-camera/commit/68639b82ed98ef53ac1a0cc1762c35c5941b61b6#r29392431).

Here is a basic proposal of what would have made it clear to me.

I haven't gotten around making the basic example work yet. Would be nice to have a full, basic example  along with the import.

*Context:*

I am fairly experienced with the React/Redux ecossystem for web-development, but as a newbie to React-Native, I would like to see a short snippet of code that let's me use the camera.

(ps.: I'd love to propose another README change with an example once I learn how to)

Cheers