### PR TITLE
[iOS] Simple way to prevent camera flickering when starting a recording adding a new property

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -273,27 +273,30 @@ The video stabilization mode used for a video recording. The possible values are
 You can read more about each stabilization type here: https://developer.apple.com/documentation/avfoundation/avcapturevideostabilizationmode
 
 ### `iOS` `defaultVideoQuality`
-  - `quality`. This option specifies the quality of the video to be taken. The possible values are:
-   - `RNCamera.Constants.VideoQuality.2160p`.
-      - `ios` Specifies capture settings suitable for 2160p (also called UHD or 4K) quality (3840x2160 pixel) video output.
-      - `android` Quality level corresponding to the 2160p (3840x2160) resolution. (Android Lollipop and above only!).
-   - `RNCamera.Constants.VideoQuality.1080p`.
-     - `ios` Specifies capture settings suitable for 1080p quality (1920x1080 pixel) video output.
-      - `android` Quality level corresponding to the 1080p (1920 x 1080) resolution.
-   - `RNCamera.Constants.VideoQuality.720p`.
-     - `ios` Specifies capture settings suitable for 720p quality (1280x720 pixel) video output.
-     - `android` Quality level corresponding to the 720p (1280 x 720) resolution.
-   - `RNCamera.Constants.VideoQuality.480p`.
-     - `ios` Specifies capture settings suitable for VGA quality (640x480 pixel) video output.
-     - `android` Quality level corresponding to the 480p (720 x 480) resolution.
-   - `RNCamera.Constants.VideoQuality.4:3`.
-     - `ios` Specifies capture settings suitable for VGA quality (640x480 pixel) video output. (Same as RNCamera.Constants.VideoQuality.480p).
-     - `android` Quality level corresponding to the 480p (720 x 480) resolution but with video frame width set to 640.
-   - `RNCamera.Constants.VideoQuality.288p`.
-     - `ios` Specifies capture settings suitable for CIF quality (352x288 pixel) video output.
-     - `android` Not supported.
-     If nothing is passed the device's highest camera quality will be used as default.
-     Note: This solve the flicker video recording issue for iOS
+
+This option specifies the quality of the video to be taken. The possible values are:
+
+  - `RNCamera.Constants.VideoQuality.2160p`.
+    - `ios` Specifies capture settings suitable for 2160p (also called UHD or 4K) quality (3840x2160 pixel) video output.
+    - `android` Quality level corresponding to the 2160p (3840x2160) resolution. (Android Lollipop and above only!).
+  - `RNCamera.Constants.VideoQuality.1080p`.
+    - `ios` Specifies capture settings suitable for 1080p quality (1920x1080 pixel) video output.
+    - `android` Quality level corresponding to the 1080p (1920 x 1080) resolution.
+  - `RNCamera.Constants.VideoQuality.720p`.
+    - `ios` Specifies capture settings suitable for 720p quality (1280x720 pixel) video output.
+    - `android` Quality level corresponding to the 720p (1280 x 720) resolution.
+  - `RNCamera.Constants.VideoQuality.480p`.
+    - `ios` Specifies capture settings suitable for VGA quality (640x480 pixel) video output.
+    - `android` Quality level corresponding to the 480p (720 x 480) resolution.
+  - `RNCamera.Constants.VideoQuality.4:3`.
+    - `ios` Specifies capture settings suitable for VGA quality (640x480 pixel) video output. (Same as RNCamera.Constants.VideoQuality.480p).
+    - `android` Quality level corresponding to the 480p (720 x 480) resolution but with video frame width set to 640.
+  - `RNCamera.Constants.VideoQuality.288p`.
+    - `ios` Specifies capture settings suitable for CIF quality (352x288 pixel) video output.
+    - `android` Not supported.
+
+If nothing is passed the device's highest camera quality will be used as default.
+Note: This solve the flicker video recording issue for iOS
 
 
 ### Native Event callbacks props

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -272,6 +272,30 @@ The video stabilization mode used for a video recording. The possible values are
 
 You can read more about each stabilization type here: https://developer.apple.com/documentation/avfoundation/avcapturevideostabilizationmode
 
+### `iOS` `defaultVideoQuality`
+  - `quality`. This option specifies the quality of the video to be taken. The possible values are:
+   - `RNCamera.Constants.VideoQuality.2160p`.
+      - `ios` Specifies capture settings suitable for 2160p (also called UHD or 4K) quality (3840x2160 pixel) video output.
+      - `android` Quality level corresponding to the 2160p (3840x2160) resolution. (Android Lollipop and above only!).
+   - `RNCamera.Constants.VideoQuality.1080p`.
+     - `ios` Specifies capture settings suitable for 1080p quality (1920x1080 pixel) video output.
+      - `android` Quality level corresponding to the 1080p (1920 x 1080) resolution.
+   - `RNCamera.Constants.VideoQuality.720p`.
+     - `ios` Specifies capture settings suitable for 720p quality (1280x720 pixel) video output.
+     - `android` Quality level corresponding to the 720p (1280 x 720) resolution.
+   - `RNCamera.Constants.VideoQuality.480p`.
+     - `ios` Specifies capture settings suitable for VGA quality (640x480 pixel) video output.
+     - `android` Quality level corresponding to the 480p (720 x 480) resolution.
+   - `RNCamera.Constants.VideoQuality.4:3`.
+     - `ios` Specifies capture settings suitable for VGA quality (640x480 pixel) video output. (Same as RNCamera.Constants.VideoQuality.480p).
+     - `android` Quality level corresponding to the 480p (720 x 480) resolution but with video frame width set to 640.
+   - `RNCamera.Constants.VideoQuality.288p`.
+     - `ios` Specifies capture settings suitable for CIF quality (352x288 pixel) video output.
+     - `android` Not supported.
+     If nothing is passed the device's highest camera quality will be used as default.
+     Note: This solve the flicker video recording issue for iOS
+
+
 ### Native Event callbacks props
 
 #### `onCameraReady`

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -43,6 +43,7 @@
 @property (nonatomic, assign) BOOL canReadText;
 @property(assign, nonatomic) AVVideoCodecType videoCodecType;
 @property (assign, nonatomic) AVCaptureVideoStabilizationMode videoStabilizationMode;
