### PR TITLE
Fix default resolution on iOS

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -43,7 +43,7 @@
 @property (nonatomic, assign) BOOL canReadText;
 @property(assign, nonatomic) AVVideoCodecType videoCodecType;
 @property (assign, nonatomic) AVCaptureVideoStabilizationMode videoStabilizationMode;
-@property(assign, nonatomic) NSInteger defaultVideoQuality;
+@property(assign, nonatomic, nullable) NSNumber *defaultVideoQuality;
 
 - (id)initWithBridge:(RCTBridge *)bridge;
 - (void)updateType;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -605,7 +605,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             return;
         }
 
-        AVCaptureSessionPreset preset = [RNCameraUtils captureSessionPresetForVideoResolution:[self defaultVideoQuality]];
+        // Default video quality AVCaptureSessionPresetHigh if non is provided
+        AVCaptureSessionPreset preset = ([self defaultVideoQuality]) ? [RNCameraUtils captureSessionPresetForVideoResolution:[[self defaultVideoQuality] integerValue]] : AVCaptureSessionPresetHigh;
+
         self.session.sessionPreset = preset == AVCaptureSessionPresetHigh ? AVCaptureSessionPresetPhoto: preset;
 
         AVCaptureStillImageOutput *stillImageOutput = [[AVCaptureStillImageOutput alloc] init];

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -246,7 +246,7 @@ RCT_CUSTOM_VIEW_PROPERTY(textRecognizerEnabled, BOOL, RNCamera)
 
 RCT_CUSTOM_VIEW_PROPERTY(defaultVideoQuality, NSInteger, RNCamera)
 {
-    [view setDefaultVideoQuality:(NSInteger) [RCTConvert NSInteger:json]];
+    [view setDefaultVideoQuality: [NSNumber numberWithInteger:[RCTConvert NSInteger:json]]];
 }
 
 RCT_REMAP_METHOD(takePicture,


### PR DESCRIPTION
I believe this is the fix to #1900, fixing a bug that was introduced in #1886. 

The root of the issue is that [this enum](https://github.com/react-native-community/react-native-camera/blob/master/ios/RN/RNCameraManager.h#L50-L56) for video resolution defines `0` as `RNCameraVideo2160p`, and `defaultVideoQuality` was an Integer, so if it was not set it was mapping to `0` and thus to `RNCameraVideo2160p`, causing any user of this library who didn't pass in an explicit `defaultVideoQuality` to request `AVCaptureSessionPreset3840x2160` which is far higher than many iOS cameras support, leading to the `AVCaptureSessionPreset3840x2160 is not a supported preset` error. 

This is starting to stretch both my knowledge of Objective C best practices and `react-native-camera` design decisions, but I attempted to fix this issue by switching to use `NSNumber` and then explicitly checking for it being `NULL` when when we set the sessionPreset, thereby only setting it if it's been explicitly set by the consumer. 

Not sure if there's a better way to do this? Have tested it and confirmed (with the debugger) that
- If you do not provide a `defaultVideoQuality` prop that we fall back to `AVCaptureSessionPresetHigh` (which we then convert to `AVCaptureSessionPresetPhoto` for reasons beyond me)
- If you provide a valid `defaultVideoQuality` prop, we use that instead. 

Fixes #1900