### PR TITLE
check if face or text detector libraries are included independently

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -341,27 +341,33 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [self updateSessionPreset:self.pictureSize];
 }
 
-#if __has_include(<GoogleMobileVision/GoogleMobileVision.h>)
 - (void)updateFaceDetecting:(id)faceDetecting
 {
-    [_faceDetectorManager setIsEnabled:faceDetecting];
+    #if __has_include("RNFaceDetectorManager.h")
+        [_faceDetectorManager setIsEnabled:faceDetecting];
+    #endif
 }
 
 - (void)updateFaceDetectionMode:(id)requestedMode
 {
-    [_faceDetectorManager setMode:requestedMode];
+    #if __has_include("RNFaceDetectorManager.h")
+        [_faceDetectorManager setMode:requestedMode];
+    #endif
 }
 
 - (void)updateFaceDetectionLandmarks:(id)requestedLandmarks
 {
-    [_faceDetectorManager setLandmarksDetected:requestedLandmarks];
+    #if __has_include("RNFaceDetectorManager.h")
+        [_faceDetectorManager setLandmarksDetected:requestedLandmarks];
+    #endif
 }
 
 - (void)updateFaceDetectionClassifications:(id)requestedClassifications
 {
-    [_faceDetectorManager setClassificationsDetected:requestedClassifications];
+    #if __has_include("RNFaceDetectorManager.h")
+        [_faceDetectorManager setClassificationsDetected:requestedClassifications];
+    #endif
 }
-#endif
 
 
 - (void)takePictureWithOrientation:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject{
@@ -485,8 +491,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         // At the time of writing AVCaptureMovieFileOutput and AVCaptureVideoDataOutput (> GMVDataOutput)
         // cannot coexist on the same AVSession (see: https://stackoverflow.com/a/4986032/1123156).
         // We stop face detection here and restart it in when AVCaptureMovieFileOutput finishes recording.
-#if __has_include(<GoogleMobileVision/GoogleMobileVision.h>)
+#if __has_include("RNFaceDetectorManager.h")
         [_faceDetectorManager stopFaceDetection];
+#endif
+#if __has_include("TextDetectorManager.h")
         [self stopTextRecognition];
 #endif
         [self setupMovieFileCapture];
@@ -597,11 +605,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             self.stillImageOutput = stillImageOutput;
         }
 
-#if __has_include(<GoogleMobileVision/GoogleMobileVision.h>)
+#if __has_include("RNFaceDetectorManager.h")
         [_faceDetectorManager maybeStartFaceDetectionOnSession:_session withPreviewLayer:_previewLayer];
-        if ([self.textDetector isRealDetector]) {
-            [self setupOrDisableTextDetector];
-        }
+#elif __has_include("TextDetectorManager.h")
+        [self setupOrDisableTextDetector];
 #else
         // If AVCaptureVideoDataOutput is not required because of Google Vision
         // (see comment in -record), we go ahead and add the AVCaptureMovieFileOutput
@@ -634,7 +641,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     return;
 #endif
     dispatch_async(self.sessionQueue, ^{
-#if __has_include(<GoogleMobileVision/GoogleMobileVision.h>)
+#if __has_include("RNFaceDetectorManager.h")
         [_faceDetectorManager stopFaceDetection];
 #endif
         if ([self.textDetector isRealDetector]) {
@@ -930,7 +937,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     self.videoRecordedReject = nil;
     self.videoCodecType = nil;
 
-#if __has_include(<GoogleMobileVision/GoogleMobileVision.h>)
+#if __has_include("RNFaceDetectorManager.h")
     [self cleanupMovieFileCapture];
 
     // If face detection has been running prior to recording to file
@@ -999,7 +1006,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     Class faceDetectorManagerClass = NSClassFromString(@"RNFaceDetectorManager");
     Class faceDetectorManagerStubClass = NSClassFromString(@"RNFaceDetectorManagerStub");
 
-#if __has_include(<GoogleMobileVision/GoogleMobileVision.h>)
+#if __has_include("RNFaceDetectorManager.h")
     if (faceDetectorManagerClass) {
         return [[faceDetectorManagerClass alloc] initWithSessionQueue:_sessionQueue delegate:self];
     } else if (faceDetectorManagerStubClass) {
@@ -1028,7 +1035,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     Class textDetectorManagerStubClass =
         NSClassFromString(@"TextDetectorManagerStub");
 
-#if __has_include(<GoogleMobileVision/GoogleMobileVision.h>)
+#if __has_include("TextDetectorManager.h")
     if (textDetectorManagerClass) {
         return [[textDetectorManagerClass alloc] init];
     } else if (textDetectorManagerStubClass) {


### PR DESCRIPTION
Addresses  #1856, i.e. removes warning `FaceDetector not integrated, stub used!` when text detector is integrated but not face detector, and vice versa