### PR TITLE
workaround for PermissionsAndroid request rationale issue

### DIFF
--- a/src/handlePermissions.js
+++ b/src/handlePermissions.js
@@ -13,7 +13,11 @@ export const requestPermissions = async (hasVideoAndAudio, CameraManager, permis
         if(permissionDialogTitle || permissionDialogMessage)
             params = { title: permissionDialogTitle, message: permissionDialogMessage };
         const granted = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA, params);
-        return granted === PermissionsAndroid.RESULTS.GRANTED || granted === true;
+        if (!hasVideoAndAudio)
+            return granted === PermissionsAndroid.RESULTS.GRANTED || granted === true;
+        const grantedAudio = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.RECORD_AUDIO, params);
+        return (granted === PermissionsAndroid.RESULTS.GRANTED || granted === true)
+            && (grantedAudio === PermissionsAndroid.RESULTS.GRANTED || grantedAudio === true);
     }
     return true;
 }

--- a/src/handlePermissions.js
+++ b/src/handlePermissions.js
@@ -11,7 +11,7 @@ export const requestPermissions = async (hasVideoAndAudio, CameraManager, permis
     } else if (Platform.OS === 'android') {
         let params = undefined;
         if(permissionDialogTitle || permissionDialogMessage)
-            params = {title: permissionDialogTitle, message: permissionDialogMessage};
+            params = { title: permissionDialogTitle, message: permissionDialogMessage };
         const granted = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA, params);
         return granted === PermissionsAndroid.RESULTS.GRANTED || granted === true;
     }

--- a/src/handlePermissions.js
+++ b/src/handlePermissions.js
@@ -6,25 +6,14 @@ export const requestPermissions = async (hasVideoAndAudio, CameraManager, permis
             ? CameraManager.checkDeviceAuthorizationStatus
             : CameraManager.checkVideoAuthorizationStatus;
 
-        if (check) {
-            const isAuthorized = await check();
-            return isAuthorized;
-        }
+        if (check) 
+            return await check();
     } else if (Platform.OS === 'android') {
-        const grantedCamera = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA, {
-            title: permissionDialogTitle,
-            message: permissionDialogMessage,
-          });
-        if (!hasVideoAndAudio) {
-            return grantedCamera === PermissionsAndroid.RESULTS.GRANTED || grantedCamera === true;
-        }
-        const grantedAudio = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.RECORD_AUDIO, {
-            title: permissionDialogTitle,
-            message: permissionDialogMessage,
-        });
-
-        return (grantedCamera === PermissionsAndroid.RESULTS.GRANTED || grantedCamera === true)
-            && (grantedAudio === PermissionsAndroid.RESULTS.GRANTED || grantedAudio === true);
+        let params = undefined;
+        if(permissionDialogTitle || permissionDialogMessage)
+            params = {title: permissionDialogTitle, message: permissionDialogMessage};
+        const granted = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA, params);
+        return granted === PermissionsAndroid.RESULTS.GRANTED || granted === true;
     }
     return true;
 }


### PR DESCRIPTION
related to #1722.
This is a workaround for the problem in PermissionsAndroid request rationale being something different that undefined, but the case is that if any of the permissions are passed is not required to be sent.
Meanwhile, I will open an issue in `react-native` project and link it here.