### PR TITLE
Fix for issue #2434

### DIFF
--- a/ios/RN/BarcodeDetectorManagerMlkit.m
+++ b/ios/RN/BarcodeDetectorManagerMlkit.m
@@ -149,14 +149,14 @@
                 if(barcode.contactInfo.name) {
                     FIRVisionBarcodePersonName *name = barcode.contactInfo.name;
                     NSObject *nameObject = @{
-                                       @"formattedName" : name.formattedName,
-                                       @"firstName" : name.first,
-                                       @"middleName" : name.middle,
-                                       @"lastName" : name.last,
-                                       @"prefix" : name.prefix,
-                                       @"pronounciation" : name.pronounciation,
-                                       @"suffix" : name.suffix,
-                                       };
+                                             @"formattedName" : name.formattedName ? name.formattedName : @"",
+                                             @"firstName" : name.first ? name.first : @"",
+                                             @"middleName" : name.middle ? name.middle : @"",
+                                             @"lastName" : name.last ? name.last : @"",
+                                             @"prefix" : name.prefix ? name.prefix : @"",
+                                             @"pronounciation" : name.pronounciation ? name.pronounciation : @"",
+                                             @"suffix" : name.suffix ? name.suffix : @"",
+                                             };
                     [resultDict setObject:nameObject forKey:@"name"];
                 }
                 if(barcode.contactInfo.phones) {


### PR DESCRIPTION


# Summary

When VCARD doesnt contain ALL name fields, app crashes because it is trying to insert nil values into dictionary. This provides blank strings for nil values in vcard

This fixes #2434 

## Test Plan

Scanning a VCARD with missing name fields no longer crashes on ios

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
