### PR TITLE
fix(android): prevent crash when using Camera2 with autoFocusPointOfInterest

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -1050,6 +1050,9 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
 
     // Much credit - https://gist.github.com/royshil/8c760c2485257c85a11cafd958548482
     void setFocusArea(float x, float y) {
+        if (mCaptureSession == null) {
+            return;
+        }
         CameraCaptureSession.CaptureCallback captureCallbackHandler = new CameraCaptureSession.CaptureCallback() {
             @Override
             public void onCaptureCompleted(CameraCaptureSession session, CaptureRequest request, TotalCaptureResult result) {
@@ -1074,7 +1077,6 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
 
         try {
             mCaptureSession.stopRepeating();
-
         } catch (CameraAccessException e) {
             Log.e(TAG, "Failed to manual focus.", e);
         }


### PR DESCRIPTION
# Summary

Crashes on component init when using Camera2 with autoFocusPointOfInterest:

> com.facebook.react.bridge.JSApplicationIllegalArgumentException: Error while updating property 'autoFocusPointOfInterest' of a view managed by: RNCamera
> 	at com.facebook.react.uimanager.ViewManagersPropertyCache$PropSetter.updateViewProp(ViewManagersPropertyCache.java:95)
> 	...  23 more
> Caused by: java.lang.reflect.InvocationTargetException
> 	at java.lang.reflect.Method.invoke(Native Method)
> 	at com.facebook.react.uimanager.ViewManagersPropertyCache$PropSetter.updateViewProp(ViewManagersPropertyCache.java:83)
> 	... 23 more
> Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.hardware.camera2.CameraCaptureSession.stopRepeating()' on a null object reference
> 	at com.google.android.cameraview.Camera2.setFocusArea(Camera2.java:1076)
> 	at com.google.android.cameraview.CameraView.setAutoFocusPointOfInterest(CameraView.java:506)
> 	at org.reactnative.camera.CameraViewManager.setAutoFocusPointOfInterest(CameraViewManager.java:105)
> 	... 25 more

## Test Plan

`
                <RNCamera
                    autoFocusPointOfInterest={{ x: 0.5, y: 0.5 }}
                    useCamera2Api={true}
                    {...rest}
                />
`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
