### PR TITLE
Allow for devices without flash hardware

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -771,15 +771,18 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         if (isCameraOpened()) {
             List<String> modes = mCameraParameters.getSupportedFlashModes();
             String mode = FLASH_MODES.get(flash);
-            if (modes != null && modes.contains(mode)) {
+            if(modes == null) {
+                return false;
+            }
+            if (modes.contains(mode)) {
                 mCameraParameters.setFlashMode(mode);
                 mFlash = flash;
                 return true;
             }
             String currentMode = FLASH_MODES.get(mFlash);
-            if (modes == null || !modes.contains(currentMode)) {
-                mCameraParameters.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
-                return true;
+            if (!modes.contains(currentMode)) {
+                 mCameraParameters.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
+                 return true;
             }
             return false;
         } else {

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -781,8 +781,8 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             }
             String currentMode = FLASH_MODES.get(mFlash);
             if (!modes.contains(currentMode)) {
-                 mCameraParameters.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
-                 return true;
+                mCameraParameters.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
+                return true;
             }
             return false;
         } else {


### PR DESCRIPTION
Allows devices without flash hardware to run RNCamera. Currently crashes when attempting to setParameters for flashMode to any that are passed in, or to the default of `off`

Found and Fixed in conjunction with @ctravail