### PR TITLE
fix(android): Support writing custom Exif tags to modified image file

### DIFF
--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -15,6 +15,7 @@ import org.reactnative.camera.utils.RNFileUtils;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 
 import java.io.ByteArrayInputStream;
@@ -119,8 +120,20 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
                 }
 
                 WritableMap exifData = null;
+                ReadableMap exifExtraData = null;
                 boolean writeExifToResponse = mOptions.hasKey("exif") && mOptions.getBoolean("exif");
-                boolean writeExifToFile = mOptions.hasKey("writeExif") && mOptions.getBoolean("writeExif");
+                boolean writeExifToFile = false;
+                if (mOptions.hasKey("writeExif")) {
+                    switch (mOptions.getType("writeExif")) {
+                        case Boolean:
+                            writeExifToFile = mOptions.getBoolean("writeExif");
+                            break;
+                        case Map:
+                            exifExtraData = mOptions.getMap("writeExif");
+                            writeExifToFile = true;
+                            break;
+                    }
+                }
 
                 // Read Exif data if needed
                 if (writeExifToResponse || writeExifToFile) {
@@ -135,6 +148,9 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
                     fileExifData.putInt("height", mBitmap.getHeight());
                     if (fixOrientation) {
                         fileExifData.putInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+                    }
+                    if (exifExtraData != null) {
+                        fileExifData.merge(exifExtraData);
                     }
                 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,7 +29,7 @@ interface TakePictureOptions {
   /** Android only */
   skipProcessing?: boolean;
   fixOrientation?: boolean;
-  writeExif?: boolean;
+  writeExif?: boolean | { [name: string]: any };
 
   /** iOS only */
   forceUpOrientation?: boolean;

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -99,7 +99,7 @@ type PictureOptions = {
   base64?: boolean,
   mirrorImage?: boolean,
   exif?: boolean,
-  writeExif?: boolean,
+  writeExif?: boolean | { [name: string]: any },
   width?: number,
   fixOrientation?: boolean,
   forceUpOrientation?: boolean,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -353,7 +353,7 @@ interface TakePictureOptions {
   /** Android only */
   skipProcessing?: boolean;
   fixOrientation?: boolean;
-  writeExif?: boolean;
+  writeExif?: boolean | { [name: string]: any };
 
   /** iOS only */
   forceUpOrientation?: boolean;


### PR DESCRIPTION
# Summary
Adding an option to set a data object to field **writeExif** in **takePictureAsync** options, so that it can be saved custom Exif tags to modified image file.

## Test Plan
Here is example with GPS coordinates:
```
  takePicture = async() => {
    if (this.camera) {
      const options = {
        quality: 0.5,
        writeExif: {
            GPSLatitude: 42.733883,
            GPSLongitude: 25.48583,
            GPSAltitude: 0
        }
      };
      const data = await this.camera.takePictureAsync(options);
    }
  };
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
