### PR TITLE
[Android] Expose rawValue from google vision barcode scanner

### DIFF
--- a/android/src/main/java/org/reactnative/camera/events/BarcodesDetectedEvent.java
+++ b/android/src/main/java/org/reactnative/camera/events/BarcodesDetectedEvent.java
@@ -72,6 +72,7 @@ public class BarcodesDetectedEvent extends Event<BarcodesDetectedEvent> {
       Barcode barcode = mBarcodes.valueAt(i);
       WritableMap serializedBarcode = Arguments.createMap();
       serializedBarcode.putString("data", barcode.displayValue);
+      serializedBarcode.putString("rawValue", barcode.rawValue);
       serializedBarcode.putString("type", BarcodeFormatUtils.get(barcode.format));
       barcodesList.pushMap(serializedBarcode);
     }

--- a/android/src/main/java/org/reactnative/camera/events/BarcodesDetectedEvent.java
+++ b/android/src/main/java/org/reactnative/camera/events/BarcodesDetectedEvent.java
@@ -72,7 +72,7 @@ public class BarcodesDetectedEvent extends Event<BarcodesDetectedEvent> {
       Barcode barcode = mBarcodes.valueAt(i);
       WritableMap serializedBarcode = Arguments.createMap();
       serializedBarcode.putString("data", barcode.displayValue);
-      serializedBarcode.putString("rawValue", barcode.rawValue);
+      serializedBarcode.putString("rawData", barcode.rawValue);
       serializedBarcode.putString("type", BarcodeFormatUtils.get(barcode.format));
       barcodesList.pushMap(serializedBarcode);
     }


### PR DESCRIPTION
Hello,

I've faced a pretty interesting issue with Google Vision scanner. When scanning a barcode, that contains, for example, VCard (contact) information in the following format:
```
BEGIN:VCARD
FN:Robert Pau Shou Chang
N:Pau;Shou Chang;Robert
SORT-STRING:Pau
END:VCARD
```
`onGoogleVisionBarcodesDetected` will receive the following object:
```
{
  barcodes: [
    {
      data: "Robert Pau Shou Chang",
      type: "QR_CODE"
  ],
  ...
}
```

The reason is that currently, `data` field is populated from `displayValue`, which is "user friendly code value", as stated here: https://developers.google.com/android/reference/com/google/android/gms/vision/barcode/Barcode

I think that in many cases users will expect to get a raw scanned value and now it's impossible to get it from Google Vision.

The solution is to get `data` from `rawValue` field, which is "Barcode value as it was encoded in the barcode." from documentation.

But this change will breack some existent code that relies on data, so here I've added rawValue as an additional parameter to the codes object.

Please let me know you throuhgts on it. If it's ok, I'll add documentation to this PR as well.

Thanks!