### PR TITLE
fix: use initial exposure value

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -979,8 +979,8 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
 
     private boolean setExposureInternal(int exposure) {
         Log.e("CAMERA_1::", ""+isCameraOpened()+"; Exposure: "+exposure);
+        mExposure = exposure;
         if (isCameraOpened()){
-            mExposure = exposure;
             int minExposure = mCameraParameters.getMinExposureCompensation();
             int maxExposure = mCameraParameters.getMaxExposureCompensation();
             Log.e("CAMERA_1::", ""+minExposure);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -139,6 +139,7 @@ export interface RNCameraProps {
   notAuthorizedView?: JSX.Element;
   pendingAuthorizationView?: JSX.Element;
   useCamera2Api?: boolean;
+  exposure?: number;
   whiteBalance?: keyof WhiteBalance;
   captureAudio?: boolean;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

The initial exposure value given as prop to RNCamera is overwritten with 0, since the camera isn't open at start time. With this fix the exposure value is actually used.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
