### PR TITLE
wrap captureStillImageAsynchronouslyFromConnection with try/catch

### DIFF
--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -492,6 +492,10 @@ export default class Camera extends React.Component<PropsType, StateType> {
       options.pauseAfterCapture = false;
     }
 
+    if (!this._cameraHandle) {
+      throw 'Camera handle cannot be null';
+    }
+
     return await CameraManager.takePicture(options, this._cameraHandle);
   }
 


### PR DESCRIPTION
hi everyone, 
my app is crashing from time to time and I've noticed it is happening due to unhandled exception raised somewhere inside of `captureStillImageAsynchronouslyFromConnection` method. 

The only solution I could come up with is simple try/catch block where catch is calling `reject` function so the code execution passed further to JavaScript level and can be handled there. 

The PR diff can look pretty big but the only change is try/catch block as I've mentioned. 

The issue can be found here - https://github.com/react-native-community/react-native-camera/issues/1956
You can find crash log posted by @gaurav321garg, which is very similar to crash log I had. 

With this fix app is not crashing BUT I'm now getting Black Screen instead of actual stream from camera for some reason (the frequency of this black screen is the same as frequency of crash that I had).

Let me know if I can do anything to improve this PR. 