### PR TITLE
save files in custom directory

### DIFF
--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -254,7 +254,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void takePicture(final ReadableMap options, final int viewTag, final Promise promise) {
     final ReactApplicationContext context = getReactApplicationContext();
-    final File cacheDirectory = mScopedContext.getCacheDirectory();
+    final File cacheDirectory = options.hasKey("saveInDirectory") ?
+      new File(options.getString("saveInDirectory")) :
+      mScopedContext.getCacheDirectory();
     UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
     uiManager.addUIBlock(new UIBlock() {
       @Override
@@ -276,7 +278,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void record(final ReadableMap options, final int viewTag, final Promise promise) {
       final ReactApplicationContext context = getReactApplicationContext();
-      final File cacheDirectory = mScopedContext.getCacheDirectory();
+      final File cacheDirectory = options.hasKey("saveInDirectory") ?
+        new File(options.getString("saveInDirectory")) :
+        mScopedContext.getCacheDirectory();
       UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
 
       uiManager.addUIBlock(new UIBlock() {

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -417,7 +417,13 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
             float quality = [options[@"quality"] floatValue];
             NSData *takenImageData = UIImageJPEGRepresentation(takenImage, quality);
-            NSString *path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+            NSString *path = nil;
+            if (options[@"saveInDirectory"]) {
+                NSString *directory = options[@"saveInDirectory"];
+                path = [RNFileSystem generatePathInDirectory:directory withExtension:@".jpg"];
+            } else {
+                path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+            }
             if (![options[@"doNotSave"] boolValue]) {
                 response[@"uri"] = [RNImageUtils writeImage:takenImageData toPath:path];
             }
@@ -554,8 +560,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         NSString *path = nil;
         if (options[@"path"]) {
             path = options[@"path"];
-        }
-        else {
+        } else if (options[@"saveInDirectory"]) {
+            NSString *directory = options[@"saveInDirectory"];
+            path = [RNFileSystem generatePathInDirectory:directory withExtension:@".mov"];
+        } else {
             path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".mov"];
         }
 

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -103,6 +103,7 @@ type PictureOptions = {
   fixOrientation?: boolean,
   forceUpOrientation?: boolean,
   pauseAfterCapture?: boolean,
+  saveInDirectory?: string,
 };
 
 type TrackedFaceFeature = FaceFeature & {
@@ -224,6 +225,7 @@ type RecordingOptions = {
   mute?: boolean,
   path?: string,
   videoBitrate?: number,
+  saveInDirectory?: string,
 };
 
 type EventCallbackArgumentsType = {


### PR DESCRIPTION
In my application I need to save photos and videos to different directories.
I patched react-native-camera to make it possible to specify custom paths to folders.
One can construct path to directory with a library such as RN-Fetch-Blob and pass it as an option to takePictureAsync or recordAsync.
If the change seems beneficial I am happy to share it with the community. 
