### PR TITLE
[WIP] Adds defaultMuted prop to help with flickering

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -296,8 +296,18 @@ This option specifies the quality of the video to be taken. The possible values 
     - `android` Not supported.
 
 If nothing is passed the device's highest camera quality will be used as default.
-Note: This solve the flicker video recording issue for iOS
 
+Note: This can help with flickering when calling `recordAsync`.
+
+### `iOS` `defaultMuted`
+
+This option is a hint to the component about whether or not it will be used to capture audio.
+
+Values: `true` (default) or `false`
+
+If `true`, the audio input will not be added to the `AVCaptureSession`. If `false`, the audio input will be preemptively added to the `AVCaptureSession`.
+
+Note: This can help with flickering when calling `recordAsync`.
 
 ### Native Event callbacks props
 

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -44,6 +44,7 @@
 @property(assign, nonatomic) AVVideoCodecType videoCodecType;
 @property (assign, nonatomic) AVCaptureVideoStabilizationMode videoStabilizationMode;
 @property(assign, nonatomic, nullable) NSNumber *defaultVideoQuality;
+@property(assign, nonatomic) BOOL defaultMuted;
 
 - (id)initWithBridge:(RCTBridge *)bridge;
 - (void)updateType;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -606,7 +606,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         }
 
         // Default video quality AVCaptureSessionPresetHigh if non is provided
-        AVCaptureSessionPreset preset = ([self defaultVideoQuality]) ? [RNCameraUtils captureSessionPresetForVideoResolution:[[self defaultVideoQuality] integerValue]] : AVCaptureSessionPresetHigh;
+        AVCaptureSessionPreset preset = ([self defaultVideoQuality]) ? [RNCameraUtils captureSessionPresetForVideoResolution:[self defaultVideoQuality]] : AVCaptureSessionPresetHigh;
 
         self.session.sessionPreset = preset == AVCaptureSessionPresetHigh ? AVCaptureSessionPresetPhoto: preset;
 

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -937,6 +937,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
     if ([self.session canAddOutput:movieFileOutput]) {
         [self.session addOutput:movieFileOutput];
+        [self updateSessionAudioIsMuted:self.defaultMuted];
         self.movieFileOutput = movieFileOutput;
     }
 }

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -249,6 +249,11 @@ RCT_CUSTOM_VIEW_PROPERTY(defaultVideoQuality, NSInteger, RNCamera)
     [view setDefaultVideoQuality: [NSNumber numberWithInteger:[RCTConvert NSInteger:json]]];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(defaultMuted, BOOL, RNCamera)
+{
+    view.defaultMuted = [RCTConvert BOOL:json];
+}
+
 RCT_REMAP_METHOD(takePicture,
                  options:(NSDictionary *)options
                  reactTag:(nonnull NSNumber *)reactTag

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -213,6 +213,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     pictureSize: PropTypes.string,
     mirrorVideo: PropTypes.bool,
     defaultVideoQuality: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    defaultMuted: PropTypes.bool,
   };
 
   static defaultProps: Object = {
@@ -249,6 +250,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     pictureSize: 'None',
     videoStabilizationMode: 0,
     mirrorVideo: false,
+    defaultMuted: true,
   };
 
   _cameraRef: ?Object;


### PR DESCRIPTION
See https://github.com/react-native-community/react-native-camera/issues/1934#issuecomment-440963828 and https://github.com/react-native-community/react-native-camera/issues/1934#issuecomment-440966283

This is a work in progress.

- [x] Add `defaultMuted` prop and use it on initial session setup
- [x] Add `defaultMuted` documentation
- [x] Determine cause of flicker on first `stopRecording` and fix it
- [ ] Look into handling change of `defaultMuted` and `defaultVideoQuality` values

Refs #1934