### PR TITLE
Honor captureAudio flag by not requesting audio input if set to false.

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -45,6 +45,7 @@
 @property(nonatomic, assign) BOOL canReadText;
 @property(nonatomic, assign) BOOL canDetectFaces;
 @property(nonatomic, assign) BOOL canDetectBarcodes;
+@property(nonatomic, assign) BOOL captureAudio;
 @property(nonatomic, assign) CGRect rectOfInterest;
 @property(assign, nonatomic) AVVideoCodecType videoCodecType;
 @property(assign, nonatomic)

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -296,6 +296,11 @@ RCT_CUSTOM_VIEW_PROPERTY(textRecognizerEnabled, BOOL, RNCamera)
     [view setupOrDisableTextDetector];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(captureAudio, BOOL, RNCamera)
+{
+    [view setCaptureAudio:[RCTConvert BOOL:json]];
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(rectOfInterest, CGRect, RNCamera)
 {
     [view setRectOfInterest: [RCTConvert CGRect:json]];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Fix for https://github.com/react-native-community/react-native-camera/issues/2541 to prevent iOS from prompting for audio recording permission if captureAudio is set to false.

Ideally, the captureAudio prop should not reach native at all, and the request permission call should be used just like Android. In practice, however, this makes Apple complain about microphone usage (even if it is not used at all, https://github.com/react-native-community/react-native-camera/issues/2085). For this reason, the permission request call on iOS is dummy when not in DEBUG mode. The flag on native should not be needed at all if we can do the permission check in a way Apple does not complain.

In addition, fix https://github.com/react-native-community/react-native-camera/issues/2538 even further. The 0.5 delay might still allow for the video not recording log to happen (and video not getting stopped). With the added check, an enqueued video recording should not start if requested to stop early.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Tested on iPhone 7, iOS 13. The following cases were tested without any crashes:

- Fresh install, captureAudio true (default): App requests audio permission as soon as the camera mounts, this behaves just like Android. However, video is already visible (camera fully mounted) due to the dummy iOS audio permission check. Furthermore, on iOS production build, audio permission will be always incorrectly reported as given due to that dummy implementation ( https://github.com/react-native-community/react-native-camera/blob/master/ios/RN/RNCameraManager.m#L452 )

- After the above install. Audio permission removed from settings. Videos record fine, no audio, no crash. No permission checks done neither, but audio device request error is handled.

- Fresh install, captureAudio=false. Camera mounts and no audio permission prompt. 
- Update app, set captureAudio=true. Camera mounts, audio prompt happens. 

### What's required for testing (prerequisites)?
Real device

### What are the steps to reproduce (after prerequisites)?
-

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
