### PR TITLE
Much faster picture taking on Android, configurable

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ android {
   buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
   defaultConfig {
-    minSdkVersion safeExtGet('minSdkVersion', 16)
+    minSdkVersion safeExtGet('minSdkVersion', 17)
     targetSdkVersion safeExtGet('targetSdkVersion', 28)
   }
 

--- a/android/src/main/java/org/reactnative/camera/CameraViewManager.java
+++ b/android/src/main/java/org/reactnative/camera/CameraViewManager.java
@@ -142,6 +142,11 @@ public class CameraViewManager extends ViewGroupManager<RNCameraView> {
     view.setUsingCamera2Api(useCamera2Api);
   }
 
+  @ReactProp(name = "camera1ScanMode")
+  public void setCamera1ScanMode(RNCameraView view, String camera1ScanMode) {
+    view.setCamera1ScanMode(camera1ScanMode);
+  }
+
   @ReactProp(name = "playSoundOnCapture")
   public void setPlaySoundOnCapture(RNCameraView view, boolean playSoundOnCapture) {
     view.setPlaySoundOnCapture(playSoundOnCapture);

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -43,6 +43,15 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
         mPictureSavedDelegate = delegate;
     }
 
+    public ResolveTakenPictureAsyncTask(Bitmap bitmap, Promise promise, ReadableMap options, File cacheDirectory, int deviceOrientation, PictureSavedDelegate delegate) {
+        mPromise = promise;
+        mOptions = options;
+        mBitmap = bitmap;
+        mCacheDirectory = cacheDirectory;
+        mDeviceOrientation = deviceOrientation;
+        mPictureSavedDelegate = delegate;
+    }
+
     private int getQuality() {
         return (int) (mOptions.getDouble("quality") * 100);
     }

--- a/android/src/main/java/org/reactnative/camera/utils/YuvToBitmap.java
+++ b/android/src/main/java/org/reactnative/camera/utils/YuvToBitmap.java
@@ -1,0 +1,64 @@
+package org.reactnative.camera.utils;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.renderscript.Allocation;
+import android.renderscript.Element;
+import android.renderscript.RenderScript;
+import android.renderscript.ScriptIntrinsicYuvToRGB;
+
+/**
+ * Created by Boris Conforty on 26.03.18.
+ */
+
+public class YuvToBitmap {
+    private Context mContext;
+    private RenderScript mRenderScript;
+    private ScriptIntrinsicYuvToRGB mYuvToRgbIntrinsic;
+    private Allocation aIn, aOut;
+    private Bitmap mBitmap;
+    private boolean mReloadBitmap;
+
+    public YuvToBitmap(Context context) {
+        mContext = context;
+    }
+
+    private void prepare(int width, int height) {
+        boolean renderScriptNeeded = mRenderScript == null;
+        boolean bitmapNeeded = mBitmap == null || mBitmap.getWidth() != width || mBitmap.getHeight() != height;
+        boolean inNeeded = aIn == null || (mBitmap != null && mBitmap.getWidth() * mBitmap.getHeight() != width * height);
+
+        if (renderScriptNeeded) {
+            mRenderScript = RenderScript.create(mContext);
+            mYuvToRgbIntrinsic = ScriptIntrinsicYuvToRGB.create(mRenderScript, Element.U8_4(mRenderScript));
+        }
+        if (bitmapNeeded) {
+            mBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+            aOut = Allocation.createFromBitmap(mRenderScript, mBitmap);
+        }
+        if (inNeeded) {
+            int yuvDataLength = width * height * 3 / 2;  // 12 bits per pixel
+            aIn = Allocation.createSized(mRenderScript, Element.U8(mRenderScript), yuvDataLength);
+            mYuvToRgbIntrinsic.setInput(aIn);
+        }
+    }
+
+    public Allocation getOut() {
+        return aOut;
+    }
+
+    public Bitmap getBimap() {
+        if (mReloadBitmap) {
+            aOut.copyTo(mBitmap);
+            mReloadBitmap = false;
+        }
+        return mBitmap;
+    }
+
+    public void refreshBitmap(byte[] data, int width, int height) {
+        mReloadBitmap = true;
+        this.prepare(width, height);
+        aIn.copyFrom(data);
+        mYuvToRgbIntrinsic.forEach(aOut);
+    }
+}

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -227,6 +227,8 @@ type RecordingOptions = {
   videoBitrate?: number,
 };
 
+type Camera1ScanMode = 'none' | 'eco' | 'fast' | 'boost';
+
 type EventCallbackArgumentsType = {
   nativeEvent: Object,
 };
@@ -264,6 +266,7 @@ type PropsType = typeof View.props & {
   onTextRecognized?: ({ textBlocks: Array<TrackedTextFeature> }) => void,
   captureAudio?: boolean,
   useCamera2Api?: boolean,
+  camera1ScanMode: Camera1ScanMode,
   playSoundOnCapture?: boolean,
   videoStabilizationMode?: number | string,
   pictureSize?: string,
@@ -405,6 +408,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     pendingAuthorizationView: PropTypes.element,
     captureAudio: PropTypes.bool,
     useCamera2Api: PropTypes.bool,
+    camera1ScanMode: PropTypes.string,
     playSoundOnCapture: PropTypes.bool,
     videoStabilizationMode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     pictureSize: PropTypes.string,
@@ -452,6 +456,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     ),
     captureAudio: true,
     useCamera2Api: false,
+    camera1ScanMode: 'eco',
     playSoundOnCapture: false,
     pictureSize: 'None',
     videoStabilizationMode: 0,


### PR DESCRIPTION
# Summary

Android's native camera takePicture() is very slow. I wasn't happy with it and many people complain too (see #1836 for instance).

Camera1 allows capturing frame previews. By processing frame previews we can avoid using takePicture() altogether.

The previews are in YUV and need to be transformed to RGB. The proposed implementation uses a render script for fast processing.

4 modes are proposed (as a RN prop, "camera1ScanMode"): "none", "eco", "fast" and "boost".

- none: use takePicture(), as currently done by react-native-camera
- eco: capture a frame preview when a picture is requested, then process it
- fast: capture all frame previews and process one when a picture is requested
- boost: capture and process all frame previews. When a picture is requested, send the last one

In my app, on my device, the benchmark is the following (average of 3 pictures):
- none: 1.7 s
- eco: 415 ms
- fast: 361 ms
- boost: 171 ms

These measures were done in React Native, from the call to `capture()` to the result being received after conversion to base64 and bridge transfer. The speed increase of the proposed change if seen at a lower level (Android `takePicture()` vs frame previews processing) is even more dramatic.

I use the library to get pictures in base64. My tests did not cover all possible uses of the library.

Note that the min SDK upgrade to version 17 is needed for the render script.

## Test Plan

I'll leave it to more experienced users of the library to test every possible use case.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)