### PR TITLE
Android API < 19 crash fix

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -34,11 +34,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.reactnative.camera.utils.ObjectUtils;
 
 
 @SuppressWarnings("deprecation")
@@ -342,13 +343,13 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     @Override
     void setCameraId(String id) {
 
-        if(!Objects.equals(_mCameraId, id)){
+        if(!ObjectUtils.equals(_mCameraId, id)){
             _mCameraId = id;
 
             // only update if our camera ID actually changes
             // from what we currently have.
             // Passing null will always yield true
-            if(!Objects.equals(_mCameraId, String.valueOf(mCameraId))){
+            if(!ObjectUtils.equals(_mCameraId, String.valueOf(mCameraId))){
                 // this will call chooseCamera
                 mBgHandler.post(new Runnable() {
                     @Override

--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -53,10 +53,13 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
+
+import org.reactnative.camera.utils.ObjectUtils;
+
+
 
 @SuppressWarnings("MissingPermission")
 @TargetApi(21)
@@ -366,13 +369,13 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
 
     @Override
     void setCameraId(String id) {
-        if(!Objects.equals(_mCameraId, id)){
+        if(!ObjectUtils.equals(_mCameraId, id)){
             _mCameraId = id;
 
             // only update if our camera ID actually changes
             // from what we currently have.
             // Passing null will always yield true
-            if(!Objects.equals(_mCameraId, mCameraId)){
+            if(!ObjectUtils.equals(_mCameraId, mCameraId)){
                 // this will call chooseCameraIdByFacing
                 if (isCameraOpened()) {
                     stop();

--- a/android/src/main/java/org/reactnative/camera/utils/ObjectUtils.java
+++ b/android/src/main/java/org/reactnative/camera/utils/ObjectUtils.java
@@ -1,0 +1,15 @@
+package org.reactnative.camera.utils;
+
+
+public class ObjectUtils {
+
+    /*
+    * Replacement for Objects.equals that is only available after Android API 19
+    */
+    public static boolean equals(Object o1, Object o2) {
+        if (o1 == null && o2 == null) return true;
+        if (o1 == null) return false;
+        return o1.equals(o2);
+    }
+
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

`Objects.equals` was added on Android API 19 (4.4), and RN supports API 16, so we need to make a helper instead of using Objects so the camera doesn't crash on Android < 4.4.

Fixes https://github.com/react-native-community/react-native-camera/issues/2528 and https://github.com/react-native-community/react-native-camera/issues/2634 

Thanks @gaykov  for the replacement code.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Tested on Android 8.1 and 10 (devices), and simulator with 4.2.2

### What's required for testing (prerequisites)?
-

### What are the steps to reproduce (after prerequisites)?
-

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
