### PR TITLE
fix(ios): workaround accidental breaking change

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -531,8 +531,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         }
     }
 
-    if ([options valueForKey:@"mute"] != nil) {
-        [self updateSessionAudioIsMuted:[options[@"mute"] boolValue]];
+    // only update audio session when mute is not set or set to false, because otherwise there will be a flickering
+    if ([options valueForKey:@"mute"] == nil || ([options valueForKey:@"mute"] != nil && ![options[@"mute"] boolValue])) {
+        [self updateSessionAudioIsMuted:NO];
     }
 
     AVCaptureConnection *connection = [self.movieFileOutput connectionWithMediaType:AVMediaTypeVideo];


### PR DESCRIPTION
Introduced here: https://github.com/react-native-community/react-native-camera/commit/401c485#diff-deff8cbb3789a329a4a17e2e3bd13bceR534

However when you set `mute: true` it will cause flickering. This is only to fix the breaking change. The "final" solution will be the `captureAudio` property (#2011).

Fixes #2029