### PR TITLE
[ios] fix possible race condition in removeFromSuperview

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -132,9 +132,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
 - (void)removeFromSuperview
 {
-    [self stopSession];
     [super removeFromSuperview];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
+    [self stopSession];
 }
 
 -(void)updateType


### PR DESCRIPTION
the method stopSession dispatches an async task which can result in a race condition between  the calls of`[super removeFromSuperview];` and `[self stopSession];`.

In our crash logs (captured from test devices and end consumers) the following crash occured on a frequent basis:

```
-[RNCamera removeFromSuperview]
RNCamera.m - line 122
NSGenericException: *** Collection <CALayerArray: 0x28376bed0> was mutated while being enumerated.
```

By moving the `stopSession` call (which is async) below the `removeFromSuperview` call (which seems sync) I could reduce the occurrences to zero. 