### PR TITLE
Optional Android permissions and microphone permissions

### DIFF
--- a/docs/RCTCamera.md
+++ b/docs/RCTCamera.md
@@ -240,6 +240,14 @@ Starting on android M individual permissions must be granted for certain service
 
 Starting on android M individual permissions must be granted for certain services, the camera is one of them, you can use this to change the content of the dialog prompt requesting permissions.
 
+#### `Android` `microphonePermissionDialogTitle`
+
+Starting on android M individual permissions must be granted for certain services, the microphone is one of them, you can use this to change the title of the dialog prompt requesting permissions.
+
+#### `Android` `microphonePermissionDialogMessage`
+
+Starting on android M individual permissions must be granted for certain services, the microphone is one of them, you can use this to change the content of the dialog prompt requesting permissions.
+
 #### `notAuthorizedView`
 
 By default a `Camera not authorized` message will be displayed when access to the camera has been denied, if set displays the passed react element instead of the default one.

--- a/src/Camera.js
+++ b/src/Camera.js
@@ -124,6 +124,8 @@ export default class Camera extends Component {
     type: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     permissionDialogTitle: PropTypes.string,
     permissionDialogMessage: PropTypes.string,
+    microphonePermissionDialogTitle: PropTypes.string,
+    microphonePermissionDialogMessage: PropTypes.string,
     notAuthorizedView: PropTypes.element,
     pendingAuthorizationView: PropTypes.element,
   };
@@ -149,6 +151,8 @@ export default class Camera extends Component {
     barCodeTypes: Object.values(CameraManager.BarCodeType),
     permissionDialogTitle: '',
     permissionDialogMessage: '',
+    microphonePermissionDialogTitle: '',
+    microphonePermissionDialogMessage: '',
     notAuthorizedView: (
       <View style={styles.authorizationContainer}>
         <Text style={styles.notAuthorizedText}>Camera not authorized</Text>
@@ -195,6 +199,8 @@ export default class Camera extends Component {
       Camera,
       this.props.permissionDialogTitle,
       this.props.permissionDialogMessage,
+      this.props.microphonePermissionDialogTitle,
+      this.props.microphonePermissionDialogMessage,
     );
     this.setState({ isAuthorized, isAuthorizationChecked: true });
   }

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -197,6 +197,8 @@ export default class Camera extends React.Component<PropsType, StateType> {
     autoFocus: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
     permissionDialogTitle: PropTypes.string,
     permissionDialogMessage: PropTypes.string,
+    microphonePermissionDialogTitle: PropTypes.string,
+    microphonePermissionDialogMessage: PropTypes.string,
     notAuthorizedView: PropTypes.element,
     pendingAuthorizationView: PropTypes.element,
     captureAudio: PropTypes.bool,
@@ -223,6 +225,8 @@ export default class Camera extends React.Component<PropsType, StateType> {
     faceDetectionClassifications: ((CameraManager.FaceDetection || {}).Classifications || {}).none,
     permissionDialogTitle: '',
     permissionDialogMessage: '',
+    microphonePermissionDialogTitle: '',
+    microphonePermissionDialogMessage: '',
     notAuthorizedView: (
       <View style={styles.authorizationContainer}>
         <Text style={styles.notAuthorizedText}>Camera not authorized</Text>
@@ -356,6 +360,8 @@ export default class Camera extends React.Component<PropsType, StateType> {
       CameraManager,
       this.props.permissionDialogTitle,
       this.props.permissionDialogMessage,
+      this.props.microphonePermissionDialogTitle,
+      this.props.microphonePermissionDialogMessage,
     );
     this.setState({ isAuthorized, isAuthorizationChecked: true });
   }

--- a/src/handlePermissions.js
+++ b/src/handlePermissions.js
@@ -11,10 +11,12 @@ export const requestPermissions = async (hasVideoAndAudio, CameraManager, permis
             return isAuthorized;
         }
     } else if (Platform.OS === 'android') {
-        const grantedCamera = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA, {
-            title: permissionDialogTitle,
-            message: permissionDialogMessage,
-          });
+        const cameraPermissionDialog = permissionDialogTitle || permissionDialogMessage ? {
+          title: permissionDialogTitle,
+          message: permissionDialogMessage,
+        } : undefined;
+
+        const grantedCamera = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA, cameraPermissionDialog);
         if (!hasVideoAndAudio) {
             return grantedCamera === PermissionsAndroid.RESULTS.GRANTED || grantedCamera === true;
         }

--- a/src/handlePermissions.js
+++ b/src/handlePermissions.js
@@ -1,6 +1,6 @@
 import { PermissionsAndroid, Platform } from 'react-native';
 
-export const requestPermissions = async (hasVideoAndAudio, CameraManager, permissionDialogTitle, permissionDialogMessage) => {
+export const requestPermissions = async (hasVideoAndAudio, CameraManager, permissionDialogTitle, permissionDialogMessage, microphonePermissionDialogTitle, microphonePermissionDialogMessage) => {
     if (Platform.OS === 'ios') {
         let check = hasVideoAndAudio
             ? CameraManager.checkDeviceAuthorizationStatus
@@ -20,10 +20,13 @@ export const requestPermissions = async (hasVideoAndAudio, CameraManager, permis
         if (!hasVideoAndAudio) {
             return grantedCamera === PermissionsAndroid.RESULTS.GRANTED || grantedCamera === true;
         }
-        const grantedAudio = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.RECORD_AUDIO, {
-            title: permissionDialogTitle,
-            message: permissionDialogMessage,
-        });
+
+        const microphonePermissionDialog = microphonePermissionDialogTitle || microphonePermissionDialogMessage ? {
+          title: microphonePermissionDialogTitle,
+          message: microphonePermissionDialogMessage,
+        } : undefined;
+
+        const grantedAudio = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.RECORD_AUDIO, microphonePermissionDialog);
 
         return (grantedCamera === PermissionsAndroid.RESULTS.GRANTED || grantedCamera === true)
             && (grantedAudio === PermissionsAndroid.RESULTS.GRANTED || grantedAudio === true);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -111,6 +111,10 @@ export interface RNCameraProps {
     /** Android only */
     permissionDialogMessage?: string;
     /** Android only */
+    microphonePermissionDialogTitle?: string;
+    /** Android only */
+    microphonePermissionDialogMessage?: string;
+    /** Android only */
     playSoundOnCapture?: boolean;
 
     // -- IOS ONLY PROPS


### PR DESCRIPTION
This fixes the issue I mentioned along side this commit that @sibelius and I discussed https://github.com/react-native-community/react-native-camera/commit/ae35e4f2169a01f481ada98a00ceeccc94aa6e56#commitcomment-29939308.

Now permission is being required for the microphone, the same dialog containing the permission title and message for the camera was appearing for the microphone too, creating two duplicate dialogs.

This PR adds new props specifically for the microphone so unique titles and messages an can be added for the camera and microphone separately.

As well as making these dialogs optional. If you were to not specify the `permissionDialogTitle` and `permissionDialogMessage` prop, a blank dialog would appear. This stops the dialog from appearing all together.

A few notes implementation notes,
- prevents the dialog containing `permissionDialogTitle` and `permissionDialogMessage` if _both_ these props are empty
- adds two new props `microphonePermissionDialogTitle` and `microphonePermissionDialogMessage`, these function the same as `permissionDialogTitle` and `permissionDialogMessage` but apply specifically to microphone