### PR TITLE
Bump gradle tools to 3.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.0'
+    classpath 'com.android.tools.build:gradle:3.0.1'
   }
 }
 


### PR DESCRIPTION
This fixes error building apps that use RN 0.55 or higher and have an app build tools version of 3.0.1 or higher.