### PR TITLE
fix setParameters error

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -275,7 +275,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         }
         if (mCameraParameters != null && mCamera != null) {
             mCameraParameters.setPictureSize(mPictureSize.getWidth(), mPictureSize.getHeight());
-            mCamera.setParameters(mCameraParameters);
+            try{
+              mCamera.setParameters(mCameraParameters);
+            }
+            catch(RuntimeException e ) {
+              Log.e("Camera1", "setParameters failed", e);
+            }
         }
     }
     
@@ -314,7 +319,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             return;
         }
         if (setAutoFocusInternal(autoFocus)) {
+          try{
             mCamera.setParameters(mCameraParameters);
+          }
+          catch(RuntimeException e ) {
+            Log.e("RCTCamera1", "setParameters failed", e);
+          }
         }
     }
 
@@ -333,7 +343,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             return;
         }
         if (setFlashInternal(flash)) {
+          try{
             mCamera.setParameters(mCameraParameters);
+          }
+          catch(RuntimeException e ) {
+            Log.e("RCTCamera1", "setParameters failed", e);
+          }
         }
     }
 
@@ -354,7 +369,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             return;
         }
         if (setExposureInternal(exposure)) {
+          try{
             mCamera.setParameters(mCameraParameters);
+          }
+          catch(RuntimeException e ) {
+            Log.e("RCTCamera1", "setParameters failed", e);
+          }
         }
     }
 
@@ -374,7 +394,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             return;
         }
         if (setZoomInternal(zoom)) {
+          try{
             mCamera.setParameters(mCameraParameters);
+          }
+          catch(RuntimeException e ) {
+            Log.e("RCTCamera1", "setParameters failed", e);
+          }
         }
     }
 
@@ -389,7 +414,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             return;
         }
         if (setWhiteBalanceInternal(whiteBalance)) {
+          try{
             mCamera.setParameters(mCameraParameters);
+          }
+          catch(RuntimeException e ) {
+            Log.e("RCTCamera1", "setParameters failed", e);
+          }
         }
     }
 
@@ -470,7 +500,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 mOrientation = options.getInt("orientation");
                 int rotation = orientationEnumToRotation(mOrientation);
                 mCameraParameters.setRotation(calcCameraRotation(rotation));
-                mCamera.setParameters(mCameraParameters);
+                try{
+                  mCamera.setParameters(mCameraParameters);
+                }
+                catch(RuntimeException e ) {
+                  Log.e("RCTCamera1", "setParameters failed", e);
+                }
             }
 
             mCamera.takePicture(null, null, null, new Camera.PictureCallback() {
@@ -559,7 +594,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         mDeviceOrientation = deviceOrientation;
         if (isCameraOpened() && mOrientation == Constants.ORIENTATION_AUTO && !mIsRecording) {
             mCameraParameters.setRotation(calcCameraRotation(deviceOrientation));
-            mCamera.setParameters(mCameraParameters);
+            try{
+              mCamera.setParameters(mCameraParameters);
+            }
+            catch(RuntimeException e ) {
+              Log.e("RCTCamera1", "setParameters failed", e);
+            }
          }
     }
 
@@ -677,7 +717,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         setZoomInternal(mZoom);
         setWhiteBalanceInternal(mWhiteBalance);
         setScanningInternal(mIsScanning);
-        mCamera.setParameters(mCameraParameters);
+        try{
+          mCamera.setParameters(mCameraParameters);
+        }
+        catch(RuntimeException e ) {
+          Log.e("RCTCamera1", "setParameters failed", e);
+        }
         if (mShowingPreview) {
             startCameraPreview();
         }
@@ -744,7 +789,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 if (!parameters.getSupportedFocusModes().contains(Camera.Parameters.FOCUS_MODE_AUTO)) {
                     return; //cannot autoFocus
                 }
-                mCamera.setParameters(parameters);
+                try{
+                  mCamera.setParameters(parameters);
+                }
+                catch(RuntimeException e ) {
+                  Log.e("RCTCamera1", "setParameters failed", e);
+                }
                 mCamera.autoFocus(new Camera.AutoFocusCallback() {
                     @Override
                     public void onAutoFocus(boolean success, Camera camera) {
@@ -759,7 +809,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 parameters.setFocusAreas(meteringAreas);
                 parameters.setMeteringAreas(meteringAreas);
 
-                mCamera.setParameters(parameters);
+                try{
+                  mCamera.setParameters(parameters);
+                }
+                catch(RuntimeException e ) {
+                  Log.e("RCTCamera1", "setParameters failed", e);
+                }
                 mCamera.autoFocus(new Camera.AutoFocusCallback() {
                     @Override
                     public void onAutoFocus(boolean success, Camera camera) {
@@ -791,7 +846,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                         parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
                         parameters.setFocusAreas(null);
                         parameters.setMeteringAreas(null);
-                        mCamera.setParameters(parameters);
+                        try{
+                          mCamera.setParameters(parameters);
+                        }
+                        catch(RuntimeException e ) {
+                          Log.e("RCTCamera1", "setParameters failed", e);
+                        }
                     }
 
                     mCamera.cancelAutoFocus();

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -279,7 +279,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
               mCamera.setParameters(mCameraParameters);
             }
             catch(RuntimeException e ) {
-              Log.e("Camera1", "setParameters failed", e);
+              Log.e("CAMERA_1::", "setParameters failed", e);
             }
         }
     }
@@ -323,7 +323,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             mCamera.setParameters(mCameraParameters);
           }
           catch(RuntimeException e ) {
-            Log.e("RCTCamera1", "setParameters failed", e);
+            Log.e("CAMERA_1::", "setParameters failed", e);
           }
         }
     }
