### PR TITLE
Change play-services-vision version.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ dependencies {
   compileOnly 'com.facebook.infer.annotation:infer-annotation:+'
   implementation "com.google.zxing:core:3.3.0"
   implementation "com.drewnoakes:metadata-extractor:2.9.1"
-  implementation "com.google.android.gms:play-services-vision:${safeExtGet('googlePlayServicesVersion', '15.0.2')}"
+  implementation "com.google.android.gms:play-services-vision:${safeExtGet('googlePlayServicesVisionVersion', '15.0.2')}"
   implementation "com.android.support:exifinterface:${safeExtGet('supportLibVersion', '27.1.0')}"
   implementation "com.android.support:support-annotations:${safeExtGet('supportLibVersion', '27.1.0')}"
   implementation "com.android.support:support-v4:${safeExtGet('supportLibVersion', '27.1.0')}"


### PR DESCRIPTION
According to https://developers.google.com/android/guides/releases
>Google Play services libraries after 15.0.0 now have independent version numbers which follow SemVer. This change will allow for more frequent, flexible updates by individual components.

To avoid compilation errors with new google play service versions.