### PR TITLE
feat: added inverted gv barcode scanning

### DIFF
--- a/android/src/main/java/org/reactnative/barcodedetector/RNBarcodeDetector.java
+++ b/android/src/main/java/org/reactnative/barcodedetector/RNBarcodeDetector.java
@@ -9,6 +9,10 @@ import org.reactnative.frame.RNFrame;
 
 public class RNBarcodeDetector {
 
+    public static int NORMAL_MODE = 0;
+    public static int ALTERNATE_MODE = 1;
+    public static int INVERTED_MODE = 2;
+
     private BarcodeDetector mBarcodeDetector = null;
     private ImageDimensions mPreviousDimensions;
     private BarcodeDetector.Builder mBuilder;

--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -33,6 +33,10 @@ public class CameraModule extends ReactContextBaseJavaModule {
   static final int VIDEO_480P = 3;
   static final int VIDEO_4x3 = 4;
 
+  static final int GOOGLE_VISION_BARCODE_MODE_NORMAL = 0;
+  static final int GOOGLE_VISION_BARCODE_MODE_ALTERNATE = 1;
+  static final int GOOGLE_VISION_BARCODE_MODE_INVERTED = 2;
+
   public static final Map<String, Object> VALID_BARCODE_TYPES =
       Collections.unmodifiableMap(new HashMap<String, Object>() {
         {
@@ -118,6 +122,7 @@ public class CameraModule extends ReactContextBaseJavaModule {
         put("GoogleVisionBarcodeDetection", Collections.unmodifiableMap(new HashMap<String, Object>() {
           {
             put("BarcodeType", BarcodeFormatUtils.REVERSE_FORMATS);
+            put("BarcodeMode", getGoogleVisionBarcodeModeConstants());
           }
         }));
       }
@@ -172,6 +177,16 @@ public class CameraModule extends ReactContextBaseJavaModule {
             put("720p", VIDEO_720P);
             put("480p", VIDEO_480P);
             put("4:3", VIDEO_4x3);
+          }
+        });
+      }
+
+      private Map<String, Object> getGoogleVisionBarcodeModeConstants() {
+        return Collections.unmodifiableMap(new HashMap<String, Object>() {
+          {
+            put("NORMAL", GOOGLE_VISION_BARCODE_MODE_NORMAL);
+            put("ALTERNATE", GOOGLE_VISION_BARCODE_MODE_ALTERNATE);
+            put("INVERTED", GOOGLE_VISION_BARCODE_MODE_INVERTED);
           }
         });
       }

--- a/android/src/main/java/org/reactnative/camera/CameraViewManager.java
+++ b/android/src/main/java/org/reactnative/camera/CameraViewManager.java
@@ -164,6 +164,11 @@ public class CameraViewManager extends ViewGroupManager<RNCameraView> {
     view.setGoogleVisionBarcodeType(barcodeType);
   }
 
+  @ReactProp(name = "googleVisionBarcodeMode")
+  public void setGoogleVisionBarcodeMode(RNCameraView view, int barcodeMode) {
+    view.setGoogleVisionBarcodeMode(barcodeMode);
+  }
+
   @ReactProp(name = "textRecognizerEnabled")
   public void setTextRecognizing(RNCameraView view, boolean textRecognizerEnabled) {
     view.setShouldRecognizeText(textRecognizerEnabled);

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -46,6 +46,7 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
 
   private boolean mIsPaused = false;
   private boolean mIsNew = true;
+  private boolean invertImageData = false;
 
   // Concurrency lock for scanners to avoid flooding the runtime
   public volatile boolean barCodeScannerTaskLock = false;
@@ -66,6 +67,7 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
   private int mFaceDetectionLandmarks = RNFaceDetector.NO_LANDMARKS;
   private int mFaceDetectionClassifications = RNFaceDetector.NO_CLASSIFICATIONS;
   private int mGoogleVisionBarCodeType = Barcode.ALL_FORMATS;
+  private int mGoogleVisionBarCodeMode = RNBarcodeDetector.NORMAL_MODE;
 
   public RNCameraView(ThemedReactContext themedReactContext) {
     super(themedReactContext, true);
@@ -144,6 +146,16 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
 
         if (willCallGoogleBarcodeTask) {
           googleBarcodeDetectorTaskLock = true;
+          if (mGoogleVisionBarCodeMode == RNBarcodeDetector.ALTERNATE_MODE) {
+            invertImageData = !invertImageData;
+          } else if (mGoogleVisionBarCodeMode == RNBarcodeDetector.INVERTED_MODE) {
+            invertImageData = true;
+          }
+          if (invertImageData) {
+            for (int y = 0; y < data.length; y++) {
+              data[y] = (byte) ~data[y];
+            }
+          }
           BarcodeDetectorAsyncTaskDelegate delegate = (BarcodeDetectorAsyncTaskDelegate) cameraView;
           new BarcodeDetectorAsyncTask(delegate, mGoogleBarcodeDetector, data, width, height, correctRotation).execute();
         }
@@ -399,6 +411,10 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
     if (mGoogleBarcodeDetector != null) {
       mGoogleBarcodeDetector.setBarcodeType(barcodeType);
     }
+  }
+
+  public void setGoogleVisionBarcodeMode(int barcodeMode) {
+    mGoogleVisionBarCodeMode = barcodeMode;
   }
 
   public void onBarcodesDetected(SparseArray<Barcode> barcodesReported, int sourceWidth, int sourceHeight, int sourceRotation) {

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -349,6 +349,16 @@ Example: `<RNCamera barCodeTypes={[RNCamera.Constants.BarCodeType.qr]} />`
 
 Like `onBarCodeRead`, but we will use Google Play Service Vision to scan barcodes, which is pretty fast on Android. Note: If you already set `onBarCodeRead`, this will be invalid.
 
+#### `Android` `googleVisionBarcodeType`
+
+Like `barCodeTypes`, but applies to the Google Play Service Vision barcode detector.
+Example: `<RNCamera googleVisionBarcodeType={RNCamera.Constants.GoogleVisionBarcodeDetection.BarcodeType.DATA_MATRIX} />`
+
+#### `Android` `googleVisionBarcodeMode`
+
+Change the mode in order to scan "inverted" barcodes. You can either change it to `alternate`, which will inverted the image data every second screen and be able to read both normal and inverted barcodes, or `inverted`, which will only read inverted barcodes.  Default is `normal`, which only reads "normal" barcodes. Note: this property only applies to the Google Vision barcode detector.
+Example: `<RNCamera googleVisionBarcodeMode={RNCamera.Constants.GoogleVisionBarcodeDetection.BarcodeMode.ALTERNATE} />`
+
 ### Face Detection Related props
 
 RNCamera uses the Google Mobile Vision frameworks for Face Detection, you can read more info about it [here](https://developers.google.com/android/reference/com/google/android/gms/vision/face/FaceDetector).

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -90,6 +90,7 @@ type PropsType = typeof View.props & {
   flashMode?: number | string,
   barCodeTypes?: Array<string>,
   googleVisionBarcodeType?: number,
+  googleVisionBarcodeMode?: number,
   whiteBalance?: number | string,
   faceDetectionLandmarks?: number,
   autoFocus?: string | boolean | number,
@@ -143,6 +144,7 @@ const CameraManager: Object = NativeModules.RNCameraManager ||
     },
     GoogleVisionBarcodeDetection: {
       BarcodeType: 0,
+      BarcodeMode: 0,
     },
   };
 
@@ -193,6 +195,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     faceDetectionClassifications: PropTypes.number,
     barCodeTypes: PropTypes.arrayOf(PropTypes.string),
     googleVisionBarcodeType: PropTypes.number,
+    googleVisionBarcodeMode: PropTypes.number,
     type: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     flashMode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     whiteBalance: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -223,6 +226,8 @@ export default class Camera extends React.Component<PropsType, StateType> {
     barCodeTypes: Object.values(CameraManager.BarCodeType),
     googleVisionBarcodeType: ((CameraManager.GoogleVisionBarcodeDetection || {}).BarcodeType || {})
       .None,
+    googleVisionBarcodeMode: ((CameraManager.GoogleVisionBarcodeDetection || {}).BarcodeMode || {})
+      .NORMAL,
     faceDetectionLandmarks: ((CameraManager.FaceDetection || {}).Landmarks || {}).none,
     faceDetectionClassifications: ((CameraManager.FaceDetection || {}).Classifications || {}).none,
     permissionDialogTitle: '',
@@ -442,6 +447,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
 
     if (Platform.OS === 'ios') {
       delete newProps.googleVisionBarcodeType;
+      delete newProps.googleVisionBarcodeMode;
       delete newProps.googleVisionBarcodeDetectorEnabled;
       delete newProps.ratio;
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,6 +33,7 @@ type GoogleVisionBarcodeType = Readonly<{
     CODE_128: any, CODE_39: any, CODABAR: any, DATA_MATRIX: any, EAN_13: any, EAN_8: any,
     ITF: any, QR_CODE: any, UPC_A: any, UPC_E: any, PDF417: any, AZTEC: any
 }>;
+type GoogleVisionBarcodeMode = Readonly<{ NORMAL: any, ALTERNATE: any, INVERTED: any }>
 
 // FaCC (Function as Child Components)
 type Self<T> = { [P in keyof T]: P }
@@ -57,7 +58,8 @@ export interface Constants {
         Mode: FaceDetectionMode;
     },
     GoogleVisionBarcodeDetection: {
-        BarcodeType: GoogleVisionBarcodeType
+        BarcodeType: GoogleVisionBarcodeType;
+        BarcodeMode: GoogleVisionBarcodeMode;
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to scan inverted barcodes when using the Google Vision barcode detector through two additional "modes", `inverted`, `alternate` and `normal` (default). 

- `inverted`: each image will be inverted before being passed to the barcode detector. In this case only "inverted" barcodes can be detected.
- `alternate`: each second frame will be inverted before being passed to the barcode detector. This mode will detect both "normal" and "inverted" barcodes.

When no mode is provided the barcode scanner behaves like normal and only "normal" barcodes can be detected.