### PR TITLE
fix: android-mlkit barcode bounds are inaccurate

### DIFF
--- a/android/src/mlkit/java/org/reactnative/camera/tasks/BarcodeDetectorAsyncTask.java
+++ b/android/src/mlkit/java/org/reactnative/camera/tasks/BarcodeDetectorAsyncTask.java
@@ -57,7 +57,7 @@ public class BarcodeDetectorAsyncTask extends android.os.AsyncTask<Void, Void, V
     mBarcodeDetector = barcodeDetector;
     mImageDimensions = new ImageDimensions(width, height, rotation, facing);
     mScaleX = (double) (viewWidth) / (mImageDimensions.getWidth() * density);
-    mScaleY = (double) (viewHeight) / (mImageDimensions.getHeight() * density);
+    mScaleY = 1 / density;
     mPaddingLeft = viewPaddingLeft;
     mPaddingTop = viewPaddingTop;
   }
@@ -336,11 +336,7 @@ public class BarcodeDetectorAsyncTask extends android.os.AsyncTask<Void, Void, V
       x = x - mPaddingLeft / 2;
     }
 
-    if (frame.top < mHeight / 2) {
-      y = y + mPaddingTop / 2;
-    } else if (frame.top > mHeight / 2) {
-      y = y - mPaddingTop / 2;
-    }
+    y = y + mPaddingTop;
 
     origin.putDouble("x", x * mScaleX);
     origin.putDouble("y", y * mScaleY);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Changed the way that barcode bounds are processed after being detected by firebase mlkit. y is now simply adjusted by pixel density scale and the padding difference. 
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged

* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
Fixes #2461 



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Screenshot showing that the code works for my personal app
![image](https://user-images.githubusercontent.com/5936843/64084588-95ddbe00-ccf2-11e9-8cb2-779b5da2b8e8.png)
## Test Plan
### Build mlkit example using updated code:
Set up to detect barcodes
Use camera to hover over one or many barcodes
Barcodes should be highlighted accurately
### Change size of mlkit example camera preview frame:
Following process above, barcodes should still be highlighted accurately




## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)