### PR TITLE
Add "URL" to Barcode types & export additional TS types

### DIFF
--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -140,6 +140,7 @@ type TrackedBarcodeFeature = {
   data: string,
   dataRaw: string,
   type: BarcodeType,
+  format?: string,
   addresses?: {
     addressesType?: 'UNKNOWN' | 'Work' | 'Home',
     addressLines?: string[],

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -202,7 +202,8 @@ type BarcodeType =
   | 'WIFI'
   | 'TEXT'
   | 'ISBN'
-  | 'PRODUCT';
+  | 'PRODUCT'
+  | 'URL';
 
 type Email = {
   address?: string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -243,6 +243,7 @@ export interface Barcode {
   data: string;
   dataRaw: string;
   type: BarcodeType;
+  format?: string;
   addresses?: {
     addressesType?: "UNKNOWN" | "Work" | "Home";
     addressLines?: string[];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -235,7 +235,7 @@ interface Size<T = number> {
   height: T;
 }
 
-interface Barcode {
+export interface Barcode {
   bounds: {
     size: Size;
     origin: Point;
@@ -294,7 +294,7 @@ interface Barcode {
   message?: string;
 }
 
-type BarcodeType =
+export type BarcodeType =
   |"EMAIL"
   |"PHONE"
   |"CALENDAR_EVENT"
@@ -306,20 +306,21 @@ type BarcodeType =
   |"TEXT"
   |"ISBN"
   |"PRODUCT"
+  |"URL"
 
-interface Email {
+export interface Email {
   address?: string;
   body?: string;
   subject?: string;
   emailType?: "UNKNOWN" | "Work" | "Home";
 }
 
-interface Phone {
+export interface Phone {
   number?: string;
   phoneType?: "UNKNOWN" | "Work" | "Home" | "Fax" | "Mobile";
 }
 
-interface Face {
+export interface Face {
   faceID?: number;
   bounds: {
     size: Size;
@@ -343,7 +344,7 @@ interface Face {
   rollAngle?: number;
 }
 
-interface TrackedTextFeature {
+export interface TrackedTextFeature {
   type: 'block' | 'line' | 'element';
   bounds: {
     size: Size;
@@ -371,7 +372,7 @@ interface TakePictureOptions {
   forceUpOrientation?: boolean;
 }
 
-interface TakePictureResponse {
+export interface TakePictureResponse {
   width: number;
   height: number;
   uri: string;
@@ -395,7 +396,7 @@ interface RecordOptions {
   codec?: keyof VideoCodec | VideoCodec[keyof VideoCodec];
 }
 
-interface RecordResponse {
+export interface RecordResponse {
   /** Path to the video saved on your app's cache directory. */
   uri: string;
   videoOrientation: number;


### PR DESCRIPTION
# Summary

**1.** TS and Flow types both miss the `URL` barcode type which is a valid type of barcode for both Google Vision and builtin (see [here](https://github.com/react-native-community/react-native-camera/blob/efb6b90036d20269a17f679c07c1132fbb05d2dc/android/src/mlkit/java/org/reactnative/barcodedetector/BarcodeFormatUtils.java#L67) and [here](https://github.com/react-native-community/react-native-camera/blob/efb6b90036d20269a17f679c07c1132fbb05d2dc/android/src/general/java/org/reactnative/barcodedetector/BarcodeFormatUtils.java#L46)).

**2.** GoogleVision [sets a `format` string](https://github.com/react-native-community/react-native-camera/blob/0323eaa47b67c1adf93b5e862e725ae6257654a5/android/src/mlkit/java/org/reactnative/camera/tasks/BarcodeDetectorAsyncTask.java#L282) on Barcodes which is not exposed on types yet.

**3.** Very few of the TS types are exported which means users have to do some work to pull specific types off `RNCameraProps`. For example:
```typescript
import { RNCameraProps } from "react-native-camera";
import { ValuesType } from "utility-types";

export type BarcodeEvent = Parameters<Required<RNCameraProps>["onGoogleVisionBarcodesDetected"]>[0];
export type Barcode = ValuesType<BarcodeEvent["barcodes"]>;
```

I've exported the following additional TS types:

- Barcode
- BarcodeType
- Email
- Phone
- Face
- TrackedTextFeature
- TakePictureResponse
- RecordResponse

These changes *only* effect typings—not logic.

## Test Plan

I changed my project to reference my branch of react-native-camera and ran `tsc` to check types:

1. No more type errors when testing `type === "URL"`
2. I could reference Barcode.format without type errors
3. I was able to `import { Barcode } from "react-native-camera` and use it as a type

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
