### PR TITLE
feat(android): write Exif tags to modified image file

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -10,6 +10,7 @@ import android.support.media.ExifInterface;
 import android.view.ViewGroup;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.uimanager.UIManagerModule;
@@ -306,6 +307,27 @@ public class RNCameraViewHelper {
     }
 
     return exifMap;
+  }
+
+  public static void setExifData(ExifInterface exifInterface, WritableMap exifMap) {
+    ReadableMapKeySetIterator iterator = exifMap.keySetIterator();
+    while (iterator.hasNextKey()) {
+      String key = iterator.nextKey();
+      switch (exifMap.getType(key)) {
+        case Null:
+          exifInterface.setAttribute(key, null);
+          break;
+        case Boolean:
+          exifInterface.setAttribute(key, Boolean.toString(exifMap.getBoolean(key)));
+          break;
+        case Number:
+          exifInterface.setAttribute(key, Double.toString(exifMap.getDouble(key)));
+          break;
+        case String:
+          exifInterface.setAttribute(key, exifMap.getString(key));
+          break;
+      }
+    }
   }
 
   public static Bitmap generateSimulatorPhoto(int width, int height) {

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -86,6 +86,8 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
         }
 
         try {
+            WritableMap fileExifData = null;
+
             if (inputStream != null) {
                 ExifInterface exifInterface = new ExifInterface(inputStream);
                 // Get orientation of the image from mImageData via inputStream
@@ -93,7 +95,10 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
                         ExifInterface.ORIENTATION_UNDEFINED);
 
                 // Rotate the bitmap to the proper orientation if needed
-                if (mOptions.hasKey("fixOrientation") && mOptions.getBoolean("fixOrientation") && orientation != ExifInterface.ORIENTATION_UNDEFINED) {
+                boolean fixOrientation = mOptions.hasKey("fixOrientation")
+                        && mOptions.getBoolean("fixOrientation")
+                        && orientation != ExifInterface.ORIENTATION_UNDEFINED;
+                if (fixOrientation) {
                     mBitmap = rotateBitmap(mBitmap, getImageRotation(orientation));
                 }
 
@@ -105,9 +110,28 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
                     mBitmap = flipHorizontally(mBitmap);
                 }
 
+                WritableMap exifData = null;
+                boolean writeExifToResponse = mOptions.hasKey("exif") && mOptions.getBoolean("exif");
+                boolean writeExifToFile = mOptions.hasKey("writeExif") && mOptions.getBoolean("writeExif");
+
+                // Read Exif data if needed
+                if (writeExifToResponse || writeExifToFile) {
+                    exifData = RNCameraViewHelper.getExifData(exifInterface);
+                }
+
+                // Write Exif data to output file if requested
+                if (writeExifToFile) {
+                    fileExifData = Arguments.createMap();
+                    fileExifData.merge(exifData);
+                    fileExifData.putInt("width", mBitmap.getWidth());
+                    fileExifData.putInt("height", mBitmap.getHeight());
+                    if (fixOrientation) {
+                        fileExifData.putInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+                    }
+                }
+
                 // Write Exif data to the response if requested
-                if (mOptions.hasKey("exif") && mOptions.getBoolean("exif")) {
-                    WritableMap exifData = RNCameraViewHelper.getExifData(exifInterface);
+                if (writeExifToResponse) {
                     response.putMap("exif", exifData);
                 }
             }
@@ -123,6 +147,11 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
             // Write compressed image to file in cache directory unless otherwise specified
             if (!mOptions.hasKey("doNotSave") || !mOptions.getBoolean("doNotSave")) {
                 String filePath = writeStreamToFile(imageStream);
+                if (fileExifData != null) {
+                    ExifInterface fileExifInterface = new ExifInterface(filePath);
+                    RNCameraViewHelper.setExifData(fileExifInterface, fileExifData);
+                    fileExifInterface.saveAttributes();
+                }
                 File imageFile = new File(filePath);
                 String fileUri = Uri.fromFile(imageFile).toString();
                 response.putString("uri", fileUri);

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -99,6 +99,7 @@ type PictureOptions = {
   base64?: boolean,
   mirrorImage?: boolean,
   exif?: boolean,
+  writeExif?: boolean,
   width?: number,
   fixOrientation?: boolean,
   forceUpOrientation?: boolean,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -353,6 +353,7 @@ interface TakePictureOptions {
   /** Android only */
   skipProcessing?: boolean;
   fixOrientation?: boolean;
+  writeExif?: boolean;
 
   /** iOS only */
   forceUpOrientation?: boolean;


### PR DESCRIPTION
Modifying the photos loses Exif information from the camera. So if we need it, it should be copied from the original file.
Because this operation is expensive, it should only be done if it is really necessary. Therefore this option is disabled by default.