### PR TITLE
WIP: Honor autofocus props when useCamera2api is true

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -436,7 +436,7 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
             mStillImageReader.close();
         }
         if (size == null) {
-          if (mAspectRatio == null) {
+          if (mAspectRatio == null || mPictureSize == null) {
             return;
           }
           mPictureSizes.sizes(mAspectRatio).last();

--- a/android/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraView.java
@@ -293,6 +293,8 @@ public class CameraView extends FrameLayout {
             } else {
                 mImpl = new Camera2Api23(mCallbacks, mImpl.mPreview, mContext, mBgHandler);
             }
+
+            onRestoreInstanceState(state);
         } else {
             if (mImpl instanceof Camera1) {
                 return;
@@ -316,7 +318,7 @@ public class CameraView extends FrameLayout {
                 this.removeView(mImpl.getView());
             }
             //store the state and restore this state after fall back to Camera1
-            Parcelable state=onSaveInstanceState();
+            Parcelable state = onSaveInstanceState();
             // Camera2 uses legacy hardware layer; fall back to Camera1
             mImpl = new Camera1(mCallbacks, createPreviewImpl(getContext()), mBgHandler);
             onRestoreInstanceState(state);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When useCamera2Api props is used during recording, autofocus=true/false is not being honored.

According to my understanding is that first CameraViewImpl is set to camera1 and all the props(aspect ratio, autofocus) are set to this instance.

Now if useCamera2Api props is used, then these set props are saved and when CameraViewImpl is switched to Camera2 or Camera2Api23 these props are applied again. 

It seems that props are not being applied again which causes the autofocus not being honored.

## Test Plan

Autofocus=true && useCamera2Api=true
![Screenshot_20191122-160110](https://user-images.githubusercontent.com/6740476/69432174-dd984280-0d41-11ea-8998-a0b03c02c46f.png)

Autofocus=true && useCamera2Api=false
![Screenshot_20191122-155740](https://user-images.githubusercontent.com/6740476/69432118-bb9ec000-0d41-11ea-80ea-bcd871278599.png)

### What's required for testing (prerequisites)?

Simple RN application which uses react-native-camera to record video. 

### What are the steps to reproduce (after prerequisites)?

Set autoFocus={RNCamera.Constants.AutoFocus.on} and during preview/recording you can see that autofocus works.
Now set useCamera2Api={true} and autofocus is not working anymore.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |      ❌     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
