### PR TITLE
Exclude node_modules in sub-directories recursive searches

### DIFF
--- a/ios/RNCamera.xcodeproj/project.pbxproj
+++ b/ios/RNCamera.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 410701241ACB719800C6AA39;
@@ -235,6 +236,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXCLUDED_RECURSIVE_SEARCH_PATH_SUBDIRECTORIES = "*.nib *.lproj *.framework *.gch *.xcode* *.xcassets (*) .DS_Store CVS .svn .git .hg *.pbproj *.pbxproj node_modules";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/../../../ios/**",
 					"${BUILT_PRODUCTS_DIR}/**",
@@ -289,6 +291,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXCLUDED_RECURSIVE_SEARCH_PATH_SUBDIRECTORIES = "*.nib *.lproj *.framework *.gch *.xcode* *.xcassets (*) .DS_Store CVS .svn .git .hg *.pbproj *.pbxproj node_modules";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/../../../ios/**",
 					"${BUILT_PRODUCTS_DIR}/**",


### PR DESCRIPTION
# Summary

After manually linking the RNCamera.xcodeproj in our project we get the following build issue. Adding `node_modules` to the `Sub-Directories to Exclude in Recursive Searches` build setting appears to fix the issue. 

We've played around a bit with our project Search Path build settings without luck. 

```
info === BUILD TARGET RNCamera OF PROJECT RNCamera WITH CONFIGURATION Debug ===

info
Check dependencies

info Argument list too long: recursive header expansion failed at /Users/akenyon/repos/nebula/node_modules/react-native-camera/ios/../../../ios/Pods/React/node_modules/fsevents/node_modules/balanced-match.

info

error Failed to build iOS project. We ran "xcodebuild" command but it exited with error code 65. To debug build logs further, consider building your app with Xcode.app, by opening Shipt.xcworkspace
```
## Test Plan

Tested with existing project

## Checklist

- [x] I have tested this on a device and a simulator
