### PR TITLE
Fix the git tag format in the podspec

### DIFF
--- a/react-native-camera.podspec
+++ b/react-native-camera.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.source         = { :git => 'https://github.com/react-native-community/react-native-camera', :tag => s.version }
+  s.source         = { :git => 'https://github.com/react-native-community/react-native-camera', :tag => "v#{s.version}" }
 
   s.requires_arc   = true
   s.platform       = :ios, '9.0'


### PR DESCRIPTION
The format of the git tag which the podspec file specified did not match the ones which were being published.

Previously, it was using the raw version number from the `package.json`, however, the git tags had a `v` prefix.

This lead to errors saying the "branch could not be found" when attempting to use the library through Cocoapods.

This fix still reads the version number from `package.json`, however, it now prefixes it with a `v` to get the real git tag values. For example, `v1.6.4`.