### PR TITLE
fix: actually implement captureAudio property

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -500,7 +500,7 @@ The promise will be fulfilled with an object with some of the following properti
 
  - `maxFileSize` (int greater than 0). Specifies the maximum file size, in bytes, of the video to be recorded. For 1mb, for example, use 1\*1024\*1024. If nothing is specified, no size limit will be used.
 
- - `mute` (any value). If this flag is given in the option with any value, the video to be recorded will be mute. If nothing is specified, video will NOT be muted.
+ - `mute` (any value). (*This value will automatically be set to true if the `captureAudio` has not been passed to the Camera component*) If this flag is given in the option with any value, the video to be recorded will be mute. If nothing is specified, video will NOT be muted.  
  - `path` (file path on disk). Specifies the path on disk to record the video to. You can use the same `uri` returned to continue recording across start/stops
 
  The promise will be fulfilled with an object with some of the following properties:

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -190,6 +190,13 @@ Setting this property causes the auto focus feature of the camera to attempt to 
 
 Coordinates values are measured as floats from `0` to `1.0`.  `{ x: 0, y: 0 }` will focus on the top left of the image, `{ x: 1, y: 1 }` will be the bottom right. Values are based on landscape mode with the home button on the right—this applies even if the device is in portrait mode.
 
+#### `captureAudio`
+
+Values: boolean `true` (default) | `false`
+
+Specifies if audio recording permissions should be requested.
+Make sure to follow README instructions for audio recording permissions [here](../README.md).
+
 #### `flashMode`
 
 Values: `RNCamera.Constants.FlashMode.off` (default), `RNCamera.Constants.FlashMode.on`, `RNCamera.Constants.FlashMode.auto` or `RNCamera.Constants.FlashMode.torch`.

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -258,7 +258,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
         <ActivityIndicator size="small" />
       </View>
     ),
-    captureAudio: false,
+    captureAudio: true,
     useCamera2Api: false,
     playSoundOnCapture: false,
     pictureSize: 'None',

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -338,6 +338,12 @@ export default class Camera extends React.Component<PropsType, StateType> {
         }
       }
     }
+
+    const { captureAudio } = this.props
+
+    if (!captureAudio) {
+      options.mute = true
+    }
     return await CameraManager.record(options, this._cameraHandle);
   }
 


### PR DESCRIPTION
This fixes #2029 #2011 etc. by:

1. Changing captureAudio default to true
2. If captureAudio is set to false, disregard mute property and always pass mute:true to the camera?