### PR TITLE
Adds typing to CameraStatus constant

### DIFF
--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -111,7 +111,7 @@ type StateType = {
   isAuthorizationChecked: boolean,
 };
 
-type Status = 'READY' | 'PENDING_AUTHORIZATION' | 'NOT_AUTHORIZED';
+export type Status = 'READY' | 'PENDING_AUTHORIZATION' | 'NOT_AUTHORIZED';
 
 const CameraStatus: { [key: Status]: Status } = {
   READY: 'READY',

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -113,7 +113,7 @@ type StateType = {
 
 type Status = 'READY' | 'PENDING_AUTHORIZATION' | 'NOT_AUTHORIZED';
 
-const CameraStatus = {
+const CameraStatus: : { [key: Status]: Status } = {
   READY: 'READY',
   PENDING_AUTHORIZATION: 'PENDING_AUTHORIZATION',
   NOT_AUTHORIZED: 'NOT_AUTHORIZED',

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -113,7 +113,7 @@ type StateType = {
 
 type Status = 'READY' | 'PENDING_AUTHORIZATION' | 'NOT_AUTHORIZED';
 
-const CameraStatus: : { [key: Status]: Status } = {
+const CameraStatus: { [key: Status]: Status } = {
   READY: 'READY',
   PENDING_AUTHORIZATION: 'PENDING_AUTHORIZATION',
   NOT_AUTHORIZED: 'NOT_AUTHORIZED',

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Camera from './Camera';
-import RNCamera, { type Status as CameraStatus } from './RNCamera';
+import RNCamera, { type Status as _CameraStatus } from './RNCamera';
 import FaceDetector from './FaceDetector';
 
 export type CameraStatus = _CameraStatus;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import Camera from './Camera';
 import RNCamera, { type Status as CameraStatus } from './RNCamera';
 import FaceDetector from './FaceDetector';
 
-export type CameraStatus = CameraStatus;
+export type CameraStatus = _CameraStatus;
 export { RNCamera, FaceDetector };
 
 export default Camera;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import Camera from './Camera';
 import RNCamera, { type Status as CameraStatus } from './RNCamera';
 import FaceDetector from './FaceDetector';
 
-export type CameraStatus;
+export type CameraStatus = CameraStatus;
 export { RNCamera, FaceDetector };
 
 export default Camera;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
+// @flow
+
 import Camera from './Camera';
-import RNCamera from './RNCamera';
+import RNCamera, { type Status as CameraStatus } from './RNCamera';
 import FaceDetector from './FaceDetector';
 
+export type CameraStatus;
 export { RNCamera, FaceDetector };
 
 export default Camera;


### PR DESCRIPTION
This provides the ability to use the `Status` type from consumers of `react-native-camera` like this:
```
type SomethingWithCameraStatus = {
  status: $Values<typeof RNCamera.Constants.CameraStatus>
};
```
It would be nice to export the `Status` type directly, but it seems like that's being intentionally avoided? Either way, this typing of `CameraStatus` is probably a good thing.