### PR TITLE
fix(android): prevent shutting down camera when re-mounting children

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -214,15 +214,6 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
     // React handles this for us, so we don't need to call super.requestLayout();
   }
 
-  @Override
-  public void onViewAdded(View child) {
-    if (this.getView() == child || this.getView() == null) return;
-    // remove and read view to make sure it is in the back.
-    // @TODO figure out why there was a z order issue in the first place and fix accordingly.
-    this.removeView(this.getView());
-    this.addView(this.getView(), 0);
-  }
-
   public void setBarCodeTypes(List<String> barCodeTypes) {
     mBarCodeTypes = barCodeTypes;
     initBarcodeReader();

--- a/examples/basic/App.js
+++ b/examples/basic/App.js
@@ -203,6 +203,9 @@ export default class CameraScreen extends React.Component {
             )}
           </TouchableOpacity>
         </View>
+        {this.state.zoom !== 0 && (
+          <Text style={[styles.flipText, styles.zoomText]}>Zoom: {this.state.zoom}</Text>
+        )}
         <View
           style={{
             flex: 0.1,
@@ -273,6 +276,12 @@ const styles = StyleSheet.create({
   flipText: {
     color: 'white',
     fontSize: 15,
+  },
+  zoomText: {
+    position: 'absolute',
+    bottom: 70,
+    zIndex: 2,
+    left: 2,
   },
   picButton: {
     backgroundColor: 'darkseagreen',

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -28,9 +28,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontSize: 16,
   },
-  cameraStopPreviewTempFix: {
-    backgroundColor: 'transparent',
-  },
 });
 
 type Orientation = 'auto' | 'landscapeLeft' | 'landscapeRight' | 'portrait' | 'portraitUpsideDown';
@@ -437,32 +434,27 @@ export default class Camera extends React.Component<PropsType, StateType> {
   };
 
   render() {
-    const nativeProps = this._convertNativeProps(this.props);
+    const { style, ...nativeProps } = this._convertNativeProps(this.props);
 
     if (this.state.isAuthorized || this.hasFaCC()) {
       return (
-        <RNCamera
-          {...nativeProps}
-          ref={this._setReference}
-          onMountError={this._onMountError}
-          onCameraReady={this._onCameraReady}
-          onGoogleVisionBarcodesDetected={this._onObjectDetected(
-            this.props.onGoogleVisionBarcodesDetected,
-          )}
-          onBarCodeRead={this._onObjectDetected(this.props.onBarCodeRead)}
-          onFacesDetected={this._onObjectDetected(this.props.onFacesDetected)}
-          onTextRecognized={this._onObjectDetected(this.props.onTextRecognized)}
-          onPictureSaved={this._onPictureSaved}
-        >
-          {/* FIXME:
-           * Re-mounting direct children of RNCamera on Android results in camera shutdown.
-           * As a temporary workaround we wrap children in a View with transparent background.
-           * Reference: https://github.com/react-native-community/react-native-camera/issues/1311
-           */}
-          <View style={[this.props.style, styles.cameraStopPreviewTempFix]}>
-            {this.renderChildren()}
-          </View>
-        </RNCamera>
+        <View style={style}>
+          <RNCamera
+            {...nativeProps}
+            style={StyleSheet.absoluteFill}
+            ref={this._setReference}
+            onMountError={this._onMountError}
+            onCameraReady={this._onCameraReady}
+            onGoogleVisionBarcodesDetected={this._onObjectDetected(
+              this.props.onGoogleVisionBarcodesDetected,
+            )}
+            onBarCodeRead={this._onObjectDetected(this.props.onBarCodeRead)}
+            onFacesDetected={this._onObjectDetected(this.props.onFacesDetected)}
+            onTextRecognized={this._onObjectDetected(this.props.onTextRecognized)}
+            onPictureSaved={this._onPictureSaved}
+          />
+          {this.renderChildren()}
+        </View>
       );
     } else if (!this.state.isAuthorizationChecked) {
       return this.props.pendingAuthorizationView;

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -28,6 +28,9 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontSize: 16,
   },
+  cameraStopPreviewTempFix: {
+    backgroundColor: 'transparent',
+  },
 });
 
 type Orientation = 'auto' | 'landscapeLeft' | 'landscapeRight' | 'portrait' | 'portraitUpsideDown';
@@ -451,7 +454,14 @@ export default class Camera extends React.Component<PropsType, StateType> {
           onTextRecognized={this._onObjectDetected(this.props.onTextRecognized)}
           onPictureSaved={this._onPictureSaved}
         >
-          {this.renderChildren()}
+          {/* FIXME:
+           * Re-mounting direct children of RNCamera on Android results in camera shutdown.
+           * As a temporary workaround we wrap children in a View with transparent background.
+           * Reference: https://github.com/react-native-community/react-native-camera/issues/1311
+           */}
+          <View style={[this.props.style, styles.cameraStopPreviewTempFix]}>
+            {this.renderChildren()}
+          </View>
         </RNCamera>
       );
     } else if (!this.state.isAuthorizationChecked) {


### PR DESCRIPTION
Fixes https://github.com/react-native-community/react-native-camera/issues/1311

There's a bug where re-mounting children without transparent background shuts down the camera on Android (adb on LG G2 shows that `stopPreview` from `QCamera2HWI` gets called, but I couldn't set up debugging to see what's calling it, help appreciated).

By accident I've found a workaround, which involves wrapping children in a transparent view (not sure why `backgroundColor: 'transparent'` plays role here but it does).

As a manual test I've added a previously buggy behavior to example app – pressing zoom in / zoom out will mount/unmount a `Text` node which is a direct child of `RNCamera`.