### PR TITLE
Ios - handle audio interruptions

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -378,6 +378,15 @@ Event contains the following fields:
 - `cameraStatus` - one of the [CameraStatus](#status) values
 - `recordAudioPermissionStatus` - one of the [RecordAudioPermissionStatus](#recordAudioPermissionStatus) values
 
+### `iOS` `onAudioInterrupted`
+
+iOS only. Function to be called when the camera audio session is interrupted or fails to start for any reason (e.g., in use or not authorized). For example, this might happen due to another app taking exclusive control over the microphone (e.g., a phone call) if `captureAudio={true}`. When this happens, any active audio input will be temporarily disabled and cause a flicker on the preview screen. This will fire any time an attempt to connect the audio device fails. Use this to update your UI to indicate that audio recording is not currently possible.
+
+### `iOS` `onAudioConnected`
+
+iOS only. Function to be called when the camera audio session is connected. This will be fired the first time the camera is mounted with `captureAudio={true}`, and any time the audio device connection is established. Note that this event might not always fire after an interruption due to iOS' behavior. For example, if the audio was already interrupted before the camera was mounted, this event will only fire once a recording is attempted.
+
+
 ### `Android` `onPictureTaken`
 
 Function to be called when native code emit onPictureTaken event, when camera has taken a picture.

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -64,6 +64,7 @@
 - (void)updateWhiteBalance;
 - (void)updateExposure;
 - (void)updatePictureSize;
+- (void)updateCaptureAudio;
 // Face Detection props
 - (void)updateTrackingEnabled:(id)requestedTracking;
 - (void)updateFaceDetectionMode:(id)requestedMode;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -167,18 +167,18 @@ BOOL _sessionInterrupted = NO;
          selector:@selector(orientationChanged:)
              name:UIApplicationDidChangeStatusBarOrientationNotification
            object:nil];
-                
+
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionWasInterrupted:) name:AVCaptureSessionWasInterruptedNotification object:self.session];
-        
+
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionDidStartRunning:) name:AVCaptureSessionDidStartRunningNotification object:self.session];
-        
+
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionRuntimeError:) name:AVCaptureSessionRuntimeErrorNotification object:self.session];
-        
+
         [[NSNotificationCenter defaultCenter] addObserver:self
             selector:@selector(audioDidInterrupted:)
             name:AVAudioSessionInterruptionNotification
             object:[AVAudioSession sharedInstance]];
-        
+
 
         // this is not needed since RN will update our type value
         // after mount to set the camera's default, and that will already
