### PR TITLE
Use a more appropriate orientation change event

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -68,7 +68,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         [self startSession];
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(orientationChanged:)
-                                                     name:UIDeviceOrientationDidChangeNotification
+                                                     name:UIApplicationDidChangeStatusBarOrientationNotification
                                                    object:nil];
 
         [[NSNotificationCenter defaultCenter] addObserver:self


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Since the code relies on the status bar orientation, it makes sense to use UIApplicationDidChangeStatusBarOrientationNotification instead. This should fix some issues where the orientation value of the status bar has not been updated when the event is received.

Should fix https://github.com/react-native-community/react-native-camera/issues/2494 and also quickly changing orientations on iphones not rotating properly.

## Test Plan
Tested on iPhone 7 and iPad mini

### What's required for testing (prerequisites)?
Real devices

### What are the steps to reproduce (after prerequisites)?
- 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