+@property(assign, nonatomic) NSInteger defaultVideoQuality;
 
 - (id)initWithBridge:(RCTBridge *)bridge;
 - (void)updateType;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -565,7 +565,11 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
 - (void)stopRecording
 {
-    [self.movieFileOutput stopRecording];
+    if ([self.movieFileOutput isRecording]) {
+        [self.movieFileOutput stopRecording];
+    } else {
+        RCTLogWarn(@"Video is not recording.");
+    }
 }
 
 - (void)resumePreview

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -512,7 +512,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     }
 
     if (options[@"quality"]) {
-        [self updateSessionPreset:[RNCameraUtils captureSessionPresetForVideoResolution:(RNCameraVideoResolution)[options[@"quality"] integerValue]]];
+        NSString *newQuality = [RNCameraUtils captureSessionPresetForVideoResolution:(RNCameraVideoResolution)[options[@"quality"] integerValue]];
+        if (self.session.sessionPreset != newQuality) {
+            [self updateSessionPreset:newQuality];
+        }
     }
 
     [self updateSessionAudioIsMuted:!!options[@"mute"]];

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -950,8 +950,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         [self setupOrDisableTextDetector];
     }
 
-    if (self.session.sessionPreset != AVCaptureSessionPresetPhoto) {
-        [self updateSessionPreset:AVCaptureSessionPresetPhoto];
+    AVCaptureSessionPreset preset = [RNCameraUtils captureSessionPresetForVideoResolution:[self defaultVideoQuality]];
+    if (self.session.sessionPreset != preset) {
+        [self updateSessionPreset: preset == AVCaptureSessionPresetHigh ? AVCaptureSessionPresetPhoto: preset];
     }
 }
 

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -593,7 +593,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             return;
         }
 
-        self.session.sessionPreset = AVCaptureSessionPresetPhoto;
+        AVCaptureSessionPreset preset = [RNCameraUtils captureSessionPresetForVideoResolution:[self defaultVideoQuality]];
+        self.session.sessionPreset = preset == AVCaptureSessionPresetHigh ? AVCaptureSessionPresetPhoto: preset;
 
         AVCaptureStillImageOutput *stillImageOutput = [[AVCaptureStillImageOutput alloc] init];
         if ([self.session canAddOutput:stillImageOutput]) {

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -512,7 +512,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     }
 
     if (options[@"quality"]) {
-        NSString *newQuality = [RNCameraUtils captureSessionPresetForVideoResolution:(RNCameraVideoResolution)[options[@"quality"] integerValue]];
+        AVCaptureSessionPreset newQuality = [RNCameraUtils captureSessionPresetForVideoResolution:(RNCameraVideoResolution)[options[@"quality"] integerValue]];
         if (self.session.sessionPreset != newQuality) {
             [self updateSessionPreset:newQuality];
         }

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -244,6 +244,11 @@ RCT_CUSTOM_VIEW_PROPERTY(textRecognizerEnabled, BOOL, RNCamera)
     [view setupOrDisableTextDetector];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(defaultVideoQuality, NSInteger, RNCamera)
+{
+    [view setDefaultVideoQuality:[RCTConvert NSInteger:json]];
+}
+
 RCT_REMAP_METHOD(takePicture,
                  options:(NSDictionary *)options
                  reactTag:(nonnull NSNumber *)reactTag

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -246,7 +246,7 @@ RCT_CUSTOM_VIEW_PROPERTY(textRecognizerEnabled, BOOL, RNCamera)
 
 RCT_CUSTOM_VIEW_PROPERTY(defaultVideoQuality, NSInteger, RNCamera)
 {
-    [view setDefaultVideoQuality:[RCTConvert NSInteger:json]];
+    [view setDefaultVideoQuality:(NSInteger) [RCTConvert NSInteger:json]];
 }
 
 RCT_REMAP_METHOD(takePicture,

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -208,6 +208,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     videoStabilizationMode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     pictureSize: PropTypes.string,
     mirrorVideo: PropTypes.bool,
+    defaultVideoQuality: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   };
 
   static defaultProps: Object = {


### PR DESCRIPTION
Hi,

I added a new property to fix issue [#1249](https://github.com/react-native-community/react-native-camera/issues/1249)

This property fixes the black flicker that many people are experiencing at the start of a recording. By setting this property on the component itself, the camera no longer records a black flicker at the start of a recording and it no longer flickers!

Related [#1542](https://github.com/react-native-community/react-native-camera/pull/1542), [#1857](https://github.com/react-native-community/react-native-camera/pull/1857), 