### PR TITLE
Fix to critical issue "Could not find intellij-core.jar"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,7 @@ android {
 }
 
 repositories {
+  google()
   mavenCentral()
   maven {
    url 'https://maven.google.com'


### PR DESCRIPTION
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':react-native-camera'.
> Could not resolve all artifacts for configuration ':react-native-camera:classpath'.
   > Could not find intellij-core.jar (com.android.tools.external.com-intellij:intellij-core:26.0.1).
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/external/com-intellij/intellij-core/26.0.1/intellij-core-26.0.1.jar