### PR TITLE
[Android] fix: Error retrieving camcorder profile params

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -283,27 +283,32 @@ public class RNCameraViewHelper {
     }
   }
 
-  public static CamcorderProfile getCamcorderProfile(int quality) {
-    CamcorderProfile profile = CamcorderProfile.get(CamcorderProfile.QUALITY_HIGH);
+  private static int getCamcorderProfileQualityFromCameraModuleConstant(int quality) {
     switch (quality) {
       case CameraModule.VIDEO_2160P:
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-          profile = CamcorderProfile.get(CamcorderProfile.QUALITY_2160P);
+          return CamcorderProfile.QUALITY_2160P;
         }
-        break;
       case CameraModule.VIDEO_1080P:
-        profile = CamcorderProfile.get(CamcorderProfile.QUALITY_1080P);
-        break;
+        return CamcorderProfile.QUALITY_1080P;
       case CameraModule.VIDEO_720P:
-        profile = CamcorderProfile.get(CamcorderProfile.QUALITY_720P);
-        break;
+        return CamcorderProfile.QUALITY_720P;
       case CameraModule.VIDEO_480P:
-        profile = CamcorderProfile.get(CamcorderProfile.QUALITY_480P);
-        break;
+        return CamcorderProfile.QUALITY_480P;
       case CameraModule.VIDEO_4x3:
-        profile = CamcorderProfile.get(CamcorderProfile.QUALITY_480P);
+        return CamcorderProfile.QUALITY_480P;
+    }
+    return CamcorderProfile.QUALITY_HIGH;
+  }
+  
+  public static CamcorderProfile getCamcorderProfile(int quality) {
+    CamcorderProfile profile = CamcorderProfile.get(CamcorderProfile.QUALITY_HIGH);
+    int camcorderQuality = getCamcorderProfileQualityFromCameraModuleConstant(quality);
+    if (CamcorderProfile.hasProfile(camcorderQuality)) {
+      profile = CamcorderProfile.get(camcorderQuality);
+      if (quality == CameraModule.VIDEO_4x3) {
         profile.videoFrameWidth = 640;
-        break;
+      }
     }
     return profile;
   }


### PR DESCRIPTION
I got this error when I call `recordAsync(...)` with `quality: RNCamera.Constants.VideoQuality['480p']` on Samsung Galaxy Tab S 10.5.
```
Error: Error retrieving camcorder profile params
    at createErrorFromErrorData (NativeModules.js:123)
    at NativeModules.js:80
    at MessageQueue.__invokeCallback (MessageQueue.js:400)
    at MessageQueue.js:139
    at MessageQueue.__guardSafe (MessageQueue.js:316)
    at MessageQueue.invokeCallbackAndReturnFlushedQueue (MessageQueue.js:138)
```
It happens because there is no check if device actually supports given quality.
To make the `CamcorderProfile.get(quality)` call safe we need to check if there is appropriate CamcorderProfile by calling `CamcorderProfile.hasProfile(quality))`.

This PR fixes that issue.