### PR TITLE
Android autoFocusPointOfInterest, Camera & Camera2

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraView.java
@@ -18,6 +18,8 @@ package com.google.android.cameraview;
 
 import android.app.Activity;
 import android.content.Context;
+import android.graphics.Rect;
+import android.hardware.Camera;
 import android.media.CamcorderProfile;
 import android.os.Build;
 import android.os.Parcel;
@@ -29,6 +31,7 @@ import android.support.v4.os.ParcelableCompat;
 import android.support.v4.os.ParcelableCompatCreatorCallbacks;
 import android.support.v4.view.ViewCompat;
 import android.util.AttributeSet;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.graphics.SurfaceTexture;
@@ -491,6 +494,16 @@ public class CameraView extends FrameLayout {
      */
     public int getCameraOrientation() {
         return mImpl.getCameraOrientation();
+    }
+    
+    /**
+     * Sets the auto focus point.
+     *
+     * @param x sets the x coordinate for camera auto focus
+     * @param y sets the y coordinate for camera auto focus
+     */
+    public void setAutoFocusPointOfInterest(float x, float y) {
+        mImpl.setFocusArea(x, y);
     }
 
     public void setFocusDepth(float value) {

--- a/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
@@ -92,6 +92,8 @@ abstract class CameraViewImpl {
     abstract void setDisplayOrientation(int displayOrientation);
 
     abstract void setDeviceOrientation(int deviceOrientation);
+    
+    abstract void setFocusArea(float x, float y);
 
     abstract void setFocusDepth(float value);
 

--- a/android/src/main/java/org/reactnative/camera/CameraViewManager.java
+++ b/android/src/main/java/org/reactnative/camera/CameraViewManager.java
@@ -2,6 +2,7 @@ package org.reactnative.camera;
 
 import android.support.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -95,6 +96,13 @@ public class CameraViewManager extends ViewGroupManager<RNCameraView> {
   @ReactProp(name = "focusDepth")
   public void setFocusDepth(RNCameraView view, float depth) {
     view.setFocusDepth(depth);
+  }
+
+  @ReactProp(name = "autoFocusPointOfInterest")
+  public void setAutoFocusPointOfInterest(RNCameraView view, ReadableMap coordinates) {
+    float x = (float) coordinates.getDouble("x");
+    float y = (float) coordinates.getDouble("y");
+    view.setAutoFocusPointOfInterest(x, y);
   }
 
   @ReactProp(name = "zoom")

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -179,13 +179,16 @@ Most cameras have a Auto Focus feature. It adjusts your camera lens position aut
 
 Use the `autoFocus` property to specify the auto focus setting of your camera. `RNCamera.Constants.AutoFocus.on` turns it ON, `RNCamera.Constants.AutoFocus.off` turns it OFF.
 
-#### `iOS` `autoFocusPointOfInterest`
+#### `autoFocusPointOfInterest`
 
 Values: Object `{ x: 0.5, y: 0.5 }`.
 
 Setting this property causes the auto focus feature of the camera to attempt to focus on the part of the image at this coordiate.
 
 Coordinates values are measured as floats from `0` to `1.0`. `{ x: 0, y: 0 }` will focus on the top left of the image, `{ x: 1, y: 1 }` will be the bottom right. Values are based on landscape mode with the home button on the right—this applies even if the device is in portrait mode.
+
+Hint:
+for portrait orientation, apply 90° clockwise rotation + translation: [Example](https://gist.github.com/Craigtut/6632a9ac7cfff55e74fb561862bc4edb)
 
 #### `captureAudio`
 


### PR DESCRIPTION
Updates both android's Camera & Camera2 to match the autoFocusPointOfInterest prop supported on iOS.  

Most of the updates are pieced together from various sources as my experience with Android doesn't run incredibly deep. Camera 2's version works but could use a bit more work on it.

Also updates the docs to support changes.