### PR TITLE
Expose text from mlkit

### DIFF
--- a/android/src/general/java/org/reactnative/camera/tasks/TextRecognizerAsyncTask.java
+++ b/android/src/general/java/org/reactnative/camera/tasks/TextRecognizerAsyncTask.java
@@ -88,7 +88,7 @@ public class TextRecognizerAsyncTask extends android.os.AsyncTask<Void, Void, Sp
         }
         textBlocksList.pushMap(serializedTextBlock);
       }
-      mDelegate.onTextRecognized(textBlocksList);
+      mDelegate.onTextRecognized(textBlocksList, null);
     }
     mDelegate.onTextRecognizerTaskCompleted();
   }

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -449,12 +449,12 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
     setScanning(mShouldDetectFaces || mShouldGoogleDetectBarcodes || mShouldScanBarCodes || mShouldRecognizeText);
   }
 
-  public void onTextRecognized(WritableArray serializedData) {
+  public void onTextRecognized(WritableArray serializedTextBlocks, String text) {
     if (!mShouldRecognizeText) {
       return;
     }
 
-    RNCameraViewHelper.emitTextRecognizedEvent(this, serializedData);
+    RNCameraViewHelper.emitTextRecognizedEvent(this, serializedTextBlocks, text);
   }
 
   @Override

--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -225,8 +225,8 @@ public class RNCameraViewHelper {
 
   // Text recognition event
 
-  public static void emitTextRecognizedEvent(ViewGroup view, WritableArray data) {
-    TextRecognizedEvent event = TextRecognizedEvent.obtain(view.getId(), data);
+  public static void emitTextRecognizedEvent(ViewGroup view, WritableArray textBlocks, String text) {
+    TextRecognizedEvent event = TextRecognizedEvent.obtain(view.getId(), textBlocks, text);
     ReactContext reactContext = (ReactContext) view.getContext();
     reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
   }

--- a/android/src/main/java/org/reactnative/camera/events/TextRecognizedEvent.java
+++ b/android/src/main/java/org/reactnative/camera/events/TextRecognizedEvent.java
@@ -16,22 +16,24 @@ public class TextRecognizedEvent extends Event<TextRecognizedEvent> {
   private static final Pools.SynchronizedPool<TextRecognizedEvent> EVENTS_POOL =
       new Pools.SynchronizedPool<>(3);
 
-  private WritableArray mData;
+  private WritableArray mTextBlocks;
+  private String mText;
 
   private TextRecognizedEvent() {}
 
-  public static TextRecognizedEvent obtain(int viewTag, WritableArray data) {
+  public static TextRecognizedEvent obtain(int viewTag, WritableArray textBlocks, String text) {
     TextRecognizedEvent event = EVENTS_POOL.acquire();
     if (event == null) {
       event = new TextRecognizedEvent();
     }
-    event.init(viewTag, data);
+    event.init(viewTag, textBlocks, text);
     return event;
   }
 
-  private void init(int viewTag, WritableArray data) {
+  private void init(int viewTag, WritableArray textBlocks, String text) {
     super.init(viewTag);
-    mData = data;
+    mTextBlocks = textBlocks;
+    mText = text;
   }
 
   @Override
@@ -47,7 +49,8 @@ public class TextRecognizedEvent extends Event<TextRecognizedEvent> {
   private WritableMap createEvent() {
     WritableMap event = Arguments.createMap();
     event.putString("type", "textBlock");
-    event.putArray("textBlocks", mData);
+    event.putArray("textBlocks", mTextBlocks);
+    event.putString("text", mText);
     event.putInt("target", getViewTag());
     return event;
   }

--- a/android/src/main/java/org/reactnative/camera/tasks/TextRecognizerAsyncTaskDelegate.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/TextRecognizerAsyncTaskDelegate.java
@@ -3,6 +3,6 @@ package org.reactnative.camera.tasks;
 import com.facebook.react.bridge.WritableArray;
 
 public interface TextRecognizerAsyncTaskDelegate {
-  void onTextRecognized(WritableArray serializedData);
+  void onTextRecognized(WritableArray serializedData, String text);
   void onTextRecognizerTaskCompleted();
 }

--- a/android/src/mlkit/java/org/reactnative/camera/tasks/TextRecognizerAsyncTask.java
+++ b/android/src/mlkit/java/org/reactnative/camera/tasks/TextRecognizerAsyncTask.java
@@ -84,9 +84,10 @@ public class TextRecognizerAsyncTask extends android.os.AsyncTask<Void, Void, Vo
             .addOnSuccessListener(new OnSuccessListener<FirebaseVisionText>() {
               @Override
               public void onSuccess(FirebaseVisionText firebaseVisionText) {
+                String text = firebaseVisionText.getText();
                 List<FirebaseVisionText.TextBlock> textBlocks = firebaseVisionText.getTextBlocks();
-                WritableArray serializedData = serializeEventData(textBlocks);
-                mDelegate.onTextRecognized(serializedData);
+                WritableArray serializedTextBlocks = serializeEventData(textBlocks);
+                mDelegate.onTextRecognized(serializedTextBlocks, text);
                 mDelegate.onTextRecognizerTaskCompleted();
                 }
             })

--- a/examples/mlkit/App.js
+++ b/examples/mlkit/App.js
@@ -42,6 +42,7 @@ export default class CameraScreen extends React.Component {
     canDetectBarcode: false,
     faces: [],
     textBlocks: [],
+    text: "",
     barcodes: [],
   };
 
@@ -205,8 +206,8 @@ export default class CameraScreen extends React.Component {
   );
 
   textRecognized = object => {
-    const { textBlocks } = object;
-    this.setState({ textBlocks });
+    const { text, textBlocks } = object;
+    this.setState({ text, textBlocks });
   };
 
   barcodeRecognized = ({ barcodes }) => this.setState({ barcodes });
@@ -307,6 +308,15 @@ export default class CameraScreen extends React.Component {
               </Text>
             </TouchableOpacity>
           </View>
+          {canDetectText && <View
+            style={{
+              backgroundColor: 'transparent',
+              flexDirection: 'row',
+              justifyContent: 'space-around',
+            }}
+          >
+            <Text style={{ color: '#00F' }}>{this.state.text}</Text>
+          </View>}
         </View>
         <View
           style={{

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1167,8 +1167,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         // find text features
         _finishedReadingText = false;
         self.start = [NSDate date];
-        [self.textDetector findTextBlocksInFrame:image scaleX:scaleX scaleY:scaleY completed:^(NSArray * textBlocks) {
-            NSDictionary *eventText = @{@"type" : @"TextBlock", @"textBlocks" : textBlocks};
+        [self.textDetector findTextBlocksInFrame:image scaleX:scaleX scaleY:scaleY completed:^(NSArray * textBlocks, NSString * text) {
+            NSDictionary *eventText = @{@"type" : @"TextBlock", @"textBlocks" : textBlocks, @"text": text};
             [self onText:eventText];
             self.finishedReadingText = true;
         }];

--- a/ios/RN/TextDetectorManager.h
+++ b/ios/RN/TextDetectorManager.h
@@ -2,7 +2,7 @@
   #import <FirebaseMLVision/FirebaseMLVision.h>
 
   @interface TextDetectorManager : NSObject
-  typedef void(^postRecognitionBlock)(NSArray *textBlocks);
+  typedef void(^postRecognitionBlock)(NSArray *textBlocks, NSString *text);
 
   - (instancetype)init;
 
@@ -12,7 +12,7 @@
   @end
 #else
   @interface TextDetectorManager : NSObject
-  typedef void(^postRecognitionBlock)(NSArray *textBlocks);
+  typedef void(^postRecognitionBlock)(NSArray *textBlocks, NSString *text);
 
   - (instancetype)init;
 

--- a/ios/RN/TextDetectorManager.m
+++ b/ios/RN/TextDetectorManager.m
@@ -24,7 +24,7 @@
   return true;
 }
 
-- (void)findTextBlocksInFrame:(UIImage *)uiImage scaleX:(float)scaleX scaleY:(float) scaleY completed: (void (^)(NSArray * result)) completed
+- (void)findTextBlocksInFrame:(UIImage *)uiImage scaleX:(float)scaleX scaleY:(float) scaleY completed: (void (^)(NSArray * result, NSString * text)) completed
 {
     self.scaleX = scaleX;
     self.scaleY = scaleY;
@@ -34,9 +34,9 @@
                        completion:^(FIRVisionText *_Nullable result,
                                     NSError *_Nullable error) {
                            if (error != nil || result == nil) {
-                               completed(textBlocks);
+                               completed(textBlocks, nil);
                            } else {
-                           completed([self processBlocks:result.blocks]);
+                           completed([self processBlocks:result.blocks], result.text);
                            }
                        }];
 }

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -158,7 +158,7 @@ type PropsType = typeof View.props & {
   autoFocusPointOfInterest?: { x: number, y: number },
   faceDetectionClassifications?: number,
   onFacesDetected?: ({ faces: Array<TrackedFaceFeature> }) => void,
-  onTextRecognized?: ({ textBlocks: Array<TrackedTextFeature> }) => void,
+  onTextRecognized?: ({ textBlocks: Array<TrackedTextFeature>, text?: string }) => void,
   captureAudio?: boolean,
   useCamera2Api?: boolean,
   playSoundOnCapture?: boolean,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -181,7 +181,7 @@ export interface RNCameraProps {
 
   // -- ANDROID ONLY PROPS
   /** Android only */
-  onTextRecognized?(response: { textBlocks: TrackedTextFeature[] }): void;
+  onTextRecognized?(response: { textBlocks: TrackedTextFeature[], text?: string }): void;
   /** Android only */
   ratio?: string;
   /** Android only */


### PR DESCRIPTION
Closes #2141

Exposes the result of calling `FirebaseVisionText.getText`. See: https://firebase.google.com/docs/reference/android/com/google/firebase/ml/vision/text/FirebaseVisionText

Also added an element to display the text in the mlkit example.

I added a second parameter to `TextRecognizerAsyncTaskDelegate.onTextRecognized`. Another option would be to change the parameter to a `WritableMap`.

When using general (and not mlkit) I simply set the `text` String to null. But text get emitted anyway. Another option would be to only add the `text` field to the event if it is not null.

Note: I only implemented this for android.