### PR TITLE
Fix taken picture is not rotated upright to device orientation in some device and emulator

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -697,7 +697,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                         isPictureCaptureInProgress.set(false);
 
                         mOrientation = Constants.ORIENTATION_AUTO;
-                        mCallback.onPictureTaken(data, displayOrientationToOrientationEnum(mDeviceOrientation));
+                        mCallback.onPictureTaken(data, displayOrientationToOrientationEnum(mDeviceOrientation), getCameraOrientation());
 
                         if(mustUpdateSurface){
                             updateSurface();

--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -190,7 +190,7 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
                     buffer.get(data);
                     if (image.getFormat() == ImageFormat.JPEG) {
                         // @TODO: implement deviceOrientation
-                        mCallback.onPictureTaken(data, 0);
+                        mCallback.onPictureTaken(data, 0, mCameraOrientation);
                     } else {
                         mCallback.onFramePreview(data, image.getWidth(), image.getHeight(), mDisplayOrientation);
                     }

--- a/android/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraView.java
@@ -583,7 +583,7 @@ public class CameraView extends FrameLayout {
 
     /**
      * Take a picture. The result will be returned to
-     * {@link Callback#onPictureTaken(CameraView, byte[], int)}.
+     * {@link Callback#onPictureTaken(CameraView, byte[], int, int)}.
      */
     public void takePicture(ReadableMap options) {
         mImpl.takePicture(options);
@@ -658,9 +658,9 @@ public class CameraView extends FrameLayout {
         }
 
         @Override
-        public void onPictureTaken(byte[] data, int deviceOrientation) {
+        public void onPictureTaken(byte[] data, int deviceOrientation, int cameraOrientation) {
             for (Callback callback : mCallbacks) {
-                callback.onPictureTaken(CameraView.this, data, deviceOrientation);
+                callback.onPictureTaken(CameraView.this, data, deviceOrientation, cameraOrientation);
             }
         }
 
@@ -797,7 +797,7 @@ public class CameraView extends FrameLayout {
          * @param cameraView The associated {@link CameraView}.
          * @param data       JPEG data.
          */
-        public void onPictureTaken(CameraView cameraView, byte[] data, int deviceOrientation) {
+        public void onPictureTaken(CameraView cameraView, byte[] data, int deviceOrientation, int cameraOrientation) {
         }
 
         /**

--- a/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
@@ -142,7 +142,7 @@ abstract class CameraViewImpl {
 
         void onCameraClosed();
 
-        void onPictureTaken(byte[] data, int deviceOrientation);
+        void onPictureTaken(byte[] data, int deviceOrientation, int cameraOrientation);
 
         void onVideoRecorded(String path, int videoOrientation, int deviceOrientation);
 

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -84,7 +84,7 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
       }
 
       @Override
-      public void onPictureTaken(CameraView cameraView, final byte[] data, int deviceOrientation) {
+      public void onPictureTaken(CameraView cameraView, final byte[] data, int deviceOrientation, int cameraOrientation) {
         Promise promise = mPictureTakenPromises.poll();
         ReadableMap options = mPictureTakenOptions.remove(promise);
         if (options.hasKey("fastMode") && options.getBoolean("fastMode")) {
@@ -92,10 +92,10 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
         }
         final File cacheDirectory = mPictureTakenDirectories.remove(promise);
         if(Build.VERSION.SDK_INT >= 11/*HONEYCOMB*/) {
-          new ResolveTakenPictureAsyncTask(data, promise, options, cacheDirectory, deviceOrientation, RNCameraView.this)
+          new ResolveTakenPictureAsyncTask(data, promise, options, cacheDirectory, deviceOrientation, RNCameraView.this, cameraOrientation)
                   .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         } else {
-          new ResolveTakenPictureAsyncTask(data, promise, options, cacheDirectory, deviceOrientation, RNCameraView.this)
+          new ResolveTakenPictureAsyncTask(data, promise, options, cacheDirectory, deviceOrientation, RNCameraView.this, cameraOrientation)
                   .execute();
         }
         RNCameraViewHelper.emitPictureTakenEvent(cameraView);

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -16,6 +16,7 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.ThemedReactContext;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -251,15 +252,15 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
     private int getImageRotation(int orientation) {
         int rotationDegrees = 0;
         switch (orientation) {
-        case ExifInterface.ORIENTATION_ROTATE_90:
-            rotationDegrees = 90;
-            break;
-        case ExifInterface.ORIENTATION_ROTATE_180:
-            rotationDegrees = 180;
-            break;
-        case ExifInterface.ORIENTATION_ROTATE_270:
-            rotationDegrees = 270;
-            break;
+            case ExifInterface.ORIENTATION_ROTATE_90:
+                rotationDegrees = 90;
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_180:
+                rotationDegrees = 180;
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_270:
+                rotationDegrees = 270;
+                break;
         }
         return rotationDegrees;
     }

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -15,7 +15,6 @@ import org.reactnative.camera.utils.RNFileUtils;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 
 import java.io.ByteArrayInputStream;
@@ -32,14 +31,16 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
     private File mCacheDirectory;
     private Bitmap mBitmap;
     private int mDeviceOrientation;
+    private int mCameraOrientation;
     private PictureSavedDelegate mPictureSavedDelegate;
 
-    public ResolveTakenPictureAsyncTask(byte[] imageData, Promise promise, ReadableMap options, File cacheDirectory, int deviceOrientation, PictureSavedDelegate delegate) {
+    public ResolveTakenPictureAsyncTask(byte[] imageData, Promise promise, ReadableMap options, File cacheDirectory, int deviceOrientation, PictureSavedDelegate delegate, int cameraOrientation) {
         mPromise = promise;
         mOptions = options;
         mImageData = imageData;
         mCacheDirectory = cacheDirectory;
         mDeviceOrientation = deviceOrientation;
+        mCameraOrientation = cameraOrientation;
         mPictureSavedDelegate = delegate;
     }
 
@@ -111,9 +112,15 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
                 // Rotate the bitmap to the proper orientation if needed
                 boolean fixOrientation = mOptions.hasKey("fixOrientation")
                         && mOptions.getBoolean("fixOrientation")
-                        && orientation != ExifInterface.ORIENTATION_UNDEFINED;
+                        && (orientation != ExifInterface.ORIENTATION_UNDEFINED
+                        || mCameraOrientation != 0);
+
                 if (fixOrientation) {
-                    mBitmap = rotateBitmap(mBitmap, getImageRotation(orientation));
+                    if (orientation != ExifInterface.ORIENTATION_UNDEFINED) {
+                        mBitmap = rotateBitmap(mBitmap, getImageRotation(orientation));
+                    } else {
+                        mBitmap = rotateBitmap(mBitmap, mCameraOrientation);
+                    }
                 }
 
                 if (mOptions.hasKey("width")) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->
Camera sensor orientation doesn't match device native orientation, the image taken by that camera should be rotated upright to device. But some of my clients send us 90 degrees rotated image even if we set up fixOrientation true.
This situation occurs very rare and it depends on hardware camera sensor orientation. I listed devices in which this situation occurs.
57513  OPPO  CPH1853  android  8.1.0
samsung  SM-T295  android  9
OPPO  CPH1911  android  9
samsung  SM-A750GN  android  9
OnePlus  ONEPLUS A5010  android  9
LG K10 android 5.1.1 and android emulators also

I' ve tested this change on LG K10 android 5.1.1 and android emulators. App works properly after this change.
# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a LG K10 device and a simulator
