### PR TITLE
fix: RCTCameraManager crash on ios

### DIFF
--- a/ios/RCT/RCTCameraManager.m
+++ b/ios/RCT/RCTCameraManager.m
@@ -979,7 +979,7 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
 
   for (AVMetadataMachineReadableCodeObject *metadata in metadataObjects) {
     for (id barcodeType in self.barCodeTypes) {
-      if ([metadata.type isEqualToString:barcodeType]) {
+      if ([metadata.type isEqualToString:barcodeType] && metadata.stringValue) {
         // Transform the meta-data coordinates to screen coords
         AVMetadataMachineReadableCodeObject *transformed = (AVMetadataMachineReadableCodeObject *)[_previewLayer transformedMetadataObjectForMetadataObject:metadata];
 


### PR DESCRIPTION
`AVMetadataMachineReadableCodeObject.stringValue` is a nullable property,  so it will cause a crash when it is set to the 'event' dictionary without nil detection.