### PR TITLE
Fixes type of the onStatusChange callback in types/index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -144,7 +144,7 @@ export interface RNCameraProps {
 
   onCameraReady?(): void;
   onStatusChange?(event: {
-    cameraStatus: CameraStatus;
+    cameraStatus: keyof CameraStatus;
     recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
   }): void;
   onMountError?(error: { message: string }): void;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Currently, the `onStatusChange` has a type of 
```ts
  onStatusChange?(event: {
    cameraStatus: CameraStatus;
    recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
  }): void
```
Which makes it very inconvenient to use with Typescript, having to set the `cameraStatus` field to `any` in the passed function:
```ts
  const handleStatusChange = (event: {cameraStatus: any}) => {
    if (event.cameraStatus === 'NOT_AUTHORIZED') {
    }
  }
```
By changing it to
```ts
  onStatusChange?(event: {
    cameraStatus: keyof CameraStatus;
    recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
  }): void
```
we're able to compare the new status against the intended type, autocomplete, and discard the `any`:
```ts
  const handleStatusChange = (event: {cameraStatus: keyof CameraStatus}) => {
    if (event.cameraStatus === 'NOT_AUTHORIZED') {
      onUnauthorized()
    }
  }
```

## Test Plan

As far as I can see, this doesn't affect the way RNCamera works, just how it can be used in a TS codebase.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
