### PR TITLE
fix(android): use device orientation for images/videos instead of display orientation

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -718,7 +718,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
      * @return Number of degrees to rotate image in order for it to view correctly.
      */
     private int calcCameraRotation(int screenOrientationDegrees) {
-       if (mCameraInfo.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+       if (mCameraInfo.facing == Camera.CameraInfo.CAMERA_FACING_BACK) {
            return (mCameraInfo.orientation + screenOrientationDegrees) % 360;
        }
        // back-facing

--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -233,6 +233,8 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
 
     private int mDisplayOrientation;
 
+    private int mDeviceOrientation;
+
     private float mFocusDepth;
 
     private float mZoom;
@@ -616,6 +618,13 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
     void setDisplayOrientation(int displayOrientation) {
         mDisplayOrientation = displayOrientation;
         mPreview.setDisplayOrientation(mDisplayOrientation);
+    }
+
+
+    @Override
+    void setDeviceOrientation(int deviceOrientation) {
+        mDeviceOrientation = deviceOrientation;
+        mPreview.setDisplayOrientation(mDeviceOrientation);
     }
 
     /**

--- a/android/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraView.java
@@ -119,8 +119,9 @@ public class CameraView extends FrameLayout {
         // Display orientation detector
         mDisplayOrientationDetector = new DisplayOrientationDetector(context) {
             @Override
-            public void onDisplayOrientationChanged(int displayOrientation) {
+            public void onDisplayOrientationChanged(int displayOrientation, int deviceOrientation) {
                 mImpl.setDisplayOrientation(displayOrientation);
+                mImpl.setDeviceOrientation(deviceOrientation);
             }
         };
     }

--- a/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
@@ -85,6 +85,8 @@ abstract class CameraViewImpl {
 
     abstract void setDisplayOrientation(int displayOrientation);
 
+    abstract void setDeviceOrientation(int deviceOrientation);
+
     abstract void setFocusDepth(float value);
 
     abstract float getFocusDepth();

--- a/android/src/main/java/com/google/android/cameraview/DisplayOrientationDetector.java
+++ b/android/src/main/java/com/google/android/cameraview/DisplayOrientationDetector.java
@@ -44,6 +44,8 @@ abstract class DisplayOrientationDetector {
 
     private int mLastKnownDisplayOrientation = 0;
 
+    private int mLastKnownDeviceOrientation = 0;
+
     public DisplayOrientationDetector(Context context) {
         mOrientationEventListener = new OrientationEventListener(context) {
 
@@ -56,9 +58,35 @@ abstract class DisplayOrientationDetector {
                         mDisplay == null) {
                     return;
                 }
+                boolean hasChanged = false;
+
+                /** set device orientation */
+                final int deviceOrientation;
+                if (orientation > 315 || orientation < 45) {
+                    deviceOrientation = 0;
+                } else if (orientation > 45 && orientation < 135) {
+                    deviceOrientation = 90;
+                } else if (orientation > 135 && orientation < 225) {
+                    deviceOrientation = 180;
+                } else if (orientation > 225 && orientation < 315) {
+                    deviceOrientation = 270;
+                } else {
+                    deviceOrientation = 0;
+                }
+
+                 if (mLastKnownDeviceOrientation != deviceOrientation) {
+                    mLastKnownDeviceOrientation = deviceOrientation;
+                    hasChanged = true;
+                }
+
+                 /** set screen orientation */
                 final int rotation = mDisplay.getRotation();
                 if (mLastKnownRotation != rotation) {
                     mLastKnownRotation = rotation;
+                    hasChanged = true;
+                }
+
+                if (hasChanged) {
                     dispatchOnDisplayOrientationChanged(DISPLAY_ORIENTATIONS.get(rotation));
                 }
             }
@@ -83,14 +111,15 @@ abstract class DisplayOrientationDetector {
 
     void dispatchOnDisplayOrientationChanged(int displayOrientation) {
         mLastKnownDisplayOrientation = displayOrientation;
-        onDisplayOrientationChanged(displayOrientation);
+        onDisplayOrientationChanged(displayOrientation, mLastKnownDeviceOrientation);
     }
 
     /**
      * Called when display orientation is changed.
      *
      * @param displayOrientation One of 0, 90, 180, and 270.
+     * @param deviceOrientation One of 0, 90, 180, and 270.
      */
-    public abstract void onDisplayOrientationChanged(int displayOrientation);
+    public abstract void onDisplayOrientationChanged(int displayOrientation, int deviceOrientation);
 
 }


### PR DESCRIPTION
This is my attempt for fixing #1725 based on the work of @Fsarmento (https://github.com/react-native-community/react-native-camera/issues/1725#issuecomment-441599916 https://github.com/react-native-community/react-native-camera/compare/master...Fsarmento:master)

This PR unifies the orientation used for the pictures/video with the `ios` implementation by using the device orientation instead of the display orientation.

**Related:**

Fixes #1725
Closes #1941
Fixes #1053

cc @sibelius @JulienUsson @SimonErm @Tsiniloiv

Could you please test this implementation? I tested all orientations (including when device is locked in portrait mode). But before merging I want at least one more person to test the implementation.