### PR TITLE
[Android] Add support to specify a different google vision version via gradle properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ ext {
     targetSdkVersion            = 26
     buildToolsVersion           = "26.0.2"
     googlePlayServicesVersion   = "12.0.1"
+    googlePlayServicesVisionVersion = "15.0.2"
     supportLibVersion           = "27.1.0"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -401,6 +401,18 @@ dependencies {
 }
 ```
 
+If you are using a version of `googlePlayServicesVersion` that does not have `play-services-vision`, you can specify a different version of `play-services-vision` by adding `googlePlayServicesVisionVersion` to the project-wide properties
+```
+ext {
+    compileSdkVersion           = 26
+    targetSdkVersion            = 26
+    buildToolsVersion           = "26.0.2"
+    googlePlayServicesVersion   = "16.0.1"
+    googlePlayServicesVisionVersion = "15.0.2"
+    supportLibVersion           = "27.1.0"
+}
+```
+
 #### Windows
 1. `npm install react-native-camera --save`
 2. Link the library as described here: [react-native-windows / LinkingLibrariesWindows.md](https://github.com/Microsoft/react-native-windows/blob/master/docs/LinkingLibrariesWindows.md)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,11 +46,13 @@ repositories {
 }
 
 dependencies {
+  def googlePlayServicesVisionVersion = safeExtGet('googlePlayServicesVisionVersion', safeExtGet('googlePlayServicesVersion', '15.0.2'))
+
   compileOnly 'com.facebook.react:react-native:+'
   compileOnly 'com.facebook.infer.annotation:infer-annotation:+'
   implementation "com.google.zxing:core:3.3.0"
   implementation "com.drewnoakes:metadata-extractor:2.9.1"
-  implementation "com.google.android.gms:play-services-vision:${safeExtGet('googlePlayServicesVersion', '15.0.2')}"
+  implementation "com.google.android.gms:play-services-vision:$googlePlayServicesVisionVersion"
   implementation "com.android.support:exifinterface:${safeExtGet('supportLibVersion', '27.1.0')}"
   implementation "com.android.support:support-annotations:${safeExtGet('supportLibVersion', '27.1.0')}"
   implementation "com.android.support:support-v4:${safeExtGet('supportLibVersion', '27.1.0')}"


### PR DESCRIPTION
Closes #2079.

This PR allows users to use a custom version of `play-services-vision` by adding `googlePlayServicesVisionVersion` to their project properties.

If `googlePlayServicesVisionVersion` is not present, it will fallback to `googlePlayServicesVersion`, and if `googlePlayServicesVersion` is not present, it will fallback to `15.0.2`.

**Example**

```
ext {
    compileSdkVersion           = 28
    targetSdkVersion            = 26
    minSdkVersion               = 16
    buildToolsVersion           = "28.0.2"
    supportLibVersion           = "27.1.1"
    androidMapsUtilsVersion     = "0.5+"
    googlePlayServicesVersion   = "16.0.1"
    googlePlayServicesMapsVersion = "16.0.0"
    googlePlayServicesVisionVersion = "15.0.2"
}
```
