### PR TITLE
feat(android): add videoBitrate option for recordAsync

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -853,11 +853,14 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         mMediaRecorder.setOutputFile(path);
         mVideoPath = path;
 
+        CamcorderProfile camProfile;
         if (CamcorderProfile.hasProfile(mCameraId, profile.quality)) {
-            setCamcorderProfile(CamcorderProfile.get(mCameraId, profile.quality), recordAudio);
+            camProfile = CamcorderProfile.get(mCameraId, profile.quality);
         } else {
-            setCamcorderProfile(CamcorderProfile.get(mCameraId, CamcorderProfile.QUALITY_HIGH), recordAudio);
+            camProfile = CamcorderProfile.get(mCameraId, CamcorderProfile.QUALITY_HIGH);
         }
+        camProfile.videoBitRate = profile.videoBitRate;
+        setCamcorderProfile(camProfile, recordAudio);
 
         mMediaRecorder.setOrientationHint(calcCameraRotation(mOrientation != Constants.ORIENTATION_AUTO ? orientationEnumToRotation(mOrientation) : mDeviceOrientation));
 

--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -1094,11 +1094,12 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
         mMediaRecorder.setOutputFile(path);
         mVideoPath = path;
 
-        if (CamcorderProfile.hasProfile(Integer.parseInt(mCameraId), profile.quality)) {
-            setCamcorderProfile(profile, recordAudio);
-        } else {
-            setCamcorderProfile(CamcorderProfile.get(CamcorderProfile.QUALITY_HIGH), recordAudio);
+        CamcorderProfile camProfile = profile;
+        if (!CamcorderProfile.hasProfile(Integer.parseInt(mCameraId), profile.quality)) {
+            camProfile = CamcorderProfile.get(CamcorderProfile.QUALITY_HIGH);
         }
+        camProfile.videoBitRate = profile.videoBitRate;
+        setCamcorderProfile(camProfile, recordAudio);
 
         mMediaRecorder.setOrientationHint(getOutputRotation());
 

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -256,8 +256,8 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
       if (options.hasKey("quality")) {
         profile = RNCameraViewHelper.getCamcorderProfile(options.getInt("quality"));
       }
-      if (options.hasKey("targetBitrate")) {
-        profile.videoBitRate = options.getInt("targetBitrate");
+      if (options.hasKey("videoBitrate")) {
+        profile.videoBitRate = options.getInt("videoBitrate");
       }
 
       boolean recordAudio = true;

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -256,6 +256,9 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
       if (options.hasKey("quality")) {
         profile = RNCameraViewHelper.getCamcorderProfile(options.getInt("quality"));
       }
+      if (options.hasKey("targetBitrate")) {
+        profile.videoBitRate = options.getInt("targetBitrate");
+      }
 
       boolean recordAudio = true;
       if (options.hasKey("mute")) {

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -482,7 +482,7 @@ Supported options:
     - `ios` Specifies capture settings suitable for CIF quality (352x288 pixel) video output.
     - `android` Not supported.
 
-- `targetBitrate`. (int greater than 0) This option specifies a desired video bitrate.  For example, 5\*1000\*1000 would be 5Mbps.
+- `videoBitrate`. (int greater than 0) This option specifies a desired video bitrate.  For example, 5\*1000\*1000 would be 5Mbps.
   - `ios` Not supported.
   - `android` Supported.
 

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -482,6 +482,10 @@ Supported options:
     - `ios` Specifies capture settings suitable for CIF quality (352x288 pixel) video output.
     - `android` Not supported.
 
+- `targetBitrate`. (int greater than 0) This option specifies a desired video bitrate.  For example, 5\*1000\*1000 would be 5Mbps.
+  - `ios` Not supported.
+  - `android` Supported.
+
 - `orientation` (string or number). Specifies the orientation that us used for recording the video. Possible values: `"portrait"`, `"portraitUpsideDown"`, `"landscapeLeft"` or `"landscapeRight"`.
 
   If nothing is passed the device's highest camera quality will be used as default.

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -339,8 +339,9 @@ export default class Camera extends React.Component<PropsType, StateType> {
         }
       }
     }
-    if (options.videoBitrate) {
-      if (typeof options.videoBitrate !== 'number') {
+
+    if (__DEV__) {
+      if (options.videoBitrate && typeof options.videoBitrate !== 'number') {
         // eslint-disable-next-line no-console
         console.warn('Target Bitrate should be a positive integer');
       }

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -341,6 +341,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     }
     if (options.targetBitrate) {
       if (typeof options.targetBitrate !== 'number') {
+        // eslint-disable-next-line no-console
         console.warn('Target Bitrate should be a positive integer');
       }
     }

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -72,7 +72,7 @@ type RecordingOptions = {
   codec?: string,
   mute?: boolean,
   path?: string,
-  targetBitrate?: number,
+  videoBitrate?: number,
 };
 
 type EventCallbackArgumentsType = {
@@ -339,8 +339,8 @@ export default class Camera extends React.Component<PropsType, StateType> {
         }
       }
     }
-    if (options.targetBitrate) {
-      if (typeof options.targetBitrate !== 'number') {
+    if (options.videoBitrate) {
+      if (typeof options.videoBitrate !== 'number') {
         // eslint-disable-next-line no-console
         console.warn('Target Bitrate should be a positive integer');
       }

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -72,6 +72,7 @@ type RecordingOptions = {
   codec?: string,
   mute?: boolean,
   path?: string,
+  targetBitrate?: number,
 };
 
 type EventCallbackArgumentsType = {
@@ -335,6 +336,15 @@ export default class Camera extends React.Component<PropsType, StateType> {
         if (typeof options.orientation !== 'number') {
           // eslint-disable-next-line no-console
           console.warn(`Orientation '${orientation}' is invalid.`);
+        }
+      }
+    }
+    if (options.targetBitrate) {
+      if (typeof options.targetBitrate !== 'number') {
+        console.warn('Target Bitrate should be an integer');
+      } else {
+        if (options.targetBitrate <= 0) {
+          console.warn('Target Bitrate should be a positive integer');
         }
       }
     }

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -341,11 +341,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     }
     if (options.targetBitrate) {
       if (typeof options.targetBitrate !== 'number') {
-        console.warn('Target Bitrate should be an integer');
-      } else {
-        if (options.targetBitrate <= 0) {
-          console.warn('Target Bitrate should be a positive integer');
-        }
+        console.warn('Target Bitrate should be a positive integer');
       }
     }
 

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -343,7 +343,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     if (__DEV__) {
       if (options.videoBitrate && typeof options.videoBitrate !== 'number') {
         // eslint-disable-next-line no-console
-        console.warn('Target Bitrate should be a positive integer');
+        console.warn('Video Bitrate should be a positive integer');
       }
     }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -266,6 +266,9 @@ interface RecordOptions {
   mirrorVideo?: boolean;
   path?: string;
 
+  /** Android only */
+  videoBitrate?: number;
+
   /** iOS only */
   codec?: keyof VideoCodec | VideoCodec[keyof VideoCodec];
 }


### PR DESCRIPTION
While VideoQuality can be set, this option does not give developers anyway to fine-tune the resulting file size of a recorded video.  720p recording will use a 12 Mbps bitrate on a Galaxy S8+, even though 720p should be closer to 5 Mbps.

Introducing a new optional recording option helps to solve this problem.
targetBitrate takes an integer value (e.g. 1000 x 1000 x 5 aka 5Mbps).

Example of calling it from React Native

```
const recordingOptions = {
          maxDuration: 60*20,
          mute: false,
          quality: RNCamera.Constants.VideoQuality['720p'],
          targetBitrate: 1000*1000*5 // 5 Mbps
};
const data = await this.camera.recordAsync(recordingOptions);
```