### PR TITLE
Possible ANR due to events not fired on the main thread

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -6,8 +6,6 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.media.CamcorderProfile;
 import android.os.Build;
-import android.os.Looper;
-import android.os.Handler;
 import androidx.exifinterface.media.ExifInterface;
 import android.view.ViewGroup;
 import com.facebook.react.bridge.Arguments;
@@ -159,18 +157,19 @@ public class RNCameraViewHelper {
       {"int", ExifInterface.TAG_RW2_ISO},
   };
 
-  // main thread handler so we ensure to dispatch on the appropriate thread
-  // since these events might be called from other non-ui threads
-  private static Handler mHandler = new Handler(Looper.getMainLooper());
+  // Run all events on native modules queue thread since they might be fired
+  // from other non RN threads.
+
 
   // Mount error event
 
   public static void emitMountErrorEvent(final ViewGroup view, final String error) {
-    mHandler.post(new Runnable() {
+
+    final ReactContext reactContext = (ReactContext) view.getContext();
+    reactContext.runOnNativeModulesQueueThread(new Runnable() {
       @Override
       public void run() {
         CameraMountErrorEvent event = CameraMountErrorEvent.obtain(view.getId(), error);
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
       }
     });
@@ -180,11 +179,11 @@ public class RNCameraViewHelper {
 
   public static void emitCameraReadyEvent(final ViewGroup view) {
 
-    mHandler.post(new Runnable() {
+    final ReactContext reactContext = (ReactContext) view.getContext();
+    reactContext.runOnNativeModulesQueueThread(new Runnable() {
       @Override
       public void run() {
         CameraReadyEvent event = CameraReadyEvent.obtain(view.getId());
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
       }
     });
@@ -194,11 +193,11 @@ public class RNCameraViewHelper {
 
   public static void emitPictureSavedEvent(final ViewGroup view, final WritableMap response) {
 
-    mHandler.post(new Runnable() {
+    final ReactContext reactContext = (ReactContext) view.getContext();
+    reactContext.runOnNativeModulesQueueThread(new Runnable() {
       @Override
       public void run() {
         PictureSavedEvent event = PictureSavedEvent.obtain(view.getId(), response);
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
       }
     });
@@ -208,11 +207,12 @@ public class RNCameraViewHelper {
   // Picture taken event
 
   public static void emitPictureTakenEvent(final ViewGroup view) {
-    mHandler.post(new Runnable() {
+
+    final ReactContext reactContext = (ReactContext) view.getContext();
+    reactContext.runOnNativeModulesQueueThread(new Runnable() {
       @Override
       public void run() {
         PictureTakenEvent event = PictureTakenEvent.obtain(view.getId());
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
       }
      });
@@ -221,22 +221,24 @@ public class RNCameraViewHelper {
   // Face detection events
 
   public static void emitFacesDetectedEvent(final ViewGroup view, final WritableArray data) {
-    mHandler.post(new Runnable() {
+
+    final ReactContext reactContext = (ReactContext) view.getContext();
+    reactContext.runOnNativeModulesQueueThread(new Runnable() {
       @Override
       public void run() {
         FacesDetectedEvent event = FacesDetectedEvent.obtain(view.getId(), data);
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
       }
      });
   }
 
   public static void emitFaceDetectionErrorEvent(final ViewGroup view, final RNFaceDetector faceDetector) {
-    mHandler.post(new Runnable() {
+
+    final ReactContext reactContext = (ReactContext) view.getContext();
+    reactContext.runOnNativeModulesQueueThread(new Runnable() {
       @Override
       public void run() {
         FaceDetectionErrorEvent event = FaceDetectionErrorEvent.obtain(view.getId(), faceDetector);
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
       }
     });
@@ -245,22 +247,24 @@ public class RNCameraViewHelper {
   // Barcode detection events
 
   public static void emitBarcodesDetectedEvent(final ViewGroup view, final WritableArray barcodes) {
-    mHandler.post(new Runnable() {
+
+    final ReactContext reactContext = (ReactContext) view.getContext();
+    reactContext.runOnNativeModulesQueueThread(new Runnable() {
       @Override
       public void run() {
         BarcodesDetectedEvent event = BarcodesDetectedEvent.obtain(view.getId(), barcodes);
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
       }
     });
   }
 
   public static void emitBarcodeDetectionErrorEvent(final ViewGroup view, final RNBarcodeDetector barcodeDetector) {
-    mHandler.post(new Runnable() {
+
+    final ReactContext reactContext = (ReactContext) view.getContext();
+    reactContext.runOnNativeModulesQueueThread(new Runnable() {
       @Override
       public void run() {
         BarcodeDetectionErrorEvent event = BarcodeDetectionErrorEvent.obtain(view.getId(), barcodeDetector);
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
       }
     });
@@ -269,11 +273,11 @@ public class RNCameraViewHelper {
   // Bar code read event
 
   public static void emitBarCodeReadEvent(final ViewGroup view, final Result barCode, final int width, final int height) {
-    mHandler.post(new Runnable() {
+    final ReactContext reactContext = (ReactContext) view.getContext();
+    reactContext.runOnNativeModulesQueueThread(new Runnable() {
       @Override
       public void run() {
         BarCodeReadEvent event = BarCodeReadEvent.obtain(view.getId(), barCode, width,  height);
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
       }
     });
@@ -282,11 +286,11 @@ public class RNCameraViewHelper {
   // Text recognition event
 
   public static void emitTextRecognizedEvent(final ViewGroup view, final WritableArray data) {
-    mHandler.post(new Runnable() {
+    final ReactContext reactContext = (ReactContext) view.getContext();
+    reactContext.runOnNativeModulesQueueThread(new Runnable() {
       @Override
       public void run() {
         TextRecognizedEvent event = TextRecognizedEvent.obtain(view.getId(), data);
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
       }
     });

--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -6,6 +6,8 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.media.CamcorderProfile;
 import android.os.Build;
+import android.os.Looper;
+import android.os.Handler;
 import androidx.exifinterface.media.ExifInterface;
 import android.view.ViewGroup;
 import com.facebook.react.bridge.Arguments;
@@ -156,80 +158,138 @@ public class RNCameraViewHelper {
       {"int", ExifInterface.TAG_RW2_SENSOR_TOP_BORDER},
       {"int", ExifInterface.TAG_RW2_ISO},
   };
+
+  // main thread handler so we ensure to dispatch on the appropriate thread
+  // since these events might be called from other non-ui threads
+  private static Handler mHandler = new Handler(Looper.getMainLooper());
+
   // Mount error event
 
-  public static void emitMountErrorEvent(ViewGroup view, String error) {
-    CameraMountErrorEvent event = CameraMountErrorEvent.obtain(view.getId(), error);
-    ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+  public static void emitMountErrorEvent(final ViewGroup view, final String error) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        CameraMountErrorEvent event = CameraMountErrorEvent.obtain(view.getId(), error);
+        ReactContext reactContext = (ReactContext) view.getContext();
+        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+      }
+    });
   }
 
   // Camera ready event
 
-  public static void emitCameraReadyEvent(ViewGroup view) {
-    CameraReadyEvent event = CameraReadyEvent.obtain(view.getId());
-    ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+  public static void emitCameraReadyEvent(final ViewGroup view) {
+
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        CameraReadyEvent event = CameraReadyEvent.obtain(view.getId());
+        ReactContext reactContext = (ReactContext) view.getContext();
+        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+      }
+    });
   }
 
   // Picture saved event
 
-  public static void emitPictureSavedEvent(ViewGroup view, WritableMap response) {
-    PictureSavedEvent event = PictureSavedEvent.obtain(view.getId(), response);
-    ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+  public static void emitPictureSavedEvent(final ViewGroup view, final WritableMap response) {
+
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        PictureSavedEvent event = PictureSavedEvent.obtain(view.getId(), response);
+        ReactContext reactContext = (ReactContext) view.getContext();
+        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+      }
+    });
+
   }
 
   // Picture taken event
 
-  public static void emitPictureTakenEvent(ViewGroup view) {
-    PictureTakenEvent event = PictureTakenEvent.obtain(view.getId());
-    ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+  public static void emitPictureTakenEvent(final ViewGroup view) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        PictureTakenEvent event = PictureTakenEvent.obtain(view.getId());
+        ReactContext reactContext = (ReactContext) view.getContext();
+        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+      }
+     });
   }
 
   // Face detection events
 
-  public static void emitFacesDetectedEvent(ViewGroup view, WritableArray data) {
-    FacesDetectedEvent event = FacesDetectedEvent.obtain(view.getId(), data);
-    ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+  public static void emitFacesDetectedEvent(final ViewGroup view, final WritableArray data) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        FacesDetectedEvent event = FacesDetectedEvent.obtain(view.getId(), data);
+        ReactContext reactContext = (ReactContext) view.getContext();
+        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+      }
+     });
   }
 
-  public static void emitFaceDetectionErrorEvent(ViewGroup view, RNFaceDetector faceDetector) {
-    FaceDetectionErrorEvent event = FaceDetectionErrorEvent.obtain(view.getId(), faceDetector);
-    ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+  public static void emitFaceDetectionErrorEvent(final ViewGroup view, final RNFaceDetector faceDetector) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        FaceDetectionErrorEvent event = FaceDetectionErrorEvent.obtain(view.getId(), faceDetector);
+        ReactContext reactContext = (ReactContext) view.getContext();
+        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+      }
+    });
   }
 
   // Barcode detection events
 
-  public static void emitBarcodesDetectedEvent(ViewGroup view, WritableArray barcodes) {
-    BarcodesDetectedEvent event = BarcodesDetectedEvent.obtain(view.getId(), barcodes);
-    ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+  public static void emitBarcodesDetectedEvent(final ViewGroup view, final WritableArray barcodes) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        BarcodesDetectedEvent event = BarcodesDetectedEvent.obtain(view.getId(), barcodes);
+        ReactContext reactContext = (ReactContext) view.getContext();
+        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+      }
+    });
   }
 
-  public static void emitBarcodeDetectionErrorEvent(ViewGroup view, RNBarcodeDetector barcodeDetector) {
-    BarcodeDetectionErrorEvent event = BarcodeDetectionErrorEvent.obtain(view.getId(), barcodeDetector);
-    ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+  public static void emitBarcodeDetectionErrorEvent(final ViewGroup view, final RNBarcodeDetector barcodeDetector) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        BarcodeDetectionErrorEvent event = BarcodeDetectionErrorEvent.obtain(view.getId(), barcodeDetector);
+        ReactContext reactContext = (ReactContext) view.getContext();
+        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+      }
+    });
   }
 
   // Bar code read event
 
-  public static void emitBarCodeReadEvent(ViewGroup view, Result barCode, int width, int height) {
-    BarCodeReadEvent event = BarCodeReadEvent.obtain(view.getId(), barCode, width,  height);
-    ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+  public static void emitBarCodeReadEvent(final ViewGroup view, final Result barCode, final int width, final int height) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        BarCodeReadEvent event = BarCodeReadEvent.obtain(view.getId(), barCode, width,  height);
+        ReactContext reactContext = (ReactContext) view.getContext();
+        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+      }
+    });
   }
 
   // Text recognition event
 
-  public static void emitTextRecognizedEvent(ViewGroup view, WritableArray data) {
-    TextRecognizedEvent event = TextRecognizedEvent.obtain(view.getId(), data);
-    ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+  public static void emitTextRecognizedEvent(final ViewGroup view, final WritableArray data) {
+    mHandler.post(new Runnable() {
+      @Override
+      public void run() {
+        TextRecognizedEvent event = TextRecognizedEvent.obtain(view.getId(), data);
+        ReactContext reactContext = (ReactContext) view.getContext();
+        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+      }
+    });
   }
 
   // Utilities
@@ -329,9 +389,9 @@ public class RNCameraViewHelper {
         }
       }
     }
-    
-    if (exifMap.hasKey(ExifInterface.TAG_GPS_LATITUDE) && 
-        exifMap.hasKey(ExifInterface.TAG_GPS_LONGITUDE) && 
+
+    if (exifMap.hasKey(ExifInterface.TAG_GPS_LATITUDE) &&
+        exifMap.hasKey(ExifInterface.TAG_GPS_LONGITUDE) &&
         exifMap.hasKey(ExifInterface.TAG_GPS_ALTITUDE)) {
       exifInterface.setLatLong(exifMap.getDouble(ExifInterface.TAG_GPS_LATITUDE),
                                exifMap.getDouble(ExifInterface.TAG_GPS_LONGITUDE));


### PR DESCRIPTION
# Summary
Possible fix for https://github.com/react-native-community/react-native-camera/issues/2587

RN events were fired as is, and could end up being fired on a non main thread. The reason why the ANRs are happening only sometimes is still unknown, but this seems to fix the problem. Note that before 3.9.0, all code was running on the main thread, so this was never an issue.

PS: the changes on this file might add a merge conflict to https://github.com/react-native-community/react-native-camera/pull/2577 

Updated: Main thread wasn't needed at all, just the RN's native modules thread (which is most likely a main thread somewhere). 

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
Tested on Android 8.1 and Android 10.

Test was performed using https://github.com/nartc/rncamera-navigation-android-test and my own code that uses this library.

Awaiting feedback from @nartc to confirm the issue is indeed resolved.

### What's required for testing (prerequisites)?
Real device

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
