### PR TITLE
Improve Android Camera1 error and concurrency handling.

### DIFF
--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -208,7 +208,7 @@ public class CameraModule extends ReactContextBaseJavaModule {
       }
     });
   }
-    
+
     @ReactMethod
     public void pausePreview(final int viewTag) {
         final ReactApplicationContext context = getReactApplicationContext();
@@ -217,7 +217,7 @@ public class CameraModule extends ReactContextBaseJavaModule {
             @Override
             public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
                 final RNCameraView cameraView;
-                
+
                 try {
                     cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
                     if (cameraView.isCameraOpened()) {
@@ -229,7 +229,7 @@ public class CameraModule extends ReactContextBaseJavaModule {
             }
         });
     }
-    
+
     @ReactMethod
     public void resumePreview(final int viewTag) {
         final ReactApplicationContext context = getReactApplicationContext();
@@ -238,7 +238,7 @@ public class CameraModule extends ReactContextBaseJavaModule {
             @Override
             public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
                 final RNCameraView cameraView;
-                
+
                 try {
                     cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
                     if (cameraView.isCameraOpened()) {
@@ -261,14 +261,18 @@ public class CameraModule extends ReactContextBaseJavaModule {
       public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
           RNCameraView cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
           try {
-            if (cameraView.isCameraOpened()) {
-              cameraView.takePicture(options, promise, cacheDirectory);
-            } else {
-              promise.reject("E_CAMERA_UNAVAILABLE", "Camera is not running");
-            }
-        } catch (Exception e) {
-          promise.reject("E_CAMERA_BAD_VIEWTAG", "takePictureAsync: Expected a Camera component");
-        }
+              if (cameraView.isCameraOpened()) {
+                cameraView.takePicture(options, promise, cacheDirectory);
+              } else {
+                promise.reject("E_CAMERA_UNAVAILABLE", "Camera is not running");
+              }
+          }
+          catch(IllegalStateException e){
+            promise.reject("E_CAMERA_UNAVAILABLE", e.getMessage());
+          }
+          catch (Exception e) {
+            promise.reject("E_CAMERA_BAD_VIEWTAG", e.getMessage());
+          }
       }
     });
   }
@@ -353,7 +357,7 @@ public class CameraModule extends ReactContextBaseJavaModule {
             @Override
             public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
                 final RNCameraView cameraView;
-                
+
                 try {
                     cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
                     WritableArray result = Arguments.createArray();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Improve Android Camera1 error and concurrency handling.

NOTE: Please review carefully, creating this PR for some discussion first.

These changes include the following:
- use atomic boolean for capturing photo flag just like video
- add more exception catching and checks
- raise error instead of failing silently if can't capture photo - improve error handling here
- synchronize stop to avoid race conditions and crashes
- delay params updates (surface) if capturing or recording to avoid bugs
- do not allow video or photo capture if already doing video or photo

## Test Plan

Tested on Android 8.1 (Moto G5), Android 9 and 10 (Pixel 2)

### What's required for testing (prerequisites)?
-

### What are the steps to reproduce (after prerequisites)?
-

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
