### PR TITLE
Fixes at least one cause of #1255

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -118,6 +118,10 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
           return;
         }
 
+        if (data.length < (1.5 * width * height)) {
+            return;
+        }
+
         if (willCallBarCodeTask) {
           barCodeScannerTaskLock = true;
           BarCodeScannerAsyncTaskDelegate delegate = (BarCodeScannerAsyncTaskDelegate) cameraView;


### PR DESCRIPTION
This fixes the [1255 issue](https://github.com/react-native-community/react-native-camera/issues/1255) - at least for the instance I was able to reproduce. 

It is an issue that only occurs on some android devices (for us it was a pixel). Occasionally, the data length comes through with significantly less data than it usually has which causes the error in that issue later on. 

On the phones I was able to test with the data.length is always 1.5 * width * height - except when the error occurs (when it was technically 1.5 * width * height / 100).