### PR TITLE
#1870 Correct default video preset.

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -620,7 +620,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         // Default video quality AVCaptureSessionPresetHigh if non is provided
         AVCaptureSessionPreset preset = ([self defaultVideoQuality]) ? [RNCameraUtils captureSessionPresetForVideoResolution:[[self defaultVideoQuality] integerValue]] : AVCaptureSessionPresetHigh;
 
-        self.session.sessionPreset = preset == AVCaptureSessionPresetHigh ? AVCaptureSessionPresetPhoto: preset;
+        self.session.sessionPreset = preset;
 
         AVCaptureStillImageOutput *stillImageOutput = [[AVCaptureStillImageOutput alloc] init];
         if ([self.session canAddOutput:stillImageOutput]) {


### PR DESCRIPTION
Fixed https://github.com/react-native-community/react-native-camera/issues/1870

**It broke right here:**
https://github.com/react-native-community/react-native-camera/blob/master/ios/RN/RNCamera.m#L623

(Older devices cannot shoot video with photo quality)
Its work fine from iPhone 6s and earlier with:
self.session.sessionPreset = AVCaptureSessionPresetHigh (not AVCaptureSessionPresetPhoto)

----------------------------------------------------------------------------

You can manually set a weak preset, for iPhone 6s works fine preset:
defaultVideoQuality={ RNCamera.Constants.VideoQuality.720p }

https://github.com/react-native-community/react-native-camera/blob/master/docs/RNCamera.md#ios-defaultvideoquality


----------------------------------------------------------------------------

In FaceDetectorDemo Google developers uses AVCaptureSessionPresetMedium
https://github.com/googlesamples/ios-vision/blob/master/FaceDetectorDemo/FaceDetector/CameraViewController.m#L58
