### PR TITLE
Fix android front camera face detection

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -235,7 +235,8 @@ public class RNCameraViewHelper {
 
   public static int getCorrectCameraRotation(int rotation, int facing, int cameraOrientation) {
     if (facing == CameraView.FACING_FRONT) {
-      return (360 - (cameraOrientation + rotation) % 360) % 360;
+      // Tested the below line and there's no need to do the mirror calculation
+      return (cameraOrientation + rotation) % 360;
     } else {
       final int landscapeFlip = rotationIsLandscape(rotation) ? 180 : 0;
       return (cameraOrientation - rotation + landscapeFlip) % 360;


### PR DESCRIPTION
## Intro

Android front camera face detection has been broken since this PR #2050 had landed I guess and released within **1.8.1** version.

Fixes #2100, #1962, #2246, #2221 maybe #1325

## Tested devices: 

- Pixel 2 (Android Q)
- Samsung S7 (Android 8.0)
- Nexus 5 (Android 6.0.1)