### PR TITLE
Fix for useCamera2Api

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -1053,8 +1053,8 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
                         public void onCaptureCompleted(@NonNull CameraCaptureSession session,
                                 @NonNull CaptureRequest request,
                                 @NonNull TotalCaptureResult result) {
-                            if (mCaptureCallback.getOptions().hasKey("stopPreviewAfterCapture")
-                              && !mCaptureCallback.getOptions().getBoolean("stopPreviewAfterCapture")) {
+                            if (mCaptureCallback.getOptions().hasKey("pauseAfterCapture")
+                              && !mCaptureCallback.getOptions().getBoolean("pauseAfterCapture")) {
                                 unlockFocus();
                             }
                         }

--- a/android/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraView.java
@@ -273,10 +273,7 @@ public class CameraView extends FrameLayout {
             }
             mImpl = new Camera1(mCallbacks, mImpl.mPreview);
         }
-        onRestoreInstanceState(state);
-        if (wasOpened) {
-            start();
-        }
+        start();
     }
 
     /**


### PR DESCRIPTION
Fixes the issue which lead to a crash by using useCamera2Api Prop, which was caused by setPictureSize() before view was startet and not initialized. Furthermore this PR fixes the stopPreviewAfterCapture Key to pauseAfterCapture which caused the Camera2 to freeze after takePicture, even if pauseAfterCapture was set to false.
#1837
Maybe related: #1910