### PR TITLE
Add pauseAfterCapture capture prop

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraView.java
@@ -33,6 +33,8 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.graphics.SurfaceTexture;
 
+import com.facebook.react.bridge.ReadableMap;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
@@ -503,8 +505,8 @@ public class CameraView extends FrameLayout {
      * Take a picture. The result will be returned to
      * {@link Callback#onPictureTaken(CameraView, byte[])}.
      */
-    public void takePicture() {
-        mImpl.takePicture();
+    public void takePicture(ReadableMap options) {
+        mImpl.takePicture(options);
     }
 
     /**

--- a/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
@@ -20,6 +20,8 @@ import android.media.CamcorderProfile;
 import android.view.View;
 import android.graphics.SurfaceTexture;
 
+import com.facebook.react.bridge.ReadableMap;
+
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -74,7 +76,7 @@ abstract class CameraViewImpl {
 
     abstract int getFlash();
 
-    abstract void takePicture();
+    abstract void takePicture(ReadableMap options);
 
     abstract boolean record(String path, int maxDuration, int maxFileSize,
                             boolean recordAudio, CamcorderProfile profile);

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -224,7 +224,7 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
       sound.play(MediaActionSound.SHUTTER_CLICK);
     }
     try {
-      super.takePicture();
+      super.takePicture(options);
     } catch (Exception e) {
       mPictureTakenPromises.remove(promise);
       mPictureTakenOptions.remove(promise);

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -367,6 +367,8 @@ Supported options:
  - `skipProcessing` (android only, boolean). This property skips all image processing on android, this makes taking photos super fast, but you loose some of the information, width, height and the ability to do some processing on the image (base64, width, quality, mirrorImage, exif, etc)
 
 
+ - `pauseAfterCapture` (boolean true or false).  If true, pause the preview layer immediately after capturing the image.  You will need to call `cameraRef.resumePreview()` before using the camera again. If no value is specified `pauseAfterCapture:false` is used.
+
 The promise will be fulfilled with an object with some of the following properties:
 
  - `width`: returns the image's width (taking image orientation into account)

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -331,6 +331,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [connection setVideoOrientation:orientation];
     [self.stillImageOutput captureStillImageAsynchronouslyFromConnection:connection completionHandler: ^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
         if (imageSampleBuffer && !error) {
+            if ([options[@"pauseAfterCapture"] boolValue]) {
+                [[self.previewLayer connection] setEnabled:NO];
+            }
+
             BOOL useFastMode = options[@"fastMode"] && [options[@"fastMode"] boolValue];
             if (useFastMode) {
                 resolve(nil);

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -41,6 +41,7 @@ type PictureOptions = {
   width?: number,
   fixOrientation?: boolean,
   forceUpOrientation?: boolean,
+  pauseAfterCapture?: boolean,
 };
 
 type TrackedFaceFeature = FaceFeature & {
@@ -266,6 +267,11 @@ export default class Camera extends React.Component<PropsType, StateType> {
     if (options.orientation) {
       options.orientation = CameraManager.Orientation[options.orientation];
     }
+
+    if (options.pauseAfterCapture === undefined) {
+      options.pauseAfterCapture = false;
+    }
+
     return await CameraManager.takePicture(options, this._cameraHandle);
   }
 


### PR DESCRIPTION
Adds a property to `takePictureAsync` that pauses the preview as soon as the image is captured.  I realise that `cameraRef.pausePreview()` exists, but I wanted to be able to pause the preview immediately after capture and found it insufficient for that.  You will need to call `cameraRef.resumePreview()` afterwards.

Note that I have no idea if the Camera2 code works.  I couldn't get the Camera2 API to work even before making these changes by changing true to false here: https://github.com/react-native-community/react-native-camera/blob/77e158dc2dedcd1303b2f077bee63ff3be2739f7/android/src/main/java/org/reactnative/camera/RNCameraView.java#L70

This is probably for the same reasons that it was disabled in this commit: https://github.com/react-native-community/react-native-camera/commit/8d9c06ad903b40abc8bef67927d4621c494aeb3b