### PR TITLE
Update Camera.js console warning spelling

### DIFF
--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -644,7 +644,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     if (permissionDialogTitle || permissionDialogMessage) {
       // eslint-disable-next-line no-console
       console.warn(
-        'permissionDialogTitle and permissionDialogMessage are depracated. Please use androidCameraPermissionOptions instead.',
+        'permissionDialogTitle and permissionDialogMessage are deprecated. Please use androidCameraPermissionOptions instead.',
       );
       cameraPermissions = {
         ...cameraPermissions,


### PR DESCRIPTION
I regret not making this part of the initial pull request, but this is the final instance of that misspelling within the project.