### PR TITLE
Adding 'doNotSave' option to skip saving

### DIFF
--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -115,11 +115,13 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
             ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
             mBitmap.compress(Bitmap.CompressFormat.JPEG, getQuality(), imageStream);
 
-            // Write compressed image to file in cache directory
-            String filePath = writeStreamToFile(imageStream);
-            File imageFile = new File(filePath);
-            String fileUri = Uri.fromFile(imageFile).toString();
-            response.putString("uri", fileUri);
+            // Write compressed image to file in cache directory unless otherwise specified
+            if (!mOptions.hasKey("doNotSave") || !mOptions.getBoolean("doNotSave")) {
+                String filePath = writeStreamToFile(imageStream);
+                File imageFile = new File(filePath);
+                String fileUri = Uri.fromFile(imageFile).toString();
+                response.putString("uri", fileUri);
+            }
 
             // Write base64-encoded image to the response if requested
             if (mOptions.hasKey("base64") && mOptions.getBoolean("base64")) {

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -366,6 +366,8 @@ Supported options:
 
  - `skipProcessing` (android only, boolean). This property skips all image processing on android, this makes taking photos super fast, but you loose some of the information, width, height and the ability to do some processing on the image (base64, width, quality, mirrorImage, exif, etc)
 
+- `doNotSave` (boolean true or false). Use this with `true` if you do not want the picture to be saved as a file to cache. If no value is specified `doNotSave:false` is used. If you only need the base64 for the image, you can use this with `base64:true` and avoid having to save the file.
+
 
 The promise will be fulfilled with an object with some of the following properties:
 

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -371,7 +371,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             float quality = [options[@"quality"] floatValue];
             NSData *takenImageData = UIImageJPEGRepresentation(takenImage, quality);
             NSString *path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
-            response[@"uri"] = [RNImageUtils writeImage:takenImageData toPath:path];
+            if (![options[@"doNotSave"] boolValue]) {
+                response[@"uri"] = [RNImageUtils writeImage:takenImageData toPath:path];
+            }
             response[@"width"] = @(takenImage.size.width);
             response[@"height"] = @(takenImage.size.height);
 

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -251,7 +251,9 @@ RCT_REMAP_METHOD(takePicture,
                 resolve(nil);
             }
             NSData *photoData = UIImageJPEGRepresentation(generatedPhoto, quality);
-            response[@"uri"] = [RNImageUtils writeImage:photoData toPath:path];
+            if (![options[@"doNotSave"] boolValue]) {
+                response[@"uri"] = [RNImageUtils writeImage:photoData toPath:path];
+            }
             response[@"width"] = @(generatedPhoto.size.width);
             response[@"height"] = @(generatedPhoto.size.height);
             if ([options[@"base64"] boolValue]) {


### PR DESCRIPTION
Resolution for issue #1659 

I added the option for a `doNotSave` option which would skip saving to cache when provided and set to `true`. I was able to test this on Android, but I don't have access to an iPhone where I can test this fix :disappointed: 