### PR TITLE
Feature/adding stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,45 @@
+# Configuration for probot-stale based on: https://github.com/facebook/react-native/blob/master/.github/stale.yml
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - For Discussion
+  - semantic-release
+  - Needs revision
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions. You may also mark this issue as a "discussion" and i
+  will leave this open.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  Closing this issue after a prolonged period of inactivity. Fell free to reopen
+  this issue, if this still affecting you.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
# Summary
Adding a stale.yml based on react-native and [react-native-share](https://github.com/react-native-community/react-native-share/blob/master/.github/stale.yml) to handle issues older than 60 days.

# Motivation
Since we have about 370 open issues, applying a stale to handle dead issues is a good way to go to give attention to newer issues.

Applying this PR will <b>throw a "spam"</b> on github notification/email since there are many open issues. :skull: 