### PR TITLE
[Android] Do not change camera rotation while recording video

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -557,7 +557,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             return;
         }
         mDeviceOrientation = deviceOrientation;
-        if (isCameraOpened() && mOrientation == Constants.ORIENTATION_AUTO) {
+        if (isCameraOpened() && mOrientation == Constants.ORIENTATION_AUTO && !mIsRecording) {
             mCameraParameters.setRotation(calcCameraRotation(deviceOrientation));
             mCamera.setParameters(mCameraParameters);
          }


### PR DESCRIPTION
### Overview

If you flip the phone while recording a video the app crashes on some devices (e.g OnePlus 3T) showing the following error:

```
   java.lang.RuntimeException: setParameters failed
        at android.hardware.Camera.native_setParameters(Native Method)
        at android.hardware.Camera.setParameters(Camera.java:2302)
        at com.google.android.cameraview.Camera1.setDeviceOrientation(Camera1.java:562)
        at com.google.android.cameraview.CameraView$1.onDisplayOrientationChanged(CameraView.java:127)
        at com.google.android.cameraview.DisplayOrientationDetector.dispatchOnDisplayOrientationChanged(DisplayOrientationDetector.java:114)
        at com.google.android.cameraview.DisplayOrientationDetector$1.onOrientationChanged(DisplayOrientationDetector.java:90)
        at android.view.OrientationEventListener$SensorEventListenerImpl.onSensorChanged(OrientationEventListener.java:143)
        at android.hardware.SystemSensorManager$SensorEventQueue.dispatchSensorEvent(SystemSensorManager.java:849)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:325)
        at android.os.Looper.loop(Looper.java:142)
        at android.app.ActivityThread.main(ActivityThread.java:6798)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
```

This PR fixes it.

PD: This might fix some errors described in #813 and #940.