### PR TITLE
Add the types for defaultVideoQuality

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -123,6 +123,7 @@ export interface RNCameraProps {
 
     /** iOS Only */
     captureAudio?: boolean;
+    defaultVideoQuality?: keyof VideoQuality;
 }
 
 interface Point<T = number> {


### PR DESCRIPTION
In a half hearted attempt to fix #1900 I wanted to try to configure the default video quality using the new prop (`defaultVideoQuality`) that was introduced in #1886, but it's not defined in the typescript definition file. 

This PR just adds the types. Should have no impact on anything since it's just a change to the type definitions, so as long as it seems to correctly define the API was added in #1886. 