### PR TITLE
feat(rn-camera): add ActivityIndicator style prop

### DIFF
--- a/examples/basic/App.js
+++ b/examples/basic/App.js
@@ -295,6 +295,7 @@ export default class CameraScreen extends React.Component {
         whiteBalance={this.state.whiteBalance}
         ratio={this.state.ratio}
         focusDepth={this.state.depth}
+        activityIndicatorStyle={{ color: 'blue', size: 'large' }}
         androidCameraPermissionOptions={{
           title: 'Permission to use camera',
           message: 'We need your permission to use your camera',

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -402,7 +402,6 @@ export default class Camera extends React.Component<PropsType, StateType> {
     androidCameraPermissionOptions: Rationale,
     androidRecordAudioPermissionOptions: Rationale,
     notAuthorizedView: PropTypes.element,
-    pendingAuthorizationView: PropTypes.element,
     captureAudio: PropTypes.bool,
     useCamera2Api: PropTypes.bool,
     playSoundOnCapture: PropTypes.bool,
@@ -443,11 +442,6 @@ export default class Camera extends React.Component<PropsType, StateType> {
     notAuthorizedView: (
       <View style={styles.authorizationContainer}>
         <Text style={styles.notAuthorizedText}>Camera not authorized</Text>
-      </View>
-    ),
-    pendingAuthorizationView: (
-      <View style={styles.authorizationContainer}>
-        <ActivityIndicator size="small" />
       </View>
     ),
     captureAudio: true,
@@ -742,6 +736,15 @@ export default class Camera extends React.Component<PropsType, StateType> {
     return this.props.children;
   };
 
+  renderPendingAuthorizationView = () => {
+    const { color, size } = this.props.activityIndicatorStyle;
+    return (
+      <View style={styles.authorizationContainer}>
+        <ActivityIndicator color={color} size={size || 'small'} />
+      </View>
+    );
+  };
+
   render() {
     const { style, ...nativeProps } = this._convertNativeProps(this.props);
 
@@ -766,7 +769,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
         </View>
       );
     } else if (!this.state.isAuthorizationChecked) {
-      return this.props.pendingAuthorizationView;
+      return this.renderPendingAuthorizationView();
     } else {
       return this.props.notAuthorizedView;
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -94,13 +94,11 @@ type RecordAudioPermissionStatus = Readonly<
     NOT_AUTHORIZED: 'NOT_AUTHORIZED';
   }>
 >;
-type FaCC = (
-  params: {
-    camera: RNCamera;
-    status: keyof CameraStatus;
-    recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
-  },
-) => JSX.Element;
+type FaCC = (params: {
+  camera: RNCamera;
+  status: keyof CameraStatus;
+  recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
+}) => JSX.Element;
 
 export interface Constants {
   CameraStatus: CameraStatus;
@@ -137,7 +135,7 @@ export interface RNCameraProps {
   type?: keyof CameraType;
   flashMode?: keyof FlashMode;
   notAuthorizedView?: JSX.Element;
-  pendingAuthorizationView?: JSX.Element;
+  activityIndicatorStyle?: { color: string; size: string };
   useCamera2Api?: boolean;
   exposure?: number;
   whiteBalance?: keyof WhiteBalance;
@@ -169,9 +167,7 @@ export interface RNCameraProps {
     bounds: [Point<string>, Point<string>] | { origin: Point<string>; size: Size<string> };
   }): void;
 
-  onGoogleVisionBarcodesDetected?(event: {
-    barcodes: Barcode[];
-  }): void;
+  onGoogleVisionBarcodesDetected?(event: { barcodes: Barcode[] }): void;
 
   // -- FACE DETECTION PROPS
 
@@ -232,7 +228,7 @@ interface Barcode {
   dataRaw: string;
   type: BarcodeType;
   addresses?: {
-    addressesType?: "UNKNOWN" | "Work" | "Home";
+    addressesType?: 'UNKNOWN' | 'Work' | 'Home';
     addressLines?: string[];
   }[];
   emails?: Email[];
@@ -242,9 +238,9 @@ interface Barcode {
     firstName?: string;
     lastName?: string;
     middleName?: string;
-    prefix?:string;
-    pronounciation?:string;
-    suffix?:string;
+    prefix?: string;
+    pronounciation?: string;
+    suffix?: string;
     formattedName?: string;
   };
   phone?: Phone;
@@ -283,28 +279,28 @@ interface Barcode {
 }
 
 type BarcodeType =
-  |"EMAIL"
-  |"PHONE"
-  |"CALENDAR_EVENT"
-  |"DRIVER_LICENSE"
-  |"GEO"
-  |"SMS"
-  |"CONTACT_INFO"
-  |"WIFI"
-  |"TEXT"
-  |"ISBN"
-  |"PRODUCT"
+  | 'EMAIL'
+  | 'PHONE'
+  | 'CALENDAR_EVENT'
+  | 'DRIVER_LICENSE'
+  | 'GEO'
+  | 'SMS'
+  | 'CONTACT_INFO'
+  | 'WIFI'
+  | 'TEXT'
+  | 'ISBN'
+  | 'PRODUCT';
 
 interface Email {
   address?: string;
   body?: string;
   subject?: string;
-  emailType?: "UNKNOWN" | "Work" | "Home";
+  emailType?: 'UNKNOWN' | 'Work' | 'Home';
 }
 
 interface Phone {
   number?: string;
-  phoneType?: "UNKNOWN" | "Work" | "Home" | "Fax" | "Mobile";
+  phoneType?: 'UNKNOWN' | 'Work' | 'Home' | 'Fax' | 'Mobile';
 }
 
 interface Face {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I found no clue of how to style the RNCamera's activity indicator, so I saw that no props were passed to the component.

I removed the PropType element pendingAuthorizationView and created a function called renderPendingAuthorizationView. Also added activityIndicatorStyle to RNCameraProps in index.d.ts and used the prop in the example app.

Now we can use activityIndicatorStyle, an object with color and size keys, as a RNCamera prop.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
### What are the steps to reproduce (after prerequisites)?
To reproduce, you have to add `activityIndicatorStyle={{color: 'blue', size: 'large'}}`, for example, to the RNCamera component

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
