### PR TITLE
fix(ios): only check permission descriptions availability in debug build

### DIFF
--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -371,31 +371,31 @@ RCT_EXPORT_METHOD(checkDeviceAuthorizationStatus:(RCTPromiseResolveBlock)resolve
 
 RCT_EXPORT_METHOD(checkVideoAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
-    if ([[NSBundle mainBundle].infoDictionary objectForKey:@"NSCameraUsageDescription"] != nil) {
-        __block NSString *mediaType = AVMediaTypeVideo;
-        [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
-            resolve(@(granted));
-        }];
-    } else {
 #ifdef DEBUG
-        RCTLogWarn(@"Checking video permissions without having key 'NSCameraUsageDescription' defined in your Info.plist. You will have to add it to your Info.plist file, otherwise RNCamera is not allowed to use the camera. You can learn more about adding permissions here: https://stackoverflow.com/a/38498347/4202031");
-#endif
+    if ([[NSBundle mainBundle].infoDictionary objectForKey:@"NSCameraUsageDescription"] == nil) {
+        RCTLogWarn(@"Checking video permissions without having key 'NSCameraUsageDescription' defined in your Info.plist. If you do not add it your app will crash when being built in release mode. You will have to add it to your Info.plist file, otherwise RNCamera is not allowed to use the camera.  You can learn more about adding permissions here: https://stackoverflow.com/a/38498347/4202031");
         resolve(@(NO));
+        return;
     }
+#endif
+    __block NSString *mediaType = AVMediaTypeVideo;
+    [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
+        resolve(@(granted));
+    }];
 }
 
 RCT_EXPORT_METHOD(checkRecordAudioAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
-    if ([[NSBundle mainBundle].infoDictionary objectForKey:@"NSMicrophoneUsageDescription"] != nil) {
-        [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
-            resolve(@(granted));
-        }];
-    } else {
 #ifdef DEBUG
-        RCTLogWarn(@"Checking audio permissions without having key 'NSMicrophoneUsageDescription' defined in your Info.plist. Audio Recording for your video files is therefore disabled. If you do not need audio on your videos is is recommended to set the 'captureAudio' property on your component instance to 'false', otherwise you will have to add the key 'NSMicrophoneUsageDescription' to your Info.plist. You can learn more about adding permissions here: https://stackoverflow.com/a/38498347/4202031");
-#endif
+    if ([[NSBundle mainBundle].infoDictionary objectForKey:@"NSMicrophoneUsageDescription"] == nil) {
+        RCTLogWarn(@"Checking audio permissions without having key 'NSMicrophoneUsageDescription' defined in your Info.plist. Audio Recording for your video files is therefore disabled. If you do not need audio on your recordings is is recommended to set the 'captureAudio' property on your component instance to 'false', otherwise you will have to add the key 'NSMicrophoneUsageDescription' to your Info.plist. If you do not your app will crash when being built in release mode. You can learn more about adding permissions here: https://stackoverflow.com/a/38498347/4202031");
         resolve(@(NO));
+        return;
     }
+#endif
+    [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+        resolve(@(granted));
+    }];
 }
 
 RCT_REMAP_METHOD(getAvailablePictureSizes,


### PR DESCRIPTION
Fixes #2069

It seems like Apple is rejecting apps that access a `Info.plist` usage description that is not available. This conflicts with enhanced developer warnings I implemented in #2048.

To fix that I changed the implementation to only check if the usage descriptions are available in `DEBUG` mode. I also added a note developer warnings, that the app might crash in release mode because using a feature that requires a usage description without having one provided will result in a application crash).