### PR TITLE
Update location and description of the examples

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -567,7 +567,8 @@ To learn about how to test components which uses `RNCamera` check its [documenta
 
 ## Example
 
-To see more of the `RNCamera` in action, with Face Detection, you can check out the source in [RNCamera Example](https://github.com/react-native-community/rncamera-example) repository.
+To see more of the `RNCamera` in action you can check out the [RNCamera examples directory](https://github.com/react-native-community/react-native-camera/tree/master/examples).
+
 
 ## Open Collective
 


### PR DESCRIPTION
Fixes
* Update location: Examples have moved to https://github.com/react-native-community/react-native-camera/tree/master/examples .
* Remove out of date claim: In this directory there are no examples with face recognition. Only one example has been added, that doesn't have face recognition (https://github.com/react-native-community/react-native-camera/pull/1979). 
* Remove repository reference: This is not a standalone repo anymore, it is a directory in the `react-native-camera` repo.