### PR TITLE
feat: (iOS Only) Discussion - auto-expose on point of interest && trigger on subject change

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -91,5 +91,6 @@
 - (void)onText:(NSDictionary *)event;
 - (void)onBarcodesDetected:(NSDictionary *)event;
 - (bool)isRecording;
+- (void)onSubjectAreaChanged:(NSDictionary *)event;
 
 @end

--- a/ios/RN/RNCameraManager.h
+++ b/ios/RN/RNCameraManager.h
@@ -62,4 +62,3 @@ typedef NS_ENUM(NSInteger, RNCameraVideoResolution) {
 + (NSDictionary *)validVideoStabilizationModes;
 
 @end
-

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -19,6 +19,7 @@ RCT_EXPORT_VIEW_PROPERTY(onFacesDetected, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onGoogleVisionBarcodesDetected, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onPictureSaved, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTextRecognized, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onSubjectAreaChanged, RCTDirectEventBlock);
 
 + (BOOL)requiresMainQueueSetup
 {
@@ -78,7 +79,7 @@ RCT_EXPORT_VIEW_PROPERTY(onTextRecognized, RCTDirectEventBlock);
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"onCameraReady", @"onMountError", @"onBarCodeRead", @"onFacesDetected", @"onPictureSaved", @"onTextRecognized", @"onGoogleVisionBarcodesDetected"];
+    return @[@"onCameraReady", @"onMountError", @"onBarCodeRead", @"onFacesDetected", @"onPictureSaved", @"onTextRecognized", @"onGoogleVisionBarcodesDetected", @"onSubjectAreaChanged"\];
 }
 
 + (NSDictionary *)validCodecTypes
@@ -241,7 +242,7 @@ RCT_CUSTOM_VIEW_PROPERTY(faceDetectionClassifications, NSString, RNCamera)
 
 RCT_CUSTOM_VIEW_PROPERTY(barCodeScannerEnabled, BOOL, RNCamera)
 {
-    
+
     view.isReadingBarCodes = [RCTConvert BOOL:json];
     [view setupOrDisableBarcodeScanner];
 }
@@ -264,7 +265,7 @@ RCT_CUSTOM_VIEW_PROPERTY(googleVisionBarcodeDetectorEnabled, BOOL, RNCamera)
 
 RCT_CUSTOM_VIEW_PROPERTY(textRecognizerEnabled, BOOL, RNCamera)
 {
-    
+
     view.canReadText = [RCTConvert BOOL:json];
     [view setupOrDisableTextDetector];
 }
@@ -380,7 +381,7 @@ RCT_REMAP_METHOD(stopRecording, reactTag:(nonnull NSNumber *)reactTag)
 RCT_EXPORT_METHOD(checkDeviceAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
     __block NSString *mediaType = AVMediaTypeVideo;
-    
+
     [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
         if (!granted) {
             resolve(@(granted));

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -241,6 +241,7 @@ type PropsType = typeof View.props & {
   onBarCodeRead?: Function,
   onPictureSaved?: Function,
   onGoogleVisionBarcodesDetected?: ({ barcodes: Array<TrackedBarcodeFeature> }) => void,
+  onSubjectAreaChanged?: ({ nativeEvent: { prevPoint: {| x: number, y: number |} } }) => void,
   faceDetectionMode?: number,
   trackingEnabled?: boolean,
   flashMode?: number | string,
@@ -376,6 +377,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     onGoogleVisionBarcodesDetected: PropTypes.func,
     onFacesDetected: PropTypes.func,
     onTextRecognized: PropTypes.func,
+    onSubjectAreaChanged: PropTypes.func,
     trackingEnabled: PropTypes.bool,
     faceDetectionMode: PropTypes.number,
     faceDetectionLandmarks: PropTypes.number,
@@ -622,6 +624,12 @@ export default class Camera extends React.Component<PropsType, StateType> {
     }
   };
 
+  _onSubjectAreaChanged = e => {
+    if (this.props.onSubjectAreaChanged) {
+      this.props.onSubjectAreaChanged(e);
+    }
+  };
+
   _setReference = (ref: ?Object) => {
     if (ref) {
       this._cameraRef = ref;
@@ -752,6 +760,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
             onFacesDetected={this._onObjectDetected(this.props.onFacesDetected)}
             onTextRecognized={this._onObjectDetected(this.props.onTextRecognized)}
             onPictureSaved={this._onPictureSaved}
+            onSubjectAreaChanged={this._onSubjectAreaChanged}
           />
           {this.renderChildren()}
         </View>
@@ -818,6 +827,7 @@ const RNCamera = requireNativeComponent('RNCamera', Camera, {
     onFaceDetected: true,
     onLayout: true,
     onMountError: true,
+    onSubjectAreaChanged: true,
     renderToHardwareTextureAndroid: true,
     testID: true,
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -134,6 +134,7 @@ export interface RNCameraProps {
 
   autoFocus?: keyof AutoFocus;
   autoFocusPointOfInterest?: Point;
+  onSubjectAreaChanged?: (event: { nativeEvent: { prevPoint: { x: number; y: number; } } }) => void;
   type?: keyof CameraType;
   flashMode?: keyof FlashMode;
   notAuthorizedView?: JSX.Element;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

This PR is for discussion of potential API to solve the "motivation" below. As the PR is right now, it changes pre-existing behavior (adds autoexposure when autoFocusPointOfInterest is set). I did not update readme or changelong yet as I expect this API to change based on feedback from you all.

Motivation: On the focused point, I also needed auto exposure. I also needed to let go of the auto-focused area once subject changes.

Feature: Auto exposure on the `autoFocusPointOfInterest`. Trigger when subject changes (so I can null out the `autoFocusPointOfInterest`).
How: I modified current `updateAutoFocusPointOfInterest` to also auto expose. I then added the delegate of onSubjectMonitor to trigger a callback. Subject monitor only triggers if is focused on something (`autoFocusPointofInterest` is set), as if no point of focus I assume there is no subject.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?


### What are the steps to reproduce (after prerequisites)?
* To test that auto exposure is also happening, set an `autoFocusPointOfInterest`, then move the camera from a dark area to bright area, and you should see the camera dim.
* To test the subject monitor, add a prop `onSubjectAreaChanged={e => console.log(e)}`
* To test clearing the focus point on subject area change, inside this callback (2nd bullet, clear set the `autoFocusPointOfInterest` to `null`).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
