### PR TITLE
Handle boolean return value of PermissionsAndroid.request()

### DIFF
--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -37,7 +37,11 @@ const requestPermissions = async (
       PermissionsAndroid.PERMISSIONS.CAMERA,
       params,
     );
-    hasCameraPermissions = cameraPermissionResult === PermissionsAndroid.RESULTS.GRANTED;
+    if (typeof cameraPermissionResult === 'boolean') {
+      hasCameraPermissions = cameraPermissionResult;
+    } else {
+      hasCameraPermissions = cameraPermissionResult === PermissionsAndroid.RESULTS.GRANTED;
+    }
   }
 
   if (captureAudio) {

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -53,7 +53,11 @@ const requestPermissions = async (
           PermissionsAndroid.PERMISSIONS.RECORD_AUDIO,
           params,
         );
-        hasRecordAudioPermissions = audioPermissionResult === PermissionsAndroid.RESULTS.GRANTED;
+        if (typeof audioPermissionResult === 'boolean') {
+          hasRecordAudioPermissions = audioPermissionResult
+        } else {
+          hasRecordAudioPermissions = audioPermissionResult === PermissionsAndroid.RESULTS.GRANTED;
+        }
       } else if (__DEV__) {
         // eslint-disable-next-line no-console
         console.warn(


### PR DESCRIPTION
In RNCamera.js function requestPermissions expects PermissionsAndroid.request() to return a string, namely one of PermissionsAndroid.RESULTS.

However PermissionsAndroid.request() returns a boolean if both conditions are true:
1) React-Native is below version 57
2) Android is below version 6 Marshmallow

The returned boolean can't pass comparisons with a string, requestPermissions returns false and the camera never launches
 
This pull request solves the problem with boolean return value.

Since React-Native version 57 PermissionsAndroid.request() always returns a string. So this problem only effects those who use React-Native before version 57