### PR TITLE
Feature/orientation by accelerometer

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -56,7 +56,9 @@
 - (void)updateFaceDetectionLandmarks:(id)requestedLandmarks;
 - (void)updateFaceDetectionClassifications:(id)requestedClassifications;
 - (void)takePicture:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)takePictureWithOrientation:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)record:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)recordWithOrientation:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)stopRecording;
 - (void)resumePreview;
 - (void)pausePreview;

--- a/ios/RN/RNSensorOrientationChecker.h
+++ b/ios/RN/RNSensorOrientationChecker.h
@@ -1,0 +1,21 @@
+//
+//  RNSensorOrientationChecker.h
+//  RNCamera
+//
+//  Created by Radu Popovici on 24/03/16.
+//
+//
+
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
+
+typedef void (^RNSensorCallback) (UIInterfaceOrientation orientation);
+
+@interface RNSensorOrientationChecker : NSObject
+
+@property (assign, nonatomic) UIInterfaceOrientation orientation;
+
+- (void)getDeviceOrientationWithBlock:(RNSensorCallback)callback;
+- (AVCaptureVideoOrientation)convertToAVCaptureVideoOrientation:(UIInterfaceOrientation)orientation;
+
+@end

--- a/ios/RN/RNSensorOrientationChecker.m
+++ b/ios/RN/RNSensorOrientationChecker.m
@@ -1,0 +1,105 @@
+//
+//  RNSensorOrientationChecker.m
+//  RNCamera
+//
+//  Created by Radu Popovici on 24/03/16.
+//
+//
+
+#import "RNSensorOrientationChecker.h"
+#import <CoreMotion/CoreMotion.h>
+
+
+@interface RNSensorOrientationChecker ()
+
+@property (strong, nonatomic) CMMotionManager * motionManager;
+@property (strong, nonatomic) RNSensorCallback orientationCallback;
+
+@end
+
+@implementation RNSensorOrientationChecker
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        // Initialization code
+        self.motionManager = [[CMMotionManager alloc] init];
+        self.motionManager.accelerometerUpdateInterval = 0.2;
+        self.motionManager.gyroUpdateInterval = 0.2;
+        self.orientationCallback = nil;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [self pause];
+}
+
+- (void)resume
+{
+    __weak __typeof(self) weakSelf = self;
+    [self.motionManager startAccelerometerUpdatesToQueue:[NSOperationQueue new]
+                                             withHandler:^(CMAccelerometerData  *accelerometerData, NSError *error) {
+                                                 if (!error) {
+                                                     self.orientation = [weakSelf getOrientationBy:accelerometerData.acceleration];
+                                                 }
+                                                 if (self.orientationCallback) {
+                                                     self.orientationCallback(self.orientation);
+                                                 }
+                                             }];
+}
+
+- (void)pause
+{
+    [self.motionManager stopAccelerometerUpdates];
+}
+
+- (void)getDeviceOrientationWithBlock:(RNSensorCallback)callback
+{
+    __weak __typeof(self) weakSelf = self;
+    self.orientationCallback = ^(UIInterfaceOrientation orientation) {
+        if (callback) {
+            callback(orientation);
+        }
+        weakSelf.orientationCallback = nil;
+        [weakSelf pause];
+    };
+    [self resume];
+}
+
+- (UIInterfaceOrientation)getOrientationBy:(CMAcceleration)acceleration
+{
+    if(acceleration.x >= 0.75) {
+        return UIInterfaceOrientationLandscapeLeft;
+    }
+    if(acceleration.x <= -0.75) {
+        return UIInterfaceOrientationLandscapeRight;
+    }
+    if(acceleration.y <= -0.75) {
+        return UIInterfaceOrientationPortrait;
+    }
+    if(acceleration.y >= 0.75) {
+        return UIInterfaceOrientationPortraitUpsideDown;
+    }
+    return [[UIApplication sharedApplication] statusBarOrientation];
+}
+
+- (AVCaptureVideoOrientation)convertToAVCaptureVideoOrientation:(UIInterfaceOrientation)orientation
+{
+    switch (orientation) {
+        case UIInterfaceOrientationPortrait:
+            return AVCaptureVideoOrientationPortrait;
+        case UIInterfaceOrientationPortraitUpsideDown:
+            return AVCaptureVideoOrientationPortraitUpsideDown;
+        case UIInterfaceOrientationLandscapeLeft:
+            return AVCaptureVideoOrientationLandscapeLeft;
+        case UIInterfaceOrientationLandscapeRight:
+            return AVCaptureVideoOrientationLandscapeRight;
+        default:
+            return 0; // unknown
+    }
+}
+
+@end

--- a/ios/RNCamera.xcodeproj/project.pbxproj
+++ b/ios/RNCamera.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		71D5C72B201B8A320030A15E /* RNFaceDetectorModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBB520155340003C59C3 /* RNFaceDetectorModule.m */; };
 		71D5C72C201B8A360030A15E /* RNFaceDetectorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7147DBB22015319E003C59C3 /* RNFaceDetectorManager.m */; };
 		9FE592B31CA3CBF500788287 /* RCTSensorOrientationChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FE592B21CA3CBF500788287 /* RCTSensorOrientationChecker.m */; };
+		F8393BEC21469C0000AB1995 /* RNSensorOrientationChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = F8393BEB21469C0000AB1995 /* RNSensorOrientationChecker.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -70,6 +71,8 @@
 		71C7FFD52013C824006EB75A /* RNFileSystem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNFileSystem.m; sourceTree = "<group>"; };
 		9FE592B11CA3CBF500788287 /* RCTSensorOrientationChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTSensorOrientationChecker.h; sourceTree = "<group>"; };
 		9FE592B21CA3CBF500788287 /* RCTSensorOrientationChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTSensorOrientationChecker.m; sourceTree = "<group>"; };
+		F8393BEA21469C0000AB1995 /* RNSensorOrientationChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNSensorOrientationChecker.h; sourceTree = "<group>"; };
+		F8393BEB21469C0000AB1995 /* RNSensorOrientationChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNSensorOrientationChecker.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +123,8 @@
 		714166162013E1B600EE9FCC /* RN */ = {
 			isa = PBXGroup;
 			children = (
+				F8393BEA21469C0000AB1995 /* RNSensorOrientationChecker.h */,
+				F8393BEB21469C0000AB1995 /* RNSensorOrientationChecker.m */,
 				71C7FFD42013C824006EB75A /* RNFileSystem.h */,
 				71C7FFD52013C824006EB75A /* RNFileSystem.m */,
 				71C7FFD12013C817006EB75A /* RNImageUtils.h */,
@@ -218,6 +223,7 @@
 				7103647B20195C53009691D1 /* RNFaceDetectorManagerStub.m in Sources */,
 				4107014D1ACB732B00C6AA39 /* RCTCamera.m in Sources */,
 				71D5C72A201B8A2F0030A15E /* RNFaceDetectorPointTransformCalculator.m in Sources */,
+				F8393BEC21469C0000AB1995 /* RNSensorOrientationChecker.m in Sources */,
 				71C7FFD02013C7E5006EB75A /* RNCameraUtils.m in Sources */,
 				7162BE682013EAA400FE51FF /* RNCameraManager.m in Sources */,
 				7162BE672013EAA100FE51FF /* RNCamera.m in Sources */,


### PR DESCRIPTION
Migrates the RCTSensorOrientationChecker to RNCamera to fix orientation problems with programmatically locked orientations. #1662