### PR TITLE
Add exposure (brightness) support for iOS and standardize exposure value

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -846,8 +846,6 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                   Log.e("CAMERA_1::", "autoFocus failed", e);
                 }
             }
-
-            setExposureInternal(-1);
         }
     }
 

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -106,7 +106,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
 
     private int mFlash;
 
-    private int mExposure;
+    private float mExposure;
 
     private int mDisplayOrientation;
 
@@ -358,12 +358,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     }
 
     @Override
-    int getExposureCompensation() {
+    float getExposureCompensation() {
         return mExposure;
     }
 
     @Override
-    void setExposureCompensation(int exposure) {
+    void setExposureCompensation(float exposure) {
 
         if (exposure == mExposure) {
             return;
@@ -846,6 +846,8 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                   Log.e("CAMERA_1::", "autoFocus failed", e);
                 }
             }
+
+            setExposureInternal(-1);
         }
     }
 
@@ -994,17 +996,21 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         }
     }
 
-    private boolean setExposureInternal(int exposure) {
+    private boolean setExposureInternal(float exposure) {
         Log.e("CAMERA_1::", ""+isCameraOpened()+"; Exposure: "+exposure);
         mExposure = exposure;
         if (isCameraOpened()){
             int minExposure = mCameraParameters.getMinExposureCompensation();
             int maxExposure = mCameraParameters.getMaxExposureCompensation();
-            Log.e("CAMERA_1::", ""+minExposure);
-            Log.e("CAMERA_1::", ""+maxExposure);
 
             if (minExposure != maxExposure) {
-                mCameraParameters.setExposureCompensation(mExposure);
+                int scaledValue = 0;
+                if (mExposure >= 0 && mExposure <= 1) {
+                    scaledValue = (int) (mExposure * (maxExposure - minExposure)) + minExposure; 
+                    Log.e("CAMERA_1::", "New exposure value: "+scaledValue);
+                }
+
+                mCameraParameters.setExposureCompensation(scaledValue);
                 return true;
             }
         }

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -997,7 +997,6 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     }
 
     private boolean setExposureInternal(float exposure) {
-        Log.e("CAMERA_1::", ""+isCameraOpened()+"; Exposure: "+exposure);
         mExposure = exposure;
         if (isCameraOpened()){
             int minExposure = mCameraParameters.getMinExposureCompensation();
@@ -1007,7 +1006,6 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 int scaledValue = 0;
                 if (mExposure >= 0 && mExposure <= 1) {
                     scaledValue = (int) (mExposure * (maxExposure - minExposure)) + minExposure; 
-                    Log.e("CAMERA_1::", "New exposure value: "+scaledValue);
                 }
 
                 mCameraParameters.setExposureCompensation(scaledValue);

--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -238,7 +238,7 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
 
     private int mFlash;
 
-    private int mExposure;
+    private float mExposure;
 
     private int mCameraOrientation;
 
@@ -477,12 +477,12 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
     }
 
     @Override
-    int getExposureCompensation() {
+    float getExposureCompensation() {
         return mExposure;
     }
 
     @Override
-    void setExposureCompensation(int exposure) {
+    void setExposureCompensation(float exposure) {
         Log.e("CAMERA_2:: ", "Adjusting exposure is not currently supported for Camera2");
     }
 

--- a/android/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraView.java
@@ -478,11 +478,11 @@ public class CameraView extends FrameLayout {
         return mImpl.getFlash();
     }
 
-    public void setExposureCompensation(int exposure) {
+    public void setExposureCompensation(float exposure) {
         mImpl.setExposureCompensation(exposure);
     }
 
-    public int getExposureCompensation() {
+    public float getExposureCompensation() {
         return mImpl.getExposureCompensation();
     }
 
@@ -653,7 +653,7 @@ public class CameraView extends FrameLayout {
         @Flash
         int flash;
 
-        int exposure;
+        float exposure;
 
         float focusDepth;
 
@@ -672,7 +672,7 @@ public class CameraView extends FrameLayout {
             ratio = source.readParcelable(loader);
             autoFocus = source.readByte() != 0;
             flash = source.readInt();
-            exposure = source.readInt();
+            exposure = source.readFloat();
             focusDepth = source.readFloat();
             zoom = source.readFloat();
             whiteBalance = source.readInt();
@@ -691,7 +691,7 @@ public class CameraView extends FrameLayout {
             out.writeParcelable(ratio, 0);
             out.writeByte((byte) (autoFocus ? 1 : 0));
             out.writeInt(flash);
-            out.writeInt(exposure);
+            out.writeFloat(exposure);
             out.writeFloat(focusDepth);
             out.writeFloat(zoom);
             out.writeInt(whiteBalance);

--- a/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
@@ -76,9 +76,9 @@ abstract class CameraViewImpl {
 
     abstract int getFlash();
 
-    abstract void setExposureCompensation(int exposure);
+    abstract void setExposureCompensation(float exposure);
 
-    abstract int getExposureCompensation();
+    abstract float getExposureCompensation();
 
     abstract void takePicture(ReadableMap options);
 

--- a/android/src/main/java/org/reactnative/camera/CameraViewManager.java
+++ b/android/src/main/java/org/reactnative/camera/CameraViewManager.java
@@ -84,7 +84,7 @@ public class CameraViewManager extends ViewGroupManager<RNCameraView> {
   }
 
   @ReactProp(name = "exposure")
-  public void setExposureCompensation(RNCameraView view, int exposure){
+  public void setExposureCompensation(RNCameraView view, float exposure){
     view.setExposureCompensation(exposure);
   }
 

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -32,6 +32,9 @@
 @property(copy, nonatomic) NSDictionary *autoFocusPointOfInterest;
 @property(assign, nonatomic) float focusDepth;
 @property(assign, nonatomic) NSInteger whiteBalance;
+@property(assign, nonatomic) float exposure;
+@property(assign, nonatomic) float exposureIsoMin;
+@property(assign, nonatomic) float exposureIsoMax;
 @property(assign, nonatomic) AVCaptureSessionPreset pictureSize;
 @property(nonatomic, assign) BOOL isReadingBarCodes;
 @property(nonatomic, assign) BOOL isRecording;
@@ -56,6 +59,7 @@
 - (void)updateAutoFocusPointOfInterest;
 - (void)updateZoom;
 - (void)updateWhiteBalance;
+- (void)updateExposure;
 - (void)updatePictureSize;
 // Face Detection props
 - (void)updateTrackingEnabled:(id)requestedTracking;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -239,12 +239,6 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             CGPoint autofocusPoint = CGPointMake(xValue, yValue);
             [device setFocusPointOfInterest:autofocusPoint];
             [device setFocusMode:AVCaptureFocusModeContinuousAutoFocus];
-            
-            // Manual selection of AFPoI also resets the manual exposure, if there was any.
-            if(self.exposure >= 0 && self.exposure <= 1){
-                self.exposure = -1;
-                [device setExposureMode:AVCaptureExposureModeContinuousAutoExposure];
-            }
         }
         else {
             RCTLogWarn(@"AutoFocusPointOfInterest not supported");

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -358,6 +358,17 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [device unlockForConfiguration];
 }
 
+
+/// Set the AVCaptureDevice's ISO values based on RNCamera's 'exposure' value,
+/// which is a float between 0 and 1 if defined by the user or -1 to indicate that no
+/// selection is active.
+///
+/// The exposure gets reset every time the user manually sets the autofocus-point in
+/// 'updateAutoFocusPointOfInterest' automatically. Currently no explicit event is fired.
+/// This leads to two 'exposure'-states: one here and one in the component, which is
+/// fine. 'exposure' here gets only synced if 'exposure' on the js-side changes. You
+/// can manually keep the state in sync by setting 'exposure' in your React-state
+/// everytime the js-updateAutoFocusPointOfInterest-function gets called.
 - (void)updateExposure
 {
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
@@ -370,8 +381,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         return;
     }
     
-    // Flag to indicate that either no explicit exposure-val has been set yet
-    // or that it has been reset. Check for > 1 only a gurad.
+    // Check that either no explicit exposure-val has been set yet
+    // or that it has been reset. Check for > 1 is only a guard.
     if(self.exposure < 0 || self.exposure > 1){
         [device setExposureMode:AVCaptureExposureModeContinuousAutoExposure];
         [device unlockForConfiguration];
@@ -383,7 +394,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     if(!self.exposureIsoMax){ self.exposureIsoMax = device.activeFormat.maxISO; }
     
     // Get a valid ISO-value in range from min to max. After we mapped the exposure
-    // (a val between 0 - 1), the result gets corrected by the offset from 0, witch
+    // (a val between 0 - 1), the result gets corrected by the offset from 0, which
     // is the min-ISO-value.
     float appliedExposure = (self.exposureIsoMax - self.exposureIsoMin) * self.exposure + self.exposureIsoMin;
     

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -361,7 +361,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
 /// Set the AVCaptureDevice's ISO values based on RNCamera's 'exposure' value,
 /// which is a float between 0 and 1 if defined by the user or -1 to indicate that no
-/// selection is active.
+/// selection is active. 'exposure' gets mapped to a valid ISO value between the
+/// device's min/max-range of ISO-values.
 ///
 /// The exposure gets reset every time the user manually sets the autofocus-point in
 /// 'updateAutoFocusPointOfInterest' automatically. Currently no explicit event is fired.

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -206,6 +206,12 @@ RCT_CUSTOM_VIEW_PROPERTY(whiteBalance, NSInteger, RNCamera)
     [view updateWhiteBalance];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(exposure, NSNumber, RNCamera)
+{
+    [view setExposure:[RCTConvert float:json]];
+    [view updateExposure];
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(pictureSize, NSString *, RNCamera)
 {
     [view setPictureSize:[[self class] pictureSizes][[RCTConvert NSString:json]]];

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -420,7 +420,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     type: CameraManager.Type.back,
     autoFocus: CameraManager.AutoFocus.on,
     flashMode: CameraManager.FlashMode.off,
-    exposure: 0,
+    exposure: -1,
     whiteBalance: CameraManager.WhiteBalance.auto,
     faceDetectionMode: (CameraManager.FaceDetection || {}).fast,
     barCodeTypes: Object.values(CameraManager.BarCodeType),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Add change of camera exposure for iOS and use a standardized exposure float value between 0 and 1 for all devices (previously the knowledge of the min and max exposure compensation level of the used android device was needed). -1 indicates that no custom exposure is desired. 

The exposure gets reset every time the user manually sets the autofocus-point automatically. Currently no explicit event is fired. This leads to two 'exposure'-states: one on the native side and one in the component, which is fine. 'exposure' on the native side gets only synced if 'exposure' on the js-side changes. The state can manually be kept in sync by setting 'exposure' in the React-state everytime the js-updateAutoFocusPointOfInterest-function gets called.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
