### PR TITLE
Trigger onCameraReady on iOS emulator

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -583,6 +583,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 - (void)startSession
 {
 #if TARGET_IPHONE_SIMULATOR
+    [self onReady:nil];
     return;
 #endif
     //    NSDictionary *cameraPermissions = [EXCameraPermissionRequester permissions];


### PR DESCRIPTION
When running on the emulator, the module should behave the same as on a device.

I use `onCameraReady` to change the stylesheet of the camera itself, so that my controls are properly placed - which is different than the placement I require for the "Pending instructions".

However, so far, `onCameraReady` is not called at all on the emulator. This ensures that it is.