### PR TITLE
Feature: Add method refreshAuthorizationStatus allowing to refresh authorization status of Camera

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -528,6 +528,11 @@ The promise will be fulfilled with an object with some of the following properti
 
 - `iOS` `codec`: the codec of the recorded video. One of `RNCamera.Constants.VideoCodec`
 
+#### `refreshAuthorizationStatus: Promise<void>`
+
+Allows to make RNCamera check Permissions again and set status accordingly.  
+Making it possible to refresh status of RNCamera after user initially rejected the permissions.
+
 #### `stopRecording: void`
 
 Should be called after recordAsync() to make the promise be fulfilled and get the video uri.

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -504,20 +504,43 @@ export default class Camera extends React.Component<PropsType, StateType> {
     this._isMounted = false;
   }
 
-  async componentDidMount() {
+  async arePermissionsGranted() {
     const { hasCameraPermissions, hasRecordAudioPermissions } = await requestPermissions(
       this.props.captureAudio,
       CameraManager,
       this.props.permissionDialogTitle,
       this.props.permissionDialogMessage,
     );
+    const recordAudioPermissionStatus = hasRecordAudioPermissions
+      ? RecordAudioPermissionStatusEnum.AUTHORIZED
+      : RecordAudioPermissionStatusEnum.NOT_AUTHORIZED;
+    return { hasCameraPermissions, recordAudioPermissionStatus };
+  }
+
+  async refreshAuthorizationStatus() {
+    const {
+      hasCameraPermissions,
+      recordAudioPermissionStatus,
+    } = await this.arePermissionsGranted();
     if (this._isMounted === false) {
       return;
     }
 
-    const recordAudioPermissionStatus = hasRecordAudioPermissions
-      ? RecordAudioPermissionStatusEnum.AUTHORIZED
-      : RecordAudioPermissionStatusEnum.NOT_AUTHORIZED;
+    this.setState({
+      isAuthorized: hasCameraPermissions,
+      isAuthorizationChecked: true,
+      recordAudioPermissionStatus,
+    });
+  }
+
+  async componentDidMount() {
+    const {
+      hasCameraPermissions,
+      recordAudioPermissionStatus,
+    } = await this.arePermissionsGranted();
+    if (this._isMounted === false) {
+      return;
+    }
 
     this.setState({
       isAuthorized: hasCameraPermissions,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -293,6 +293,7 @@ export class RNCamera extends Component<RNCameraProps & ViewProperties> {
 
   takePictureAsync(options?: TakePictureOptions): Promise<TakePictureResponse>;
   recordAsync(options?: RecordOptions): Promise<RecordResponse>;
+  refreshAuthorizationStatus(): Promise<void>;
   stopRecording(): void;
   pausePreview(): void;
   resumePreview(): void;


### PR DESCRIPTION
Hello,

First of all thanks for maintaining this library and effort that was put it into. We are using this library in one of our projects and at one pointed I have came across obstacle that seemed to me as impossible to resolve without forking.
After forking, I have added my own functionality and decided that it might be worth to share it, **please note that this PR might resolve a situation which can already be handled some other way but I have failed to come up with different solution - if you aware of any other possible fixes, please let me know.**

### What was happening and why I have thought that this change of code was necessary for me:
We had a view where we mounted `RNCamera` and children by using `FaCC` which worked great during typical happy path: `All permissions accepted by the user`.
After awhile we have begun testing all other paths, mostly the situation where things are happening in such order:  
1. User opens the view
2. No permissions have been granted yet
3. RNCamera is mounted for the first time, ask user for permissions
4. Decline permissions
5. Camera is showing `NotAuthorizedView` so it is all nice
6. Have a separate button that show Android Permissions Dialog once more, hoping that user will accept permissions this time around
7. User accepts permissions
8. Status of `RNCamera` returned in `FaCC` is still not `READY`

So at that point user eventually accepted the permissions but there was no way to make `RNCamera` notice that since `isAuthorized` is only set during `componentDidMount` life cycle method and since the view has not remounted that component then it won't spot the difference in permissions.
Of course closing the view and opening it once more, make recording work because `RNCamera` was mounted again.

At that point, I started to look through code to see if there is a way to update component `isAuthorized` - I haven't found a way except for remounting which could not work very well for us.
So I have added that new method - `refreshAuthorizationStatus` and called it after having permissions granted via:
`await this.camera.refreshAuthorizationStatus()`, `this.camera` being a `ref` set with:  
```
ref={cam => {
    this.camera = cam
}}
```
After that, `state` was updated therefore `Status` in `FaCC` was also correctly set and camera could start recording without having to remount it.