### PR TITLE
Fix barcode option passing to mlkit for Android

### DIFF
--- a/android/src/mlkit/java/org/reactnative/barcodedetector/BarcodeFormatUtils.java
+++ b/android/src/mlkit/java/org/reactnative/barcodedetector/BarcodeFormatUtils.java
@@ -37,7 +37,6 @@ public class BarcodeFormatUtils {
     map.put(FirebaseVisionBarcode.FORMAT_AZTEC, "AZTEC");
     map.put(FirebaseVisionBarcode.FORMAT_ALL_FORMATS, "ALL");
     map.put(FirebaseVisionBarcode.FORMAT_UPC_A, "UPC_A");
-    map.put(FirebaseVisionBarcode.FORMAT_ALL_FORMATS, "ALL");
     map.put(-1, "None");
     FORMATS = map;
 

--- a/android/src/mlkit/java/org/reactnative/barcodedetector/RNBarcodeDetector.java
+++ b/android/src/mlkit/java/org/reactnative/barcodedetector/RNBarcodeDetector.java
@@ -61,7 +61,7 @@ public class RNBarcodeDetector {
     private void createBarcodeDetector() {
         FirebaseVisionBarcodeDetectorOptions options = mBuilder.build();
         mBarcodeDetector = FirebaseVision.getInstance()
-                .getVisionBarcodeDetector();
+                .getVisionBarcodeDetector(options);
 
     }
 }


### PR DESCRIPTION
# Summary

Android creates barcode options, but doesn't actually pass them to mlkit.

This results in `onGoogleVisionBarcodesDetected` receiving barcodes of all types, not just what `googleVisionBarcodeType` is set to.

(This is [not an issue on iOS](https://github.com/react-native-community/react-native-camera/blob/master/ios/RN/BarcodeDetectorManagerMlkit.m#L60)).

## Test Plan

My project sets `googleVisionBarcodeType` to `RNCamera.Constants.GoogleVisionBarcodeDetection.BarcodeType.PDF417` to extract data from a driver's license, but was receiving the CODE_128 barcode as well (the license has two barcodes).

With the change, it now only gets the PDF417.

When leaving `googleVisionBarcodeType` at the default, both barcodes are still detected.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
