### PR TITLE
add application will enter foreground observer [iOS]

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -63,6 +63,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
                                                  selector:@selector(bridgeDidBackground:)
                                                      name:UIApplicationDidEnterBackgroundNotification
                                                    object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                selector:@selector(bridgeDidForeground:)
+                                                    name:UIApplicationWillEnterForegroundNotification
+                                                object:nil];
         self.autoFocus = -1;
         //        [[NSNotificationCenter defaultCenter] addObserver:self
         //                                                 selector:@selector(bridgeDidForeground:)


### PR DESCRIPTION
Fixes #2156 

PR #2007 introduced observer for `UIApplicationDidEnterBackgroundNotification` and was stopping the session on application going to background, method `bridgeDidBackground` that was restarting the session was implemented, but there was no observer for `UIApplicationWillEnterForegroundNotification`. This situation led to frozen session after backgrounding/foregrounding the app. 
This PR fixes it.