### PR TITLE
feat(android): support null object of androidPermissionOptions to avo…

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -206,7 +206,7 @@ export interface RNCameraProps {
     buttonPositive?: string;
     buttonNegative?: string;
     buttonNeutral?: string;
-  };
+  } | null;
 
   androidRecordAudioPermissionOptions?: {
     title: string;
@@ -214,7 +214,7 @@ export interface RNCameraProps {
     buttonPositive?: string;
     buttonNegative?: string;
     buttonNeutral?: string;
-  };
+  } | null;
 
   // -- IOS ONLY PROPS
   defaultVideoQuality?: keyof VideoQuality;


### PR DESCRIPTION
…id request window

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
Due to the android camera/audio permission popup issue #2323 , we can set: 
```js
androidCameraPermissionOptions={null}
androidRecordAudioPermissionOptions={null}
```
to avoid this, however, the types is not allow us to set null to these 2 props, so I add null type to the types file.
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Using RNCamera with TypeScript and set null to `androidCameraPermissionOptions` and `androidRecordAudioPermissionOptions`
### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
