### PR TITLE
Fix two crashes on iOS where error leads to runSession being called b…

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -697,6 +697,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
         if (error || captureDeviceInput == nil) {
             RCTLog(@"%s: %@", __func__, error);
+            [self.session commitConfiguration];
             return;
         }
 
@@ -766,6 +767,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
             if (error || audioDeviceInput == nil) {
                 RCTLogWarn(@"%s: %@", __func__, error);
+                [self.session commitConfiguration];
                 return;
             }
 


### PR DESCRIPTION
…efore commitConfiguration

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

iOS 12, iPhone XS: user REJECTS camera permission ("Don't allow").
Next time app launches: CRASH with

```
2019-06-21 15:52:01.358925-0400 Bike[1621:93865] -[RNCamera initializeCaptureSessionInput]_block_invoke: Error Domain=AVFoundationErrorDomain Code=-11852 "Cannot use Back Camera" UserInfo={NSLocalizedFailureReason=This app is not authorized to use Back Camera., AVErrorDeviceKey=<AVCaptureFigVideoDevice: 0x13720b660 [Back Camera][com.apple.avfoundation.avcapturedevice.built-in_video:0]>, NSLocalizedDescription=Cannot use Back Camera}
2019-06-21 15:52:01.396681-0400 Bike[1621:93865] *** Terminating app due to uncaught exception 'NSGenericException', reason: '*** -[AVCaptureSession startRunning] startRunning may not be called between calls to beginConfiguration and commitConfiguration'
*** First throw call stack:
(0x19a0a63a8 0x1992abd00 0x1a013c38c 0x102bec8b4 0x10658b1f8 0x10658c778 0x106594a34 0x10659573c 0x10659f474 0x199cb0a98 0x199cb6dc4)
libc++abi.dylib: terminating with uncaught exception of type NSException
(lldb) 
```

This crashes because `beginConfiguration` was called but in the error condition it does not call `commitConfiguration`. Later `startRunning` is called, which is fatal if `commitConfiguration` was not called first


## Test Plan

Please update existing test plans to include testing the case where the user rejects permission to camera, if that's not already covered?

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    n/a    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [YES ] I have tested this on a device and a simulator
- [ N/A ] I added the documentation in `README.md`
- [ N/A ] I mentioned this change in `CHANGELOG.md`
- [ N/A ] I updated the typed files (TS and Flow)
- [ N/A ] I added a sample use of the API in the example project (`example/App.js`)
