### PR TITLE
bugfix: Handle audio interruption in session queue

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -80,7 +80,6 @@ BOOL _sessionInterrupted = NO;
         _recordRequested = NO;
         _sessionInterrupted = NO;
 
-
         // we will do other initialization after
         // the view is loaded.
         // This is to prevent code if the view is unused as react
@@ -314,16 +313,16 @@ BOOL _sessionInterrupted = NO;
 // possible on the new device, and our device reference will be
 // different
 - (void)cleanupFocus:(AVCaptureDevice*) previousDevice {
-    
+
     self.isFocusedOnPoint = NO;
     self.isExposedOnPoint = NO;
-    
+
     // cleanup listeners if we had any
     if(previousDevice != nil){
-        
+
         // remove event listener
         [[NSNotificationCenter defaultCenter] removeObserver:self name:AVCaptureDeviceSubjectAreaDidChangeNotification object:previousDevice];
-        
+
         // cleanup device flags
         NSError *error = nil;
         if (![previousDevice lockForConfiguration:&error]) {
@@ -332,11 +331,11 @@ BOOL _sessionInterrupted = NO;
             }
             return;
         }
-        
+
         previousDevice.subjectAreaChangeMonitoringEnabled = NO;
-        
+
         [previousDevice unlockForConfiguration];
-        
+
     }
 }
 
@@ -1278,14 +1277,14 @@ BOOL _sessionInterrupted = NO;
             return;
         }
 
-        
+
         // Do additional cleanup that might be needed on the
         // previous device, if any.
         AVCaptureDevice *previousDevice = self.videoCaptureDeviceInput != nil ? self.videoCaptureDeviceInput.device : nil;
 
         [self cleanupFocus:previousDevice];
-        
-        
+
+
         // Remove inputs
         [self.session removeInput:self.videoCaptureDeviceInput];
 
@@ -1293,13 +1292,13 @@ BOOL _sessionInterrupted = NO;
         // Otherwise, if setting fails, we end up with a stale value.
         // and we are no longer able to detect if it changed or not
         self.videoCaptureDeviceInput = nil;
-        
+
         // setup our capture preset based on what was set from RN
         // and our defaults
         // if the preset is not supported (e.g., when switching cameras)
         // canAddInput below will fail
         self.session.sessionPreset = [self getDefaultPreset];
-        
+
 
         if ([self.session canAddInput:captureDeviceInput]) {
             [self.session addInput:captureDeviceInput];
@@ -1437,7 +1436,10 @@ BOOL _sessionInterrupted = NO;
         // if we have audio, stop it so preview resumes
         // it will eventually be re-loaded the next time recording
         // is requested, although it will flicker.
-        [self removeAudioCaptureSessionInput];
+        dispatch_async(self.sessionQueue, ^{
+            [self removeAudioCaptureSessionInput];
+        });
+            
     }
 
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Tiny update so that the session interrupted event fires its audio changes in the session queue to prevent concurrent changes to the AVCaptureSession instance. Such concurrent changes could lead to an inconsistent `isRunning` property.

Should fix:  https://github.com/react-native-community/react-native-camera/issues/2566
Will report back with other devices in a day or so.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Test on iPhone 7 (13.2) using speech-to-text on a screen with the camera preview and audio enabled.

### What's required for testing (prerequisites)?
A real device

### What are the steps to reproduce (after prerequisites)?
Cause an audio interruption without leaving the actual app (e.g., text to speech and music)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
