### PR TITLE
Fix CocoaPods spec for FaceDetector 

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ And add something like this to the `scripts` section in your `package.json`:
 GMV (Google Mobile Vision) is used for Face detection by the iOS RNCamera. You have to link the google frameworks to your project to successfully compile the RNCamera project.
 
 ###### CocoaPods Path
-1. Modify the dependency towards `react-native-camera` in your
+
+Modify the dependency towards `react-native-camera` in your
  `Podfile`, from
 
  ```
@@ -139,17 +140,10 @@ GMV (Google Mobile Vision) is used for Face detection by the iOS RNCamera. You h
 to
 
 ```
-pod 'react-native-camera', subspecs: ['RCT', 'RN', 'FaceDetector'], path: '../node_modules/react-native-camera'
+pod 'react-native-camera', path: '../node_modules/react-native-camera', subspecs: [
+  'FaceDetector'
+]
 ```
-
-2. Add the following to your `Podfile`: 
-```
-  pod 'GoogleMobileVision/Detector', '~> 1.1.0'
-  pod 'GoogleMobileVision/MVDataOutput', '~> 1.1.0'
-  pod 'GoogleMobileVision/FaceDetector', '~> 1.1.0'
-```
-
-3. In XCode, On your target -> Build Phases -> Link Binary with Libraries -> add AddressBook.framework
 
 ###### Non-CocoaPods Path
 1. Download:

--- a/react-native-camera.podspec
+++ b/react-native-camera.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
 
   s.subspec "FaceDetector" do |ss|
     ss.dependency 'react-native-camera/RN'
+    ss.dependency 'react-native-camera/RCT'
 
     ss.dependency 'GoogleMobileVision/Detector', '~> 1.1.0'
     ss.dependency 'GoogleMobileVision/MVDataOutput', '~> 1.1.0'

--- a/react-native-camera.podspec
+++ b/react-native-camera.podspec
@@ -24,7 +24,14 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "FaceDetector" do |ss|
+    ss.dependency 'react-native-camera/RN'
+
+    ss.dependency 'GoogleMobileVision/Detector', '~> 1.1.0'
+    ss.dependency 'GoogleMobileVision/MVDataOutput', '~> 1.1.0'
+    ss.dependency 'GoogleMobileVision/FaceDetector', '~> 1.1.0'
+
     ss.source_files = "ios/FaceDetector/**/*.{h,m}"
+    s.static_framework = true
   end
 
   s.default_subspecs = "RN", "RCT"


### PR DESCRIPTION
I had a run-time error in `react-native` when I implemented `FaceDetector` using CocoaPods and because the `GoogleMobileVision` framework  wasn't recognized and `__has_include(<GoogleMobileVision/GoogleMobileVision.h>)` was returning `false`

This fixes that error by making the dependency to `GoogleMobileVision` explicit in `FaceDetector` spec and making `react-native-camera` framework static when using `FaceDetector`.