### PR TITLE
build(windows): update min sdk version

### DIFF
--- a/windows/RNCamera/RNCamera.csproj
+++ b/windows/RNCamera/RNCamera.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
It's time to update TargetPlatformMinVersion in order to be in accordance with the react-native-windows
and prevent this kind of errors

![image](https://user-images.githubusercontent.com/24648180/53005567-92fd3900-3444-11e9-82b9-af6e3d13aa08.png)


https://github.com/Microsoft/react-native-windows/blob/master/ReactWindows/ReactNative/ReactNative.csproj#L15