### PR TITLE
Fix getSupportedRatios is not a function

### DIFF
--- a/examples/basic/App.js
+++ b/examples/basic/App.js
@@ -42,7 +42,7 @@ export default class CameraScreen extends React.Component {
   };
 
   getRatios = async function() {
-    const ratios = await this.camera.getSupportedRatios();
+    const ratios = await this.camera.getSupportedRatiosAsync();
     return ratios;
   };
 


### PR DESCRIPTION
Function does not seem to be used in the example, yet I'm using it as a first step into trying this library out.

The Error Message was:
```
TypeError: undefined is not a function (evaluating 'this.camera.getSupportedRatios()')
```

The correct function seems to have Async appended as shown in https://github.com/react-native-community/react-native-camera/issues/1280#issuecomment-368644836