@@ -347,7 +347,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             mCamera.setParameters(mCameraParameters);
           }
           catch(RuntimeException e ) {
-            Log.e("RCTCamera1", "setParameters failed", e);
+            Log.e("CAMERA_1::", "setParameters failed", e);
           }
         }
     }
@@ -373,7 +373,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             mCamera.setParameters(mCameraParameters);
           }
           catch(RuntimeException e ) {
-            Log.e("RCTCamera1", "setParameters failed", e);
+            Log.e("CAMERA_1::", "setParameters failed", e);
           }
         }
     }
@@ -398,7 +398,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             mCamera.setParameters(mCameraParameters);
           }
           catch(RuntimeException e ) {
-            Log.e("RCTCamera1", "setParameters failed", e);
+            Log.e("CAMERA_1::", "setParameters failed", e);
           }
         }
     }
@@ -418,7 +418,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             mCamera.setParameters(mCameraParameters);
           }
           catch(RuntimeException e ) {
-            Log.e("RCTCamera1", "setParameters failed", e);
+            Log.e("CAMERA_1::", "setParameters failed", e);
           }
         }
     }
@@ -504,7 +504,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                   mCamera.setParameters(mCameraParameters);
                 }
                 catch(RuntimeException e ) {
-                  Log.e("RCTCamera1", "setParameters failed", e);
+                  Log.e("CAMERA_1::", "setParameters failed", e);
                 }
             }
 
@@ -598,7 +598,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
               mCamera.setParameters(mCameraParameters);
             }
             catch(RuntimeException e ) {
-              Log.e("RCTCamera1", "setParameters failed", e);
+              Log.e("CAMERA_1::", "setParameters failed", e);
             }
          }
     }
