### PR TITLE
Return raw barcode data if available

### DIFF
--- a/android/src/main/java/org/reactnative/camera/events/BarCodeReadEvent.java
+++ b/android/src/main/java/org/reactnative/camera/events/BarCodeReadEvent.java
@@ -12,6 +12,7 @@ import com.google.zxing.Result;
 import com.google.zxing.ResultPoint;
 
 import java.util.Date;
+import java.util.Formatter;
 
 public class BarCodeReadEvent extends Event<BarCodeReadEvent> {
   private static final Pools.SynchronizedPool<BarCodeReadEvent> EVENTS_POOL =
@@ -68,6 +69,14 @@ public class BarCodeReadEvent extends Event<BarCodeReadEvent> {
 
     event.putInt("target", getViewTag());
     event.putString("data", mBarCode.getText());
+
+    Formatter formatter = new Formatter();
+    for (byte b : mBarCode.getRawBytes()) {
+      formatter.format("%02x", b);
+    }
+    event.putString("rawData", formatter.toString());
+    formatter.close();
+
     event.putString("type", mBarCode.getBarcodeFormat().toString());
     WritableArray resultPoints = Arguments.createArray();
     ResultPoint[] points = mBarCode.getResultPoints();

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -319,7 +319,10 @@ Function to be called when native code emit onPictureTaken event, when camera ha
 
 Will call the specified method when a barcode is detected in the camera's view.
 
-Event contains `data` (the data in the barcode) and `type` (the type of the barcode detected).
+Event contains the following fields
+- `data` - a textual representation of the barcode, if available
+- `rawData` - The raw data encoded in the barcode, if available
+- `type` - the type of the barcode detected
 
 The following barcode types can be recognised:
 
@@ -336,8 +339,6 @@ The following barcode types can be recognised:
 - `interleaved2of5` (when available)
 - `itf14` (when available)
 - `datamatrix` (when available)
-
-The barcode type is provided in the `data` object.
 
 
 #### `barCodeTypes`

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -864,22 +864,58 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             for (id barcodeType in self.barCodeTypes) {
                 if ([metadata.type isEqualToString:barcodeType]) {
                     AVMetadataMachineReadableCodeObject *transformed = (AVMetadataMachineReadableCodeObject *)[_previewLayer transformedMetadataObjectForMetadataObject:metadata];
-                    NSDictionary *event = @{
-                                            @"type" : codeMetadata.type,
-                                            @"data" : codeMetadata.stringValue,
-                                            @"bounds": @{
-                                                @"origin": @{
-                                                    @"x": [NSString stringWithFormat:@"%f", transformed.bounds.origin.x],
-                                                    @"y": [NSString stringWithFormat:@"%f", transformed.bounds.origin.y]
-                                                },
-                                                @"size": @{
-                                                    @"height": [NSString stringWithFormat:@"%f", transformed.bounds.size.height],
-                                                    @"width": [NSString stringWithFormat:@"%f", transformed.bounds.size.width]
-                                                }
-                                            }
-                                            };
+                    NSMutableDictionary *event = [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"type" : codeMetadata.type,
+                        @"data" : [NSNull null],
+                        @"rawData" : [NSNull null],
+                        @"bounds": @{
+                            @"origin": @{
+                                    @"x": [NSString stringWithFormat:@"%f", transformed.bounds.origin.x],
+                                    @"y": [NSString stringWithFormat:@"%f", transformed.bounds.origin.y]
+                                    },
+                            @"size": @{
+                                    @"height": [NSString stringWithFormat:@"%f", transformed.bounds.size.height],
+                                    @"width": [NSString stringWithFormat:@"%f", transformed.bounds.size.width]
+                                    }
+                            }
+                        }
+                    ];
 
-                    [self onCodeRead:event];
+                    NSData *rawData;
+                    // If we're on ios11 then we can use `descriptor` to access the raw data of the barcode.
+                    // If we're on an older version of iOS we're stuck using valueForKeyPath to peak at the
+                    // data.
+                    if (@available(iOS 11, *)) {
+                        // descriptor is a CIBarcodeDescriptor which is an abstract base class with no useful fields.
+                        // in practice it's a subclass, many of which contain errorCorrectedPayload which is the data we
+                        // want. Instead of individually checking the class types, just duck type errorCorrectedPayload
+                        if ([codeMetadata.descriptor respondsToSelector:@selector(errorCorrectedPayload)]) {
+                            rawData = [codeMetadata.descriptor performSelector:@selector(errorCorrectedPayload)];
+                        }
+                    } else {
+                        rawData = [codeMetadata valueForKeyPath:@"_internal.basicDescriptor.BarcodeRawData"];
+                    }
+
+                    // Now that we have the raw data of the barcode translate it into a hex string to pass to the JS
+                    const unsigned char *dataBuffer = (const unsigned char *)[rawData bytes];
+                    if (dataBuffer) {
+                        NSMutableString     *rawDataHexString  = [NSMutableString stringWithCapacity:([rawData length] * 2)];
+                        for (int i = 0; i < [rawData length]; ++i) {
+                            [rawDataHexString appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)dataBuffer[i]]];
+                        }
+                        [event setObject:[NSString stringWithString:rawDataHexString] forKey:@"rawData"];
+                    }
+
+                    // If we were able to extract a string representation of the barcode, attach it to the event as well
+                    // else just send null along.
+                    if (codeMetadata.stringValue) {
+                        [event setObject:codeMetadata.stringValue forKey:@"data"];
+                    }
+
+                    // Only send the event if we were able to pull out a binary or string representation
+                    if ([event objectForKey:@"data"] != [NSNull null] || [event objectForKey:@"rawData"] != [NSNull null]) {
+                        [self onCodeRead:event];
+                    }
                 }
             }
         }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -89,6 +89,7 @@ export interface RNCameraProps {
     googleVisionBarcodeType?: keyof GoogleVisionBarcodeType;
     onBarCodeRead?(event: {
         data: string,
+        rawData?: string,
         type: keyof BarCodeType,
         /**
          * @description For Android use `[Point<string>, Point<string>]`


### PR DESCRIPTION
Currently on iOS if you scan a barcode that doesn't have a textual representation such as 

![Bad QR code](https://cl.ly/dce74f42d237/bad-qr.png)

The app will crash. This is obviously not the desired behavior, there should never be a situation where a user can scan something that causes the app to crash, especially when it's a _valid_ barcode. 

This issue has come up a few times, such as #1292, #926 and #691.

At the bare minimum we should check for `stringValue` to exist so we don't _crash_. That said, this isn't super useful for those of us who actually want to scan these (valid) barcodes. Better would be to return the raw barcode data if it exists, so even if it doesn't have a valid string representation the consumer can still read handle it as they'd like. 

This PR does just that. In android it's pretty straightforward since ZXing exposes `getRawBytes` to get well, the raw bytes. In iOS it's a fair bit more rigamarole. In iOS11+ we can use [CIBarcodeDescriptor](https://developer.apple.com/documentation/coreimage/cibarcodedescriptor?language=objc)'s subclasses to access `errorCorrectedPayload`, which is the data we want. On earlier versions we have to peak into the `AVMetadataMachineReadableCodeObject` internals which is a little annoying, but not [without](https://stackoverflow.com/a/36957666) [precedent](https://github.com/behestee/cordova-plugin-multipartqrcodescanner/blob/master/src/ios/CDVBarcodeScanner.mm#L604). 

Tested that the barcodes that previously failed to scan now scan properly. Additionally tested barcodes in formats that wouldn't have rawData (such as `code39`) to ensure we're backwards compatible.

I'm not an expert in Objective C/Java best practices to happy to make any changes if there are better ways to write anything. 