### PR TITLE
Fix: Adding case 270 degrees to getFirebaseRotation method

### DIFF
--- a/android/src/mlkit/java/org/reactnative/camera/tasks/FaceDetectorAsyncTask.java
+++ b/android/src/mlkit/java/org/reactnative/camera/tasks/FaceDetectorAsyncTask.java
@@ -107,6 +107,9 @@ public class FaceDetectorAsyncTask extends android.os.AsyncTask<Void, Void, Void
       case 180:
         result = FirebaseVisionImageMetadata.ROTATION_180;
         break;
+      case 270:
+        result = FirebaseVisionImageMetadata.ROTATION_270;
+        break;
       case -90:
         result = FirebaseVisionImageMetadata.ROTATION_270;
         break;


### PR DESCRIPTION
## Intro

Telmen's last released PR (https://github.com/react-native-community/react-native-camera/pull/2257) did improve Android's front camera face detection. However, using RNCamera alongside with ML Kit, still presented a rotation issue, as reported in https://github.com/react-native-community/react-native-camera/issues/2261

By adding a 270 degrees case in `getFirebaseRotation()` method, the problem is fixed since some Android devices consider 270, and not -90. As it is only one other case of `switch` and Android specific code, it should not break anything that is already working.

Having this case makes Android's front camera face detection using ML Kit correct.

Fixes: https://github.com/react-native-community/react-native-camera/issues/2246, https://github.com/react-native-community/react-native-camera/issues/2261

![android-rncam-fix](https://user-images.githubusercontent.com/38483050/57639054-72490900-7585-11e9-8cec-b82f4b0bdb63.jpeg)

## Tested devices:
- Samsung S5 (Android 6.0.1)
- Moto C Plus (Android 7.0.0)
- Samsung J7 Prime (Android (8.1.0)