### PR TITLE
Update Camera1.java

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -247,7 +247,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 return;
             }
           SortedSet<Size> sizes = mPictureSizes.sizes(mAspectRatio);
-          if(sizes != null && !sizes.IsEmpty())
+          if(sizes != null && !sizes.isEmpty())
           {
             mPictureSize = sizes.last();
           }

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -246,7 +246,11 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             if (mAspectRatio == null) {
                 return;
             }
-          mPictureSize = mPictureSizes.sizes(mAspectRatio).last();
+          SortedSet<Size> sizes = mPictureSizes.sizes(mAspectRatio);
+          if(sizes != null && !sizes.IsEmpty())
+          {
+            mPictureSize = sizes.last();
+          }
         } else {
           mPictureSize = size;
         }


### PR DESCRIPTION
Check setPictureSize for null to prevent an exception

Fixed a bug which android throw a null reference exception when there is no 'pictureSize' attribute on RNCamera component