### PR TITLE
videoBitrate option for iOS

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -76,8 +76,6 @@ interface RecordOptions {
   mute?: boolean;
   mirrorVideo?: boolean;
   path?: string;
-
-  /** Android only */
   videoBitrate?: number;
 
   /** iOS only */

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -555,7 +555,7 @@ Supported options:
 
 - `videoBitrate`. (int greater than 0) This option specifies a desired video bitrate. For example, 5\*1000\*1000 would be 5Mbps.
 
-  - `ios` Not supported.
+  - `ios` Supported however requires that the codec key is also set.
   - `android` Supported.
 
 - `orientation` (string or number). Specifies the orientation that us used for recording the video. Possible values: `"portrait"`, `"portraitUpsideDown"`, `"landscapeLeft"` or `"landscapeRight"`.

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -599,17 +599,28 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [connection setVideoOrientation:orientation];
 
     if (options[@"codec"]) {
-      if (@available(iOS 10, *)) {
-        AVVideoCodecType videoCodecType = options[@"codec"];
-        if ([self.movieFileOutput.availableVideoCodecTypes containsObject:videoCodecType]) {
-          [self.movieFileOutput setOutputSettings:@{AVVideoCodecKey:videoCodecType} forConnection:connection];
-          self.videoCodecType = videoCodecType;
-        } else {
-            RCTLogWarn(@"%s: Setting videoCodec is only supported above iOS version 10.", __func__);
+        if (@available(iOS 10, *)) {
+            AVVideoCodecType videoCodecType = options[@"codec"];
+            if ([self.movieFileOutput.availableVideoCodecTypes containsObject:videoCodecType]) {
+                self.videoCodecType = videoCodecType;
+                if(options[@"videoBitrate"]) {
+                    NSString *videoBitrate = options[@"videoBitrate"];
+                    [self.movieFileOutput setOutputSettings:@{
+                      AVVideoCodecKey:videoCodecType,
+                      AVVideoCompressionPropertiesKey:
+                          @{
+                              AVVideoAverageBitRateKey:videoBitrate
+                          }
+                      } forConnection:connection];
+                } else {
+                    [self.movieFileOutput setOutputSettings:@{AVVideoCodecKey:videoCodecType} forConnection:connection];
+                }
+            } else {
+                RCTLogWarn(@"%s: Setting videoCodec is only supported above iOS version 10.", __func__);
+            }
         }
-      }
     }
-
+    
     dispatch_async(self.sessionQueue, ^{
         [self updateFlashMode];
         NSString *path = nil;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -378,8 +378,6 @@ interface RecordOptions {
   mute?: boolean;
   mirrorVideo?: boolean;
   path?: string;
-
-  /** Android only */
   videoBitrate?: number;
 
   /** iOS only */


### PR DESCRIPTION
Add videoBitrate option for ios, setting video bitrate requires a codec to be set

# Summary

Android allows this, adding the same functionality to iOS

## Test Plan

Testing on real devices:
iPod Touch
iPad
iPhone 8+

### What's required for testing (prerequisites)?
Test with and without videoBitrate key set, support is ios10+

### What are the steps to reproduce (after prerequisites)?

Check video output bitrate is the same or close to the videoBitrate key

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [yes] I have tested this on a device and a simulator
- [yes] I added the documentation in `README.md`
- [yes] I mentioned this change in `CHANGELOG.md`
- [yes] I updated the typed files (TS and Flow)
- [yes] I added a sample use of the API in the example project (`example/App.js`)
