### PR TITLE
React Native Camera 1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/lwansbrough/react-native-camera.git"
   },
-  "version": "0.4.1",
+  "version": "1.0.0-alpha1",
   "description": "A Camera component for React Native. Also reads barcodes.",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "nativePackage": true,


### PR DESCRIPTION
Argument list too long: recursive header expansion failed

react native camera 1.1.4
i am trying to use react native camera without face detection. 
But after i implemented it on my project. (Done by manually link). l am still getting this error as above