### PR TITLE
Fix jitpack.io maven link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -227,7 +227,7 @@ android {
 ```gradle
 allprojects {
     repositories {
-        maven { url "https://jitpack.io" }
+        maven { url "https://www.jitpack.io" }
         maven { url "https://maven.google.com" }
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged

When using the link `https://jitpack.io` and run `react-native run-android`, the users will get following errors:
```
 Could not GET 'https://jitpack.io/org/webkit/android-jsc/maven-metadata.xml'. Received status code 522 from server: Origin Connection Time-out 
```

* How did you implement the solution?
Add `www` to the maven url

* What areas of the library does it impact?
--> Installation

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
- react-native v0.60.5
- yarn add react-native-camera

### What are the steps to reproduce (after prerequisites)?
* Follow this installation guide ( without `www`) to configure react-native-camera on Android
* run `react-native run-android`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
