### PR TITLE
Remove flickering due to audio input

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -16,6 +16,7 @@
 @property(nonatomic, strong) dispatch_queue_t sessionQueue;
 @property(nonatomic, strong) AVCaptureSession *session;
 @property(nonatomic, strong) AVCaptureDeviceInput *videoCaptureDeviceInput;
+@property(nonatomic, strong) AVCaptureDeviceInput *audioCaptureDeviceInput;
 @property(nonatomic, strong) AVCaptureStillImageOutput *stillImageOutput;
 @property(nonatomic, strong) AVCaptureMovieFileOutput *movieFileOutput;
 @property(nonatomic, strong) AVCaptureMetadataOutput *metadataOutput;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -764,6 +764,13 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     }
 
     NSInteger orientation = [options[@"orientation"] integerValue];
+    
+    // some operations will change our config
+    // so we batch config updates, even if inner calls
+    // might also call this, only the outermost commit will take effect
+    // making the camera changes much faster.
+    [self.session beginConfiguration];
+    
 
     if (_movieFileOutput == nil) {
         // At the time of writing AVCaptureMovieFileOutput and AVCaptureVideoDataOutput (> GMVDataOutput)
@@ -782,6 +789,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     }
 
     if (self.movieFileOutput == nil || self.movieFileOutput.isRecording || _videoRecordedResolve != nil || _videoRecordedReject != nil) {
+        [self.session commitConfiguration];
       return;
     }
 
@@ -807,11 +815,6 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         if (self.session.sessionPreset != newQuality) {
             [self updateSessionPreset:newQuality];
         }
-    }
-
-    // only update audio session when mute is not set or set to false, because otherwise there will be a flickering
-    if ([options valueForKey:@"mute"] == nil || ([options valueForKey:@"mute"] != nil && ![options[@"mute"] boolValue])) {
-        [self updateSessionAudioIsMuted:NO];
     }
 
     AVCaptureConnection *connection = [self.movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
@@ -846,6 +849,16 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             }
         }
     }
+    
+    // sound recording connection, we can easily turn it on/off without manipulating inputs, this prevents flickering.
+    AVCaptureConnection *audioConnection = [self.movieFileOutput connectionWithMediaType:AVMediaTypeAudio];
+
+    if ([options valueForKey:@"mute"] == nil || ([options valueForKey:@"mute"] != nil && ![options[@"mute"] boolValue])) {
+        audioConnection.enabled = YES;
+    }
+    else{
+        audioConnection.enabled = NO;
+    }
 
     dispatch_async(self.sessionQueue, ^{
 
@@ -863,6 +876,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
                 [connection setVideoMirrored:YES];
             }
         }
+        
+        // finally, commit our config changes before starting to record
+        [self.session commitConfiguration];
 
         NSURL *outputURL = [[NSURL alloc] initFileURLWithPath:path];
         [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];
@@ -873,11 +889,13 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
 - (void)stopRecording
 {
-    if ([self.movieFileOutput isRecording]) {
-        [self.movieFileOutput stopRecording];
-    } else {
-        RCTLogWarn(@"Video is not recording.");
-    }
+    dispatch_async(self.sessionQueue, ^{
+        if ([self.movieFileOutput isRecording]) {
+            [self.movieFileOutput stopRecording];
+        } else {
+            RCTLogWarn(@"Video is not recording.");
+        }
+    });
 }
 
 - (void)resumePreview
@@ -973,6 +991,12 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         for (AVCaptureOutput *output in self.session.outputs) {
             [self.session removeOutput:output];
         }
+        
+        // clean these up as well since we've removed
+        // all inputs and outputs from session
+        self.videoCaptureDeviceInput = nil;
+        self.audioCaptureDeviceInput = nil;
+        self.movieFileOutput = nil;
     });
 }
 
@@ -1053,6 +1077,28 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         else{
             RCTLog(@"The selected device does not work with the Preset [%@] or configuration provided", self.session.sessionPreset);
         }
+        
+        
+        // if we have not yet set our audio capture device
+        // set it. Setting it early will prevent flickering when
+        // recording a video
+        if(self.audioCaptureDeviceInput == nil){
+            AVCaptureDevice *audioCaptureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
+            AVCaptureDeviceInput *audioDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:audioCaptureDevice error:&error];
+
+            if (error || audioDeviceInput == nil) {
+                RCTLogWarn(@"%s: %@", __func__, error);
+            }
+            else{
+                if ([self.session canAddInput:audioDeviceInput]) {
+                    [self.session addInput:audioDeviceInput];
+                    self.audioCaptureDeviceInput = audioDeviceInput;
+                }
+                else{
+                    RCTLog(@"Cannot add audio input");
+                }
+            }
+        }
 
         [self.session commitConfiguration];
     });
@@ -1089,41 +1135,6 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 #endif
 }
 
-- (void)updateSessionAudioIsMuted:(BOOL)isMuted
-{
-    dispatch_async(self.sessionQueue, ^{
-        [self.session beginConfiguration];
-
-        for (AVCaptureDeviceInput* input in [self.session inputs]) {
-            if ([input.device hasMediaType:AVMediaTypeAudio]) {
-                if (isMuted) {
-                    [self.session removeInput:input];
-                }
-                [self.session commitConfiguration];
-                return;
-            }
-        }
-
-        if (!isMuted) {
-            NSError *error = nil;
-
-            AVCaptureDevice *audioCaptureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
-            AVCaptureDeviceInput *audioDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:audioCaptureDevice error:&error];
-
-            if (error || audioDeviceInput == nil) {
-                RCTLogWarn(@"%s: %@", __func__, error);
-                [self.session commitConfiguration];
-                return;
-            }
-
-            if ([self.session canAddInput:audioDeviceInput]) {
-                [self.session addInput:audioDeviceInput];
-            }
-        }
-
-        [self.session commitConfiguration];
-    });
-}
 
 - (void)bridgeDidForeground:(NSNotification *)notification
 {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Adding/removing audio input would cause the video recording to flicker. The current code tries to prevent it by only doing this if necessary, but it will always flicker the first time a record is done (because the audio input gets added there). With these changes, the audio input is always available (just like the video input), but it is turned on/off through the connection. This also has the advantage that audio could potentially be muted/unmuted on demand even while recording, but that's for another PR.

Recording will also batch all operations in a configure/commit block in order to make the change faster the internal block does configuration changes.

Lastly, stop recording is called in the same session queue in order to prevent an issue when stopping too early.

Should fix https://github.com/react-native-community/react-native-camera/issues/2538
Should improve https://github.com/react-native-community/react-native-camera/issues/2533 . However, there will still be flickering there's a preset change when recording (e.g., video quality is different than picture quality)

## Test Plan
Tested on iPhone 7

### What's required for testing (prerequisites)?
Real device

### What are the steps to reproduce (after prerequisites)?
-

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
