### PR TITLE
feat: barcodefindermask subview for rncamera to show barcode style

### DIFF
--- a/docs/BarcodeFinderMask.md
+++ b/docs/BarcodeFinderMask.md
@@ -1,0 +1,130 @@
+# BarcodeFinderMask
+
+> A subview for RNCamera to show barcode style layout
+
+<p align="center" >
+    <img 
+        height="300" 
+        src="https://user-images.githubusercontent.com/20506431/53305262-40d37200-38a1-11e9-9f87-c83a5cb44ac6.gif"
+    >
+</p>
+
+## Usage
+
+All you need is to `import` `{ BarcodeFinderMask }` from the `react-native-camera` module and then use it inside
+`<RNCamera>...</RNCamera>` tag as a child component.
+
+```javascript
+'use strict';
+import React, { Component } from 'react';
+import { RNCamera, BarcodeFinderMask } from 'react-native-camera';
+
+...
+    <RNCamera
+        ...
+    >
+        <BarcodeFinderMask />
+    </RNCamera>
+...
+```
+
+## Properties
+
+#### `width`
+
+Value: number | string (`%`)  
+Default: `280`
+
+Finder's width (the visible area)
+
+#### `height`
+
+Value: number | string (`%`)  
+Default: `230`
+
+Finder's height (the visible area)
+
+#### `edgeWidth`
+
+Value: number | string (`%`)  
+Default: `20`
+
+Edge/Corner's width
+
+#### `edgeHeight`
+
+Value: number | string (`%`)  
+Default: `20`
+
+Edge/Corner's height
+
+#### `edgeColor`
+
+Value: string  
+Default: `#FFF`
+
+Use this to give custom color to edges
+
+#### `edgeBorderWidth`
+
+Value: number | string (`%`)  
+Default: `4`
+
+Use this to modify the border (thickness) of edges
+
+#### `transparency`
+
+Value: float from `0` to `1.0`  
+Default: `0.6`
+
+Use this to modify the transparency of area around finder
+
+#### `showAnimatedLine`
+
+Value: boolean `true` | `false`  
+Default: `true`
+
+#### `animatedLineColor`
+
+Value: string  
+Default: `#FFF`
+
+#### `animatedLineHeight`
+
+Value: number  
+Default: `2`
+
+#### `lineAnimationDuration`
+
+Value: number  
+Default: `1500`
+
+## Examples
+
+Few style modifications (respectively):
+
+```javascript
+<BarcodeFinderMask width={300} height={100} />
+<BarcodeFinderMask edgeColor={"#62B1F6"} showAnimatedLine={false}/>
+<BarcodeFinderMask width={100} height={300} showAnimatedLine={false} transparency={0.8}/>
+<BarcodeFinderMask width={300} height={100} edgeBorderWidth={1} />
+```
+
+<p align="center" >
+    <img 
+        height="300" 
+        src="https://user-images.githubusercontent.com/20506431/53305263-40d37200-38a1-11e9-8106-6c79f4d59ead.png"
+    >
+    <img 
+        height="300" 
+        src="https://user-images.githubusercontent.com/20506431/53305265-416c0880-38a1-11e9-9364-7fd0b987207a.png"
+    >
+    <img 
+        height="300" 
+        src="https://user-images.githubusercontent.com/20506431/53305266-416c0880-38a1-11e9-8ef0-9ec9912fd355.png"
+    >
+    <img 
+        height="300" 
+        src="https://user-images.githubusercontent.com/20506431/53305264-40d37200-38a1-11e9-8752-1c5deaf78c65.png"
+    >
+</p>

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -499,7 +499,8 @@ Supported options:
     - `ios` Specifies capture settings suitable for CIF quality (352x288 pixel) video output.
     - `android` Not supported.
 
-- `videoBitrate`. (int greater than 0) This option specifies a desired video bitrate.  For example, 5\*1000\*1000 would be 5Mbps.
+- `videoBitrate`. (int greater than 0) This option specifies a desired video bitrate. For example, 5\*1000\*1000 would be 5Mbps.
+
   - `ios` Not supported.
   - `android` Supported.
 
@@ -561,6 +562,16 @@ iOS only. Returns a promise. The promise will be fulfilled with a boolean indica
 
 This component supports subviews, so if you wish to use the camera view as a background or if you want to layout buttons/images/etc. inside the camera then you can do that.
 
