### PR TITLE
fix(RNCameraViewHelper): Check for TAG_ORIENTATION when setting exif …

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -321,7 +321,12 @@ public class RNCameraViewHelper {
           exifInterface.setAttribute(key, Boolean.toString(exifMap.getBoolean(key)));
           break;
         case Number:
-          exifInterface.setAttribute(key, Double.toString(exifMap.getDouble(key)));
+          // This is to fix an issue with using doubles for Orientation
+          if (key.equals(ExifInterface.TAG_ORIENTATION)) {
+            exifInterface.setAttribute(key, Integer.toString(exifMap.getInt(key)));
+          } else {
+            exifInterface.setAttribute(key, Double.toString(exifMap.getDouble(key)));
+          }
           break;
         case String:
           exifInterface.setAttribute(key, exifMap.getString(key));


### PR DESCRIPTION
…attributes so Integer can be used

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary 
Fixes #1053 on Android by writing out correct EXIF data for picture orientation (using Integer type instead of Double type).  Affects RNCameraViewHelper.

## Test Plan

Used http://exif.regex.info/exif.cgi for before and after tests of images

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

I was able to reproduce this issue using a Google Pixel 2 XL phone.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)