@@ -190,11 +190,11 @@ BOOL _sessionInterrupted = NO;
         [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
 
         [[NSNotificationCenter defaultCenter] removeObserver:self name:AVCaptureSessionWasInterruptedNotification object:self.session];
-        
+
         [[NSNotificationCenter defaultCenter] removeObserver:self name:AVCaptureSessionDidStartRunningNotification object:self.session];
-        
+
         [[NSNotificationCenter defaultCenter] removeObserver:self name:AVCaptureSessionRuntimeErrorNotification object:self.session];
-        
+
         [[NSNotificationCenter defaultCenter] removeObserver:self name:AVAudioSessionInterruptionNotification object:[AVAudioSession sharedInstance]];
 
         [self stopSession];
@@ -255,7 +255,7 @@ BOOL _sessionInterrupted = NO;
 {
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
-    
+
     if(device == nil){
         return;
     }
@@ -314,7 +314,7 @@ BOOL _sessionInterrupted = NO;
 - (void)defocusPointOfInterest
 {
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
-    
+
 
     if (self.isFocusedOnPoint) {
 
@@ -323,7 +323,7 @@ BOOL _sessionInterrupted = NO;
         if(device == nil){
             return;
         }
-        
+
         device.subjectAreaChangeMonitoringEnabled = NO;
         [[NSNotificationCenter defaultCenter] removeObserver:self name:AVCaptureDeviceSubjectAreaDidChangeNotification object:device];
 
@@ -345,7 +345,7 @@ BOOL _sessionInterrupted = NO;
 
     if(self.isExposedOnPoint){
         self.isExposedOnPoint = NO;
-        
+
         if(device == nil){
             return;
         }
@@ -365,7 +365,7 @@ BOOL _sessionInterrupted = NO;
 
     if(self.isExposedOnPoint){
         self.isExposedOnPoint = NO;
-        
+
         if(device == nil){
             return;
         }
@@ -383,7 +383,7 @@ BOOL _sessionInterrupted = NO;
 {
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
-    
+
     if(device == nil){
         return;
     }
@@ -462,7 +462,7 @@ BOOL _sessionInterrupted = NO;
 {
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
-    
+
     if(device == nil){
         return;
     }
@@ -517,7 +517,7 @@ BOOL _sessionInterrupted = NO;
 - (void)updateZoom {
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
-    
+
     if(device == nil){
         return;
     }
@@ -547,7 +547,7 @@ BOOL _sessionInterrupted = NO;
 {
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
-    
+
     if(device == nil){
         return;
     }
@@ -604,7 +604,7 @@ BOOL _sessionInterrupted = NO;
 {
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
-    
+
     if(device == nil){
         return;
     }
@@ -821,13 +821,13 @@ BOOL _sessionInterrupted = NO;
     }
 
     NSInteger orientation = [options[@"orientation"] integerValue];
-    
+
     // some operations will change our config
     // so we batch config updates, even if inner calls
     // might also call this, only the outermost commit will take effect
     // making the camera changes much faster.
     [self.session beginConfiguration];
-    
+
 
     if (_movieFileOutput == nil) {
         // At the time of writing AVCaptureMovieFileOutput and AVCaptureVideoDataOutput (> GMVDataOutput)
@@ -906,39 +906,39 @@ BOOL _sessionInterrupted = NO;
             }
         }
     }
-    
-    
+
+
     BOOL recordAudio = [options valueForKey:@"mute"] == nil || ([options valueForKey:@"mute"] != nil && ![options[@"mute"] boolValue]);
-        
-    
+
+
     // sound recording connection, we can easily turn it on/off without manipulating inputs, this prevents flickering.
     // note that mute will also be set to true
     // if captureAudio is set to false on the JS side.
     // Check the property anyways just in case it is manipulated
     // with setNativeProps
     if(recordAudio && self.captureAudio){
-                
+
         // if we haven't initialized our capture session yet
         // initialize it. This will cause video to flicker.
         [self initializeAudioCaptureSessionInput];
-        
-        
+
+
         // finally, make sure we got access to the capture device
         // and turn the connection on.
         if(self.audioCaptureDeviceInput != nil){
             AVCaptureConnection *audioConnection = [self.movieFileOutput connectionWithMediaType:AVMediaTypeAudio];
             audioConnection.enabled = YES;
         }
-        
+
     }
-    
+
     // if we have a capture input but are muted
     // disable connection. No flickering here.
     else if(self.audioCaptureDeviceInput != nil){
         AVCaptureConnection *audioConnection = [self.movieFileOutput connectionWithMediaType:AVMediaTypeAudio];
          audioConnection.enabled = NO;
     }
-        
+
     dispatch_async(self.sessionQueue, ^{
 
         NSString *path = nil;
@@ -955,25 +955,25 @@ BOOL _sessionInterrupted = NO;
                 [connection setVideoMirrored:YES];
             }
         }
-        
+
         // finally, commit our config changes before starting to record
         [self.session commitConfiguration];
-        
+
         // and update flash in case it was turned off automatically
         // due to session/preset changes
         [self updateFlashMode];
-        
+
         // after everything is set, start recording with a tiny delay
         // to ensure the camera already has focus and exposure set.
         double delayInSeconds = 0.5;
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, delayInSeconds * NSEC_PER_SEC);
-        
+
         // we will use this flag to stop recording
         // if it was requested to stop before it could even start
         _recordRequested = YES;
 
         dispatch_after(popTime, self.sessionQueue, ^(void){
-                    
+
             // our session might have stopped in between the timeout
             // so make sure it is still valid, otherwise, error and cleanup
             if(self.movieFileOutput != nil && self.videoCaptureDeviceInput != nil && _recordRequested){
@@ -981,18 +981,18 @@ BOOL _sessionInterrupted = NO;
                 [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];
                 self.videoRecordedResolve = resolve;
                 self.videoRecordedReject = reject;
-                
+
             }
             else{
                 reject(@"E_VIDEO_CAPTURE_FAILED", !_recordRequested ? @"Recording request cancelled." : @"Camera is not ready.", nil);
                 [self cleanupCamera];
             }
-            
+
             // reset our flag
             _recordRequested = NO;
         });
 
-        
+
     });
 }
 
@@ -1087,7 +1087,7 @@ BOOL _sessionInterrupted = NO;
         [self.previewLayer removeFromSuperlayer];
         [self.session commitConfiguration];
         [self.session stopRunning];
-        
+
         for (AVCaptureInput *input in self.session.inputs) {
             [self.session removeInput:input];
         }
@@ -1095,11 +1095,11 @@ BOOL _sessionInterrupted = NO;
         for (AVCaptureOutput *output in self.session.outputs) {
             [self.session removeOutput:output];
         }
-        
+
         // cleanup audio input if any, and release
         // audio session so other apps can continue playback.
         [self removeAudioCaptureSessionInput];
-        
+
         // clean these up as well since we've removed
         // all inputs and outputs from session
         self.videoCaptureDeviceInput = nil;
@@ -1115,28 +1115,28 @@ BOOL _sessionInterrupted = NO;
     // only initialize if not initialized already
     if(self.audioCaptureDeviceInput == nil){
         NSError *error = nil;
-                
+
         AVCaptureDevice *audioCaptureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
         AVCaptureDeviceInput *audioDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:audioCaptureDevice error:&error];
 
         if (error || audioDeviceInput == nil) {
             RCTLogWarn(@"%s: %@", __func__, error);
         }
-        
+
         else{
-            
+
             // test if we can activate the device input.
             // If we fail, means it is already being used
-            BOOL setActive = [[AVAudioSession sharedInstance] setActive:YES error:&error];            
-            
+            BOOL setActive = [[AVAudioSession sharedInstance] setActive:YES error:&error];
+
             if (!setActive) {
                 RCTLogWarn(@"Audio device could not set active: %s: %@", __func__, error);
             }
-            
+
             else if ([self.session canAddInput:audioDeviceInput]) {
                 [self.session addInput:audioDeviceInput];
                 self.audioCaptureDeviceInput = audioDeviceInput;
-                
+
                 // inform that audio has been resumed
                 if(self.onAudioConnected){
                     self.onAudioConnected(nil);
@@ -1146,7 +1146,7 @@ BOOL _sessionInterrupted = NO;
                 RCTLog(@"Cannot add audio input");
             }
         }
-        
+
         // if we failed to get the audio device, fire our interrupted event
         if(self.audioCaptureDeviceInput == nil && self.onAudioInterrupted){
             self.onAudioInterrupted(nil);
@@ -1161,40 +1161,40 @@ BOOL _sessionInterrupted = NO;
 - (void)removeAudioCaptureSessionInput
 {
     if(self.audioCaptureDeviceInput != nil){
-        
+
         BOOL audioRemoved = NO;
-        
+
         if ([self.session.inputs containsObject:self.audioCaptureDeviceInput]) {
-            
+
             if ([self isRecording]) {
                 self.isRecordingInterrupted = YES;
             }
-            
+
             [self.session removeInput:self.audioCaptureDeviceInput];
-            
+
             self.audioCaptureDeviceInput = nil;
-            
+
             // update flash since it gets reset when
             // we change the session inputs
             dispatch_async(self.sessionQueue, ^{
                 [self updateFlashMode];
             });
-            
+
             audioRemoved = YES;
         }
-        
+
         // Deactivate our audio session so other audio can resume
         // playing, if any. E.g., background music.
         NSError *error = nil;
-        
+
         BOOL setInactive = [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:&error];
-        
+
         if (!setInactive) {
             RCTLogWarn(@"Audio device could not set inactive: %s: %@", __func__, error);
         }
-        
+
         self.audioCaptureDeviceInput = nil;
-        
+
         // inform that audio was interrupted
         if(audioRemoved && self.onAudioInterrupted){
            self.onAudioInterrupted(nil);
@@ -1231,7 +1231,7 @@ BOOL _sessionInterrupted = NO;
     }
 
     AVCaptureVideoOrientation orientation = [RNCameraUtils videoOrientationForInterfaceOrientation:interfaceOrientation];
-    
+
     dispatch_async(self.sessionQueue, ^{
 
         [self.session beginConfiguration];
@@ -1268,7 +1268,7 @@ BOOL _sessionInterrupted = NO;
             [self.session addInput:captureDeviceInput];
 
             self.videoCaptureDeviceInput = captureDeviceInput;
-            
+
             // Update all these async after our session has commited
             // since some values might be changed on session commit.
             dispatch_async(self.sessionQueue, ^{
@@ -1280,15 +1280,15 @@ BOOL _sessionInterrupted = NO;
                 [self updateWhiteBalance];
                 [self updateFlashMode];
             });
-            
+
             [self.previewLayer.connection setVideoOrientation:orientation];
             [self _updateMetadataObjectsToRecognize];
         }
         else{
             RCTLog(@"The selected device does not work with the Preset [%@] or configuration provided", self.session.sessionPreset);
         }
-        
-        
+
+
         // if we have not yet set our audio capture device,
         // set it. Setting it early will prevent flickering when
         // recording a video
@@ -1346,23 +1346,23 @@ BOOL _sessionInterrupted = NO;
 {
     NSDictionary *userInfo = notification.userInfo;
     NSInteger type = [[userInfo valueForKey:AVAudioSessionInterruptionTypeKey] integerValue];
-    
-    
+
+
     // if our audio interruption ended
     if(type == AVAudioSessionInterruptionTypeEnded){
-        
+
         // and the end event contains a hint that we should resume
         // audio. Then re-connect our audio session if we are
         // capturing audio.
         // Sometimes we are hinted to not resume audio; e.g.,
         // when playing music in background.
-        
+
         NSInteger option = [[userInfo valueForKey:AVAudioSessionInterruptionOptionKey] integerValue];
-        
+
         if(self.captureAudio && option == AVAudioSessionInterruptionOptionShouldResume){
-            
+
             dispatch_async(self.sessionQueue, ^{
-                
+
                 // initialize audio if we need it
                 // check again captureAudio in case it was changed
                 // in between
@@ -1371,7 +1371,7 @@ BOOL _sessionInterrupted = NO;
                 }
             });
         }
-        
+
     }
 }
 
@@ -1381,28 +1381,28 @@ BOOL _sessionInterrupted = NO;
 {
     // Mark session interruption
     _sessionInterrupted = YES;
-    
+
     // Turn on video interrupted if our session is interrupted
     // for any reason
     if ([self isRecording]) {
         self.isRecordingInterrupted = YES;
     }
-    
+
     // prevent any video recording start that we might have on the way
     _recordRequested = NO;
-    
+
     // get event info and fire RN event if our session was interrupted
     // due to audio being taken away.
     NSDictionary *userInfo = notification.userInfo;
     NSInteger type = [[userInfo valueForKey:AVCaptureSessionInterruptionReasonKey] integerValue];
-    
+
     if(type == AVCaptureSessionInterruptionReasonAudioDeviceInUseByAnotherClient){
         // if we have audio, stop it so preview resumes
         // it will eventually be re-loaded the next time recording
         // is requested, although it will flicker.
         [self removeAudioCaptureSessionInput];
     }
-    
+
 }
 
 
@@ -1410,14 +1410,14 @@ BOOL _sessionInterrupted = NO;
 - (void)sessionDidStartRunning:(NSNotification *)notification
 {
     //NSLog(@"sessionDidStartRunning Was interrupted? %d", _sessionInterrupted);
-    
+
     if(_sessionInterrupted){
         // resume flash value since it will be resetted / turned off
         dispatch_async(self.sessionQueue, ^{
             [self updateFlashMode];
         });
     }
-            
+
     _sessionInterrupted = NO;
 }
 
@@ -1425,9 +1425,11 @@ BOOL _sessionInterrupted = NO;
 {
     // Manually restarting the session since it must
     // have been stopped due to an error.
-     _sessionInterrupted = NO;
-    [self.session startRunning];
-    [self onReady:nil];
+    dispatch_async(self.sessionQueue, ^{
+         _sessionInterrupted = NO;
+        [self.session startRunning];
+        [self onReady:nil];
+    });
 }
 
 - (void)orientationChanged:(NSNotification *)notification

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -686,7 +686,7 @@ BOOL _sessionInterrupted = NO;
 - (void)takePicture:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
 {
     // if video device is not set, reject
-    if(self.videoCaptureDeviceInput == nil){
+    if(self.videoCaptureDeviceInput == nil || !self.session.isRunning){
         reject(@"E_IMAGE_CAPTURE_FAILED", @"Camera is not ready.", nil);
         return;
     }
@@ -810,7 +810,7 @@ BOOL _sessionInterrupted = NO;
 }
 - (void)record:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
 {
-    if(self.videoCaptureDeviceInput == nil){
+    if(self.videoCaptureDeviceInput == nil || !self.session.isRunning){
         reject(@"E_VIDEO_CAPTURE_FAILED", @"Camera is not ready.", nil);
         return;
     }

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1203,22 +1203,23 @@ BOOL _sessionInterrupted = NO;
 
 - (void)initializeCaptureSessionInput
 {
-    AVCaptureDevice *captureDevice = [self getDevice];
-
-
-    // if setting a new device is the same we currently have, nothing to do
-    // return.
-    if(self.videoCaptureDeviceInput != nil && captureDevice != nil && [self.videoCaptureDeviceInput.device.uniqueID isEqualToString:captureDevice.uniqueID]){
-        return;
-    }
-
-    // if the device we are setting is also invalid/nil, return
-    if(captureDevice == nil){
-        return;
-    }
-
 
     dispatch_async(self.sessionQueue, ^{
+
+        // Do all camera initialization in the session queue
+        // to prevent it from
+        AVCaptureDevice *captureDevice = [self getDevice];
+
+        // if setting a new device is the same we currently have, nothing to do
+        // return.
+        if(self.videoCaptureDeviceInput != nil && captureDevice != nil && [self.videoCaptureDeviceInput.device.uniqueID isEqualToString:captureDevice.uniqueID]){
+            return;
+        }
+
+        // if the device we are setting is also invalid/nil, return
+        if(captureDevice == nil){
+            return;
+        }
 
         // get orientation also in our session queue to prevent
         // race conditions and also blocking the main thread

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -80,8 +80,6 @@ BOOL _sessionInterrupted = NO;
         _recordRequested = NO;
         _sessionInterrupted = NO;
 
-        [self changePreviewOrientation:[UIApplication sharedApplication].statusBarOrientation];
-
 
         // we will do other initialization after
         // the view is loaded.
@@ -1219,20 +1217,19 @@ BOOL _sessionInterrupted = NO;
         return;
     }
 
-    __block UIInterfaceOrientation interfaceOrientation;
-
-    void (^statusBlock)(void) = ^() {
-        interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
-    };
-    if ([NSThread isMainThread]) {
-        statusBlock();
-    } else {
-        dispatch_sync(dispatch_get_main_queue(), statusBlock);
-    }
-
-    AVCaptureVideoOrientation orientation = [RNCameraUtils videoOrientationForInterfaceOrientation:interfaceOrientation];
 
     dispatch_async(self.sessionQueue, ^{
+
+        // get orientation also in our session queue to prevent
+        // race conditions and also blocking the main thread
+        __block UIInterfaceOrientation interfaceOrientation;
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
+        });
+
+        AVCaptureVideoOrientation orientation = [RNCameraUtils videoOrientationForInterfaceOrientation:interfaceOrientation];
+
 
         [self.session beginConfiguration];
 

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -13,6 +13,8 @@
 
 RCT_EXPORT_MODULE(RNCameraManager);
 RCT_EXPORT_VIEW_PROPERTY(onCameraReady, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onAudioInterrupted, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onAudioConnected, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onMountError, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onBarCodeRead, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onFacesDetected, RCTDirectEventBlock);
@@ -298,7 +300,12 @@ RCT_CUSTOM_VIEW_PROPERTY(textRecognizerEnabled, BOOL, RNCamera)
 
 RCT_CUSTOM_VIEW_PROPERTY(captureAudio, BOOL, RNCamera)
 {
-    [view setCaptureAudio:[RCTConvert BOOL:json]];
+    BOOL newVal = [RCTConvert BOOL:json];
+    if([view captureAudio] != newVal){
+        [view setCaptureAudio:newVal];
+        [view updateCaptureAudio];
+    }
+    
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(rectOfInterest, CGRect, RNCamera)

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -300,12 +300,8 @@ RCT_CUSTOM_VIEW_PROPERTY(textRecognizerEnabled, BOOL, RNCamera)
 
 RCT_CUSTOM_VIEW_PROPERTY(captureAudio, BOOL, RNCamera)
 {
-    BOOL newVal = [RCTConvert BOOL:json];
-    if([view captureAudio] != newVal){
-        [view setCaptureAudio:newVal];
-        [view updateCaptureAudio];
-    }
-    
+    [view setCaptureAudio:[RCTConvert BOOL:json]];
+    [view updateCaptureAudio];    
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(rectOfInterest, CGRect, RNCamera)

--- a/ios/RN/RNSensorOrientationChecker.m
+++ b/ios/RN/RNSensorOrientationChecker.m
@@ -60,11 +60,16 @@
 {
     __weak __typeof(self) weakSelf = self;
     self.orientationCallback = ^(UIInterfaceOrientation orientation) {
-        if (callback) {
-            callback(orientation);
+        // Synchronized because this might fire more than once
+        // under some circumstances, causing a very bad loop
+        // to people that uses it.
+        @synchronized (weakSelf) {
+            if (callback && weakSelf.orientationCallback) {
+                callback(orientation);
+            }
+            weakSelf.orientationCallback = nil;
+            [weakSelf pause];
         }
-        weakSelf.orientationCallback = nil;
-        [weakSelf pause];
     };
     [self resume];
 }

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -245,6 +245,8 @@ type PropsType = typeof View.props & {
   focusDepth?: number,
   type?: number | string,
   onCameraReady?: Function,
+  onAudioInterrupted?: Function,
+  onAudioConnected?: Function,
   onStatusChange?: Function,
   onBarCodeRead?: Function,
   onPictureSaved?: Function,
@@ -381,6 +383,8 @@ export default class Camera extends React.Component<PropsType, StateType> {
     focusDepth: PropTypes.number,
     onMountError: PropTypes.func,
     onCameraReady: PropTypes.func,
+    onAudioInterrupted: PropTypes.func,
+    onAudioConnected: PropTypes.func,
     onStatusChange: PropTypes.func,
     onBarCodeRead: PropTypes.func,
     onPictureSaved: PropTypes.func,
@@ -613,6 +617,18 @@ export default class Camera extends React.Component<PropsType, StateType> {
     }
   };
 
+  _onAudioInterrupted = () => {
+    if (this.props.onAudioInterrupted) {
+      this.props.onAudioInterrupted();
+    }
+  };
+
+  _onAudioConnected = () => {
+    if (this.props.onAudioConnected) {
+      this.props.onAudioConnected();
+    }
+  };
+
   _onStatusChange = () => {
     if (this.props.onStatusChange) {
       this.props.onStatusChange({
@@ -775,6 +791,8 @@ export default class Camera extends React.Component<PropsType, StateType> {
             ref={this._setReference}
             onMountError={this._onMountError}
             onCameraReady={this._onCameraReady}
+            onAudioInterrupted={this._onAudioInterrupted}
+            onAudioConnected={this._onAudioConnected}
             onGoogleVisionBarcodesDetected={this._onObjectDetected(
               this.props.onGoogleVisionBarcodesDetected,
             )}
@@ -845,6 +863,8 @@ const RNCamera = requireNativeComponent('RNCamera', Camera, {
     onBarCodeRead: true,
     onGoogleVisionBarcodesDetected: true,
     onCameraReady: true,
+    onAudioInterrupted: true,
+    onAudioConnected: true,
     onPictureSaved: true,
     onFaceDetected: true,
     onLayout: true,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -152,6 +152,10 @@ export interface RNCameraProps {
   }): void;
   onMountError?(error: { message: string }): void;
 
+  /** iOS only */
+  onAudioInterrupted?(): void;
+  onAudioConnected?(): void;
+
   /** Value: float from 0 to 1.0 */
   zoom?: number;
   /** iOS only. float from 0 to any. Locks the max zoom value to the provided value


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

These changes aim at allowing the camera to run and work while audio is unavailable (due to phone calls or other events). Currently, if captureAudio is true, and a phone call comes in, the video preview becomes unavailable. 

The update does some code cleanup, and adds two new events that can be used to listen to audio interruptions so the JS side can act accordingly, and update the UI if needed.

In order to reliably detect if audio is available, and if captureAudio is true, the camera now explicitly attempts to active the audio session, and releases it once no longer used. This does not change the current behaviour if music playback is happening in background (which is stopped), but has the side effect of actually allowing music to resume once the camera is disposed due to the audio session being released.


Summary:

- Use a more generic event to handle session interruptions. This removes the need to listen to foreground/background events, **and stopping the session this way was actually redundant/wrong** (see https://forums.developer.apple.com/thread/61406). Also makes session stopping detection more reliable (calls, suspension due to a call or notification, etc., which would previously not set the recording interrupted flag on every case)

From the above docs: "No, incorrect. You _never_ need to stop your capture session. The capture session automatically stops itself when your app goes to the background and resumes itself when you come back to the foreground."

- add onAudioInterrupted and onAudioConnected events so the UI can handle scenarios where audio is wanted but not available. This should also help in keeping the preview active even if audio is interrupted and we have captureAudio={true}. 

- check, activate, and release audio sessions (if captureAudio) so that background music/playback can be resumed after the camera stops, and so we can detect early if audio is available before attempting to connect the input. This will effectively allow us to open the camera if a phone call is currently going on. Currently, the preview will end up black and it won't resume automatically after the phone call ends if it was already running before the camera opened.

- use proper observer for session error instead of of the strong self block. No benefits, but makes code more readable and allows access to instance variables

- getDeviceOrientationWithBlock might fire more than once under some circumstances, ending up taking a picture or video twice. Add a lock and additional check to prevent this.

- Check for session running before trying to record and capture. Will save from a crash if this is not controlled on the UI side. Move all camera startup to the session queue, this should also make it faster since it won't be blocking the UI and there won't be redundant calls to camera startup.

- update orientation on the session queue only to avoid race conditions. No need to get it on component constructor. This fixes a rare case that the orientation might end up wrong if moving the device quickly

Main issue here: https://github.com/react-native-community/react-native-camera/issues/2548


## Test Plan
Locally tested on iPhone 7 (iOS 12 and 13). Tested for almost 2 weeks on iOS test flight (about 36 users and 18 devices). 
Tests consisted on doing phone calls, facetime calls, and telegram calls. Calls would be done to interrupt an existing camera session, and before a session was actually started.

Can definitely use additional testing from other use cases.


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Real device

### What are the steps to reproduce (after prerequisites)?
- 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