+### BarcodeFinderMask
+
+[BarcodeFinderMask](./BarcodeFinderMask.md) gives a nice barcode scanning style look to your camera.
+
+##### Quick and Easy:
+
+Import `BarcodeFinderMask` and use it as a child component of `RNCamera`.
+
+Check out ways to modify [BarcodeFinderMask](./BarcodeFinderMask.md).
+
 ## Testing
 
 To learn about how to test components which uses `RNCamera` check its [documentation about testing](./tests.md).
@@ -568,7 +579,6 @@ To learn about how to test components which uses `RNCamera` check its [documenta
 ## Example
 
 To see more of the `RNCamera` in action you can check out the [RNCamera examples directory](https://github.com/react-native-community/react-native-camera/tree/master/examples).
-
 
 ## Open Collective
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,9 @@
 import Camera from './Camera';
 import RNCamera, { type Status as _CameraStatus } from './RNCamera';
 import FaceDetector from './FaceDetector';
+import BarcodeFinderMask from './subviews/BarcodeFinderMask';
 
 export type CameraStatus = _CameraStatus;
-export { RNCamera, FaceDetector };
+export { RNCamera, FaceDetector, BarcodeFinderMask };
 
 export default Camera;

--- a/src/subviews/BarcodeFinderMask.js
+++ b/src/subviews/BarcodeFinderMask.js
@@ -1,0 +1,268 @@
+import React from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+import PropTypes from 'prop-types';
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...StyleSheet.absoluteFill,
+  },
+  finder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  /* eslint-disable-next-line react-native/no-unused-styles */
+  topLeftEdge: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+  },
+  /* eslint-disable-next-line react-native/no-unused-styles */
+  topRightEdge: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+  },
+  /* eslint-disable-next-line react-native/no-unused-styles */
+  bottomLeftEdge: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+  },
+  /* eslint-disable-next-line react-native/no-unused-styles */
+  bottomRightEdge: {
+    position: 'absolute',
+    bottom: 0,
+    right: 0,
+  },
+  maskOuter: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+  },
+  maskInner: {
+    backgroundColor: 'transparent',
+  },
+  maskFrame: {
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    flex: 1,
+  },
+  maskRow: {
+    width: '100%',
+  },
+  maskCenter: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  animatedLine: {
+    position: 'absolute',
+    elevation: 4,
+    zIndex: 0,
+    width: '85%',
+  },
+});
+
+type PropsType = typeof View.props & {
+  width?: number | string,
+  height?: number | string,
+  edgeWidth?: number | string,
+  edgeHeight?: number | string,
+  edgeColor?: string,
+  edgeBorderWidth?: number | string,
+  transparency?: number,
+  showAnimatedLine?: boolean,
+  animatedLineColor?: string,
+  animatedLineHeight?: number | string,
+  lineAnimationDuration?: number,
+};
+
+type StateType = {
+  isAuthorized: number,
+  maskCenterViewHeight: number,
+  intervalId?: any,
+};
+
+type EventCallbackArgumentsType = {
+  nativeEvent: Object,
+};
+
+type EdgePosition = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+
+class BarcodeFinderMask extends React.Component<PropsType, StateType> {
+  constructor(props: PropTypes) {
+    super(props);
+    this.state = {
+      top: new Animated.Value(10),
+      maskCenterViewHeight: 0,
+    };
+  }
+
+  componentDidMount() {
+    this._startLineAnimation();
+  }
+
+  _startLineAnimation = () => {
+    const intervalId = setInterval(() => {
+      if (this.state.maskCenterViewHeight > 0) {
+        this._animateLineDown();
+        clearInterval(this.state.intervalId);
+      }
+    }, 500);
+    this.setState({
+      intervalId,
+    });
+  };
+
+  _animateLineUp = () => {
+    Animated.timing(this.state.top, {
+      toValue: 10,
+      duration: this.props.lineAnimationDuration,
+    }).start(this._animateLineDown);
+  };
+
+  _animateLineDown = () => {
+    Animated.timing(this.state.top, {
+      toValue: this.state.maskCenterViewHeight - 10,
+      duration: this.props.lineAnimationDuration,
+    }).start(this._animateLineUp);
+  };
+
+  _onMaskCenterViewLayoutUpdated = ({ nativeEvent }: EventCallbackArgumentsType) => {
+    this.setState({
+      maskCenterViewHeight: nativeEvent.layout.height,
+    });
+  };
+
+  _applyMaskFrameTransparency = () => {
+    let transparency = 0.6;
+    if (
+      this.props.transparency &&
+      Number(this.props.transparency) &&
+      (this.props.transparency >= 0 || this.props.transparency <= 1)
+    ) {
+      transparency = this.props.transparency;
+    }
+    return { backgroundColor: 'rgba(0,0,0,' + transparency + ')' };
+  };
+
+  _renderEdge = (edgePosition: EdgePosition) => {
+    const defaultStyle = {
+      ...styles[edgePosition + 'Edge'],
+      width: this.props.edgeWidth,
+      height: this.props.edgeHeight,
+      borderColor: this.props.edgeColor,
+    };
+    const edgeBorderStyle = {
+      topRight: {
+        borderRightWidth: this.props.edgeBorderWidth,
+        borderTopWidth: this.props.edgeBorderWidth,
+      },
+      topLeft: {
+        borderLeftWidth: this.props.edgeBorderWidth,
+        borderTopWidth: this.props.edgeBorderWidth,
+      },
+      bottomRight: {
+        borderRightWidth: this.props.edgeBorderWidth,
+        borderBottomWidth: this.props.edgeBorderWidth,
+      },
+      bottomLeft: {
+        borderLeftWidth: this.props.edgeBorderWidth,
+        borderBottomWidth: this.props.edgeBorderWidth,
+      },
+    };
+    return <View style={[defaultStyle, edgeBorderStyle[edgePosition]]} />;
+  };
+
+  render() {
+    return (
+      <View style={[styles.container]}>
+        <View
+          style={[
+            styles.finder,
+            {
+              width: this.props.width,
+              height: this.props.height,
+            },
+          ]}
+        >
+          {this._renderEdge('topLeft')}
+          {this._renderEdge('topRight')}
+          {this._renderEdge('bottomLeft')}
+          {this._renderEdge('bottomRight')}
+
+          {this.props.showAnimatedLine && (
+            <Animated.View
+              style={[
+                styles.animatedLine,
+                {
+                  backgroundColor: this.props.animatedLineColor,
+                  height: this.props.animatedLineHeight,
+                  top: this.state.top,
+                },
+              ]}
+            />
+          )}
+        </View>
+
+        <View style={styles.maskOuter}>
+          <View style={[styles.maskRow, styles.maskFrame, this._applyMaskFrameTransparency()]} />
+          <View
+            style={[{ height: this.props.height }, styles.maskCenter]}
+            onLayout={this._onMaskCenterViewLayoutUpdated}
+          >
+            <View style={[styles.maskFrame, this._applyMaskFrameTransparency()]} />
+            <View
+              style={[
+                styles.maskInner,
+                {
+                  width: this.props.width,
+                  height: this.props.height,
+                },
+              ]}
+            />
+            <View style={[styles.maskFrame, this._applyMaskFrameTransparency()]} />
+          </View>
+          <View style={[styles.maskRow, styles.maskFrame, this._applyMaskFrameTransparency()]} />
+        </View>
+      </View>
+    );
+  }
+}
+
+const propTypes: PropsType = {
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  edgeWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  edgeHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  edgeColor: PropTypes.string,
+  edgeBorderWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  transparency: PropTypes.number,
+  showAnimatedLine: PropTypes.bool,
+  animatedLineColor: PropTypes.string,
+  animatedLineHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  lineAnimationDuration: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+const defaultProps = {
+  width: 280,
+  height: 230,
+  edgeWidth: 20,
+  edgeHeight: 20,
+  edgeColor: '#FFF',
+  edgeBorderWidth: 4,
+  transparency: 0.6,
+  showAnimatedLine: true,
+  animatedLineColor: '#FFF',
+  animatedLineHeight: 2,
+  lineAnimationDuration: 1500,
+};
+
+BarcodeFinderMask.propTypes = propTypes;
+BarcodeFinderMask.defaultProps = defaultProps;
+
+export default BarcodeFinderMask;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-native-camera 1.0
 // Definitions by: Felipe Constantino <https://github.com/fconstant>
 //                 Trent Jones <https://github.com/FizzBuzz791>
+//                 Shahnawaz Ali <https://github.com/shahnawaz>
 // If you modify this file, put your GitHub info here as well (for easy contacting purposes)
 
 /*
@@ -93,13 +94,11 @@ type RecordAudioPermissionStatus = Readonly<
     NOT_AUTHORIZED: 'NOT_AUTHORIZED';
   }>
 >;
-type FaCC = (
-  params: {
-    camera: RNCamera;
-    status: keyof CameraStatus;
-    recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
-  },
-) => JSX.Element;
+type FaCC = (params: {
+  camera: RNCamera;
+  status: keyof CameraStatus;
+  recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
+}) => JSX.Element;
 
 export interface Constants {
   CameraStatus: CameraStatus;
@@ -141,7 +140,10 @@ export interface RNCameraProps {
   captureAudio?: boolean;
 
   onCameraReady?(): void;
-  onStatusChange?(event: { cameraStatus: CameraStatus, recordAudioPermissionStatus: keyof RecordAudioPermissionStatus }): void;
+  onStatusChange?(event: {
+    cameraStatus: CameraStatus;
+    recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
+  }): void;
   onMountError?(error: { message: string }): void;
 
   /** Value: float from 0 to 1.0 */
@@ -318,6 +320,22 @@ export class FaceDetector {
   static Constants: Constants['FaceDetection'];
   static detectFacesAsync(uri: string, options?: DetectionOptions): Promise<Face[]>;
 }
+
+export interface BarcodeFinderMaskProps {
+  width?: number | string;
+  height?: number | string;
+  edgeWidth?: number | string;
+  edgeHeight?: number | string;
+  edgeColor?: string;
+  edgeBorderWidth?: number | string;
+  transparency?: number;
+  showAnimatedLine?: boolean;
+  animatedLineColor?: string;
+  animatedLineHeight?: number | string;
+  lineAnimationDuration?: number;
+}
+
+export class BarcodeFinderMask extends Component<BarcodeFinderMaskProps> {}
 
 // -- DEPRECATED CONTENT BELOW
 


### PR DESCRIPTION
# BarcodeFinderMask

> A subview for RNCamera to show barcode style layout

<p align="center" >
    <img 
        height="300" 
        src="https://user-images.githubusercontent.com/20506431/53305262-40d37200-38a1-11e9-9f87-c83a5cb44ac6.gif"
    >
</p>

## Usage

All you need is to `import` `{ BarcodeFinderMask }` from the `react-native-camera` module and then use it inside
`<RNCamera>...</RNCamera>` tag as a child component.

```javascript
'use strict';
import React, { Component } from 'react';
import { RNCamera, BarcodeFinderMask } from 'react-native-camera';

...
    <RNCamera
        ...
    >
        <BarcodeFinderMask />
    </RNCamera>
...
```

Further usage details are added in [BarcodeFinderMask.md](https://github.com/shahnawaz/react-native-camera/blob/feature/BarcodeFinderMask/docs/BarcodeFinderMask.md)

## Why I added this subview in react-native-camera?

Its pretty cool 👍 

(In all seriousness) I have used RNCamera in few projects and well, whenever there is a feature like barcode scanning, clients and customers request to see a styled view instead of a plain screen.

Pros?

- This would make life much more easier for people who are using RNCamera for barcode scanning.
- Easy to use and customize layout.
- Uses RNCamera subview style (children).
- Code is very similar to the style followed in other files.
- A separate doc created for the usage of [BarcodeFinderMask.md](https://github.com/shahnawaz/react-native-camera/blob/feature/BarcodeFinderMask/docs/BarcodeFinderMask.md)

##### Few style examples:

<p align="center" >
    <img 
        height="300" 
        src="https://user-images.githubusercontent.com/20506431/53305265-416c0880-38a1-11e9-9364-7fd0b987207a.png"
    >
    <img 
        height="300" 
        src="https://user-images.githubusercontent.com/20506431/53305266-416c0880-38a1-11e9-8ef0-9ec9912fd355.png"
    >
    <img 
        height="300" 
        src="https://user-images.githubusercontent.com/20506431/53305264-40d37200-38a1-11e9-8752-1c5deaf78c65.png"
    >
</p>

*Note:* Also updated RNCamera.md and added a small section about this subview.