### PR TITLE
[Android] Feature: support for Rationale (#2110)

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -22,8 +22,18 @@ class BadInstagramCloneApp extends Component {
           style={styles.preview}
           type={RNCamera.Constants.Type.back}
           flashMode={RNCamera.Constants.FlashMode.on}
-          permissionDialogTitle={'Permission to use camera'}
-          permissionDialogMessage={'We need your permission to use your camera phone'}
+          androidCameraPermissionOptions={{
+            title: 'Permission to use camera',
+            message: 'We need your permission to use your camera',
+            buttonPositive: 'Ok',
+            buttonNegative: 'Cancel',
+          }}
+          androidRecordAudioPermissionOptions={{
+            title: 'Permission to use audio recording',
+            message: 'We need your permission to use your audio',
+            buttonPositive: 'Ok',
+            buttonNegative: 'Cancel',
+          }}
           onGoogleVisionBarcodesDetected={({ barcodes }) => {
             console.log(barcodes);
           }}
@@ -102,8 +112,18 @@ class App extends Component {
           style={styles.preview}
           type={RNCamera.Constants.Type.back}
           flashMode={RNCamera.Constants.FlashMode.on}
-          permissionDialogTitle={'Permission to use camera'}
-          permissionDialogMessage={'We need your permission to use your camera phone'}
+          androidCameraPermissionOptions={{
+            title: 'Permission to use camera',
+            message: 'We need your permission to use your camera',
+            buttonPositive: 'Ok',
+            buttonNegative: 'Cancel',
+          }}
+          androidRecordAudioPermissionOptions={{
+            title: 'Permission to use audio recording',
+            message: 'We need your permission to use your audio',
+            buttonPositive: 'Ok',
+            buttonNegative: 'Cancel',
+          }}
         >
           {({ camera, status, recordAudioPermissionStatus }) => {
             if (status !== 'READY') return <PendingView />;
@@ -245,13 +265,21 @@ Value: float from `0` to `1.0`
 
 Specifies the zoom of your camera. The value 0 is no zoom, 1 is maximum zoom. For a medium zoom, for example, you could pass `0.5`.
 
-#### `Android` `permissionDialogTitle`
+#### `Android` `permissionDialogTitle` - Depracated
 
 Starting on android M individual permissions must be granted for certain services, the camera is one of them, you can use this to change the title of the dialog prompt requesting permissions.
 
-#### `Android` `permissionDialogMessage`
+#### `Android` `permissionDialogMessage` - Depracated
 
 Starting on android M individual permissions must be granted for certain services, the camera is one of them, you can use this to change the content of the dialog prompt requesting permissions.
+
+#### `Android` `androidRecordAudioPermissionOptions`
+
+Configuration options for permissions request for recording audio. It will be passed as `rationale` parameter to [`PermissionsAndroid.request`](https://facebook.github.io/react-native/docs/permissionsandroid#request). This replaces and deprecates old `permissionDialogTitle` and `permissionDialogMessage` parameters.
+
+#### `Android` `androidCameraPermissionOptions`
+
+Configuration options for permissions request for camera. It will be passed as `rationale` parameter to [`PermissionsAndroid.request`](https://facebook.github.io/react-native/docs/permissionsandroid#request). This replaces and deprecates old `permissionDialogTitle` and `permissionDialogMessage` parameters.
 
 #### `notAuthorizedView`
 

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -16,26 +16,29 @@ import {
 
 import type { FaceFeature } from './FaceDetector';
 
+const Rationale = PropTypes.shape({
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  buttonPositive: PropTypes.string,
+  buttonNegative: PropTypes.string,
+  buttonNeutral: PropTypes.string,
+});
+
 const requestPermissions = async (
   captureAudio: boolean,
   CameraManager: any,
-  permissionDialogTitle?: string,
-  permissionDialogMessage?: string,
+  androidCameraPermissionOptions: Rationale,
+  androidRecordAudioPermissionOptions: Rationale,
 ): Promise<{ hasCameraPermissions: boolean, hasRecordAudioPermissions: boolean }> => {
   let hasCameraPermissions = false;
   let hasRecordAudioPermissions = false;
-
-  let params = undefined;
-  if (permissionDialogTitle || permissionDialogMessage) {
-    params = { title: permissionDialogTitle, message: permissionDialogMessage };
-  }
 
   if (Platform.OS === 'ios') {
     hasCameraPermissions = await CameraManager.checkVideoAuthorizationStatus();
   } else if (Platform.OS === 'android') {
     const cameraPermissionResult = await PermissionsAndroid.request(
       PermissionsAndroid.PERMISSIONS.CAMERA,
-      params,
+      androidCameraPermissionOptions,
     );
     if (typeof cameraPermissionResult === 'boolean') {
       hasCameraPermissions = cameraPermissionResult;
@@ -51,7 +54,7 @@ const requestPermissions = async (
       if (await CameraManager.checkIfRecordAudioPermissionsAreDefined()) {
         const audioPermissionResult = await PermissionsAndroid.request(
           PermissionsAndroid.PERMISSIONS.RECORD_AUDIO,
-          params,
+          androidRecordAudioPermissionOptions,
         );
         if (typeof audioPermissionResult === 'boolean') {
           hasRecordAudioPermissions = audioPermissionResult;
@@ -297,6 +300,8 @@ export default class Camera extends React.Component<PropsType, StateType> {
     autoFocusPointOfInterest: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
     permissionDialogTitle: PropTypes.string,
     permissionDialogMessage: PropTypes.string,
+    androidCameraPermissionOptions: Rationale,
+    androidRecordAudioPermissionOptions: Rationale,
     notAuthorizedView: PropTypes.element,
     pendingAuthorizationView: PropTypes.element,
     captureAudio: PropTypes.bool,
@@ -327,6 +332,14 @@ export default class Camera extends React.Component<PropsType, StateType> {
     faceDetectionClassifications: ((CameraManager.FaceDetection || {}).Classifications || {}).none,
     permissionDialogTitle: '',
     permissionDialogMessage: '',
+    androidCameraPermissionOptions: {
+      title: '',
+      message: '',
+    },
+    androidRecordAudioPermissionOptions: {
+      title: '',
+      message: '',
+    },
     notAuthorizedView: (
       <View style={styles.authorizationContainer}>
         <Text style={styles.notAuthorizedText}>Camera not authorized</Text>
@@ -529,12 +542,39 @@ export default class Camera extends React.Component<PropsType, StateType> {
   }
 
   async arePermissionsGranted() {
+    const {
+      permissionDialogTitle,
+      permissionDialogMessage,
+      androidCameraPermissionOptions,
+      androidRecordAudioPermissionOptions,
+    } = this.props;
+
+    let cameraPermissions = androidCameraPermissionOptions;
+    let audioPermissions = androidRecordAudioPermissionOptions;
+    if (permissionDialogTitle || permissionDialogMessage) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'permissionDialogTitle and permissionDialogMessage are depracated. Please use androidCameraPermissionOptions instead.',
+      );
+      cameraPermissions = {
+        ...cameraPermissions,
+        title: permissionDialogTitle,
+        message: permissionDialogMessage,
+      };
+      audioPermissions = {
+        ...audioPermissions,
+        title: permissionDialogTitle,
+        message: permissionDialogMessage,
+      };
+    }
+
     const { hasCameraPermissions, hasRecordAudioPermissions } = await requestPermissions(
       this.props.captureAudio,
       CameraManager,
-      this.props.permissionDialogTitle,
-      this.props.permissionDialogMessage,
+      cameraPermissions,
+      audioPermissions,
     );
+
     const recordAudioPermissionStatus = hasRecordAudioPermissions
       ? RecordAudioPermissionStatusEnum.AUTHORIZED
       : RecordAudioPermissionStatusEnum.NOT_AUTHORIZED;


### PR DESCRIPTION
*Overview*
Implemented feature request from #2110.
- Deprecated `permissionDialogTitle` and `permissionDialogMessage` in favour of newly introduced `androidCameraPermissionOptions` and `androidRecordAudioPermissionOptions`
- Updated documentation to reflect changes.

*Notes*
- Didn't used Rationale type from react-native library as it is not exported yet. @n1ru4l extracted it [here](https://github.com/facebook/react-native/commit/3e4d353d2c1db8d090fca8daf47ba29f7e928a82) but it hasn't been part of any release yet.