@@ -721,7 +721,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
           mCamera.setParameters(mCameraParameters);
         }
         catch(RuntimeException e ) {
-          Log.e("RCTCamera1", "setParameters failed", e);
+          Log.e("CAMERA_1::", "setParameters failed", e);
         }
         if (mShowingPreview) {
             startCameraPreview();
@@ -793,7 +793,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                   mCamera.setParameters(parameters);
                 }
                 catch(RuntimeException e ) {
-                  Log.e("RCTCamera1", "setParameters failed", e);
+                  Log.e("CAMERA_1::", "setParameters failed", e);
                 }
                 mCamera.autoFocus(new Camera.AutoFocusCallback() {
                     @Override
@@ -813,7 +813,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                   mCamera.setParameters(parameters);
                 }
                 catch(RuntimeException e ) {
-                  Log.e("RCTCamera1", "setParameters failed", e);
+                  Log.e("CAMERA_1::", "setParameters failed", e);
                 }
                 mCamera.autoFocus(new Camera.AutoFocusCallback() {
                     @Override
@@ -850,7 +850,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                           mCamera.setParameters(parameters);
                         }
                         catch(RuntimeException e ) {
-                          Log.e("RCTCamera1", "setParameters failed", e);
+                          Log.e("CAMERA_1::", "setParameters failed", e);
                         }
                     }
 

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -221,7 +221,12 @@ public class RCTCamera {
         // this hint can help reduce the time it takes to start recording.
         Camera.Parameters parameters = camera.getParameters();
         parameters.setRecordingHint(captureMode == RCTCameraModule.RCT_CAMERA_CAPTURE_MODE_VIDEO);
-        camera.setParameters(parameters);
+        try{
+          camera.setParameters(parameters);
+        }
+        catch(RuntimeException e ) {
+          Log.e("RCTCamera", "setParameters failed", e);
+        }
     }
 
     public void setCaptureQuality(int cameraType, String captureQuality) {
@@ -260,7 +265,12 @@ public class RCTCamera {
 
         if (pictureSize != null) {
             parameters.setPictureSize(pictureSize.width, pictureSize.height);
+            try{
             camera.setParameters(parameters);
+            }
+            catch(RuntimeException e ) {
+              Log.e("RCTCamera", "setParameters failed", e);
+            }
         }
     }
 
@@ -332,7 +342,12 @@ public class RCTCamera {
         List<String> flashModes = parameters.getSupportedFlashModes();
         if (flashModes != null && flashModes.contains(value)) {
             parameters.setFlashMode(value);
-            camera.setParameters(parameters);
+            try{
+              camera.setParameters(parameters);
+            }
+          catch(RuntimeException e ) {
+            Log.e("RCTCamera", "setParameters failed", e);
+          }
         }
     }
 
@@ -358,7 +373,12 @@ public class RCTCamera {
         List<String> flashModes = parameters.getSupportedFlashModes();
         if (flashModes != null && flashModes.contains(value)) {
             parameters.setFlashMode(value);
+            try{
             camera.setParameters(parameters);
+            }
+            catch(RuntimeException e ) {
+              Log.e("RCTCamera", "setParameters failed", e);
+            }
         }
     }
 
@@ -373,7 +393,12 @@ public class RCTCamera {
         if (parameters.isZoomSupported()) {
             if (zoom >=0 && zoom < maxZoom) {
                 parameters.setZoom(zoom);
-                camera.setParameters(parameters);
+                try{
+                  camera.setParameters(parameters);
+                }
+                catch(RuntimeException e ) {
+                  Log.e("RCTCamera", "setParameters failed", e);
+                }
             }
         }
     }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -734,7 +734,12 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
         if (parameters.isZoomSupported()) {
             if (zoom >=0 && zoom < maxZoom) {
                 parameters.setZoom(zoom);
-                camera.setParameters(parameters);
+                try{
+                  camera.setParameters(parameters);
+                }
+                catch(RuntimeException e ) {
+                  Log.e("RCTCameraModule", "setParameters failed", e);
+                }
             }
         }
     }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
@@ -188,7 +188,12 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
                 );
                 parameters.setPictureSize(optimalPictureSize.width, optimalPictureSize.height);
 
-                _camera.setParameters(parameters);
+                try{
+                  _camera.setParameters(parameters);
+                }
+                catch(RuntimeException e ) {
+                  Log.e("RCTCameraViewFinder", "setParameters failed", e);
+                }
                 _camera.setPreviewTexture(_surfaceTexture);
                 _camera.startPreview();
                 // clear window background if needed
@@ -476,7 +481,12 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
         }
         mFingerSpacing = newDist;
         params.setZoom(zoom);
-        _camera.setParameters(params);
+        try{
+          _camera.setParameters(params);
+        }
+        catch(RuntimeException e ) {
+          Log.e("RCTCameraViewFinder", "setParameters failed", e);
+        }
     }
 
     /**
@@ -522,7 +532,12 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
             }
 
             // Set parameters before starting auto-focus.
-            _camera.setParameters(params);
+            try{
+              _camera.setParameters(params);
+            }
+            catch(RuntimeException e ) {
+              Log.e("RCTCameraViewFinder", "setParameters failed", e);
+            }
 
             // Start auto-focus now that focus area has been set. If successful, then can cancel
             // it afterwards. Wrap in try-catch to avoid crashing on merely autoFocus fails.

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
@@ -13,6 +13,7 @@ import android.hardware.Camera;
 import android.view.MotionEvent;
 import android.view.TextureView;
 import android.os.AsyncTask;
+import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;


### PR DESCRIPTION
Hi, 
This is a solution to setParameters error, it seems that that there are a lot of border cases when We set the parameters of the Camara, because depending the device it could change and raise a RuntimeError. I have an error in only one specific device Galaxy Tab A 7.0.

This fix will not change any logic, it continue working the same way. The only difference is that is catching RuntimeException at the moment of setting the parameters.
 
I was searching for the best solution, but adding try catch it was the only solution I found, because I can't replicate this in all the devices: https://stackoverflow.com/questions/39878068/exception-java-lang-runtimeexception-setparameters-failed

Let me know what do you think guys.