### PR TITLE
fix onBarcodeRead typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -175,10 +175,10 @@ export interface RNCameraProps {
     rawData?: string;
     type: keyof BarCodeType;
     /**
-     * @description For Android use `[Point<string>, Point<string>]`
+     * @description For Android use `{ width: number, height: number, origin: Array<Point<string>> }`
      * @description For iOS use `{ origin: Point<string>, size: Size<string> }`
      */
-    bounds: [Point<string>, Point<string>] | { origin: Point<string>; size: Size<string> };
+    bounds: { width: number, height: number, origin: Array<Point<string>> } | { origin: Point<string>; size: Size<string> };
   }): void;
 
   onGoogleVisionBarcodesDetected?(event: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

`onBarCodeRead` bounds property on Android has wrong typings.

Current: `bounds: [Point<string>, Point<string>];`
Reality: `bounds: { width: number, height: number, origin: Array<Point<string>> }`

The `origin` array length differs based on the `barCodeType` (length of 4 for QR code and length of 8 for pdf417)

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
