### PR TITLE
(iOS) allow for audio session to be kept

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -230,6 +230,12 @@ Values: boolean `true` (default) | `false`
 Specifies if audio recording permissions should be requested.
 Make sure to follow README instructions for audio recording permissions [here](README.md).
 
+### iOS `keepAudioSession`
+
+Values: boolean `true` | `false` (false)
+
+(iOS Only) When the camera is unmounted, it will release any audio session it acquired (if `captureAudio=true`) so other media can continue playing. However, this might not be always desirable (e.g., if video is played afterwards) and can be disabled by setting it to `true`. Setting this to `true`, means you app will not release the audio session. Note: other apps might still "steal" the audio session from your app.
+
 ### `flashMode`
 
 Values: `RNCamera.Constants.FlashMode.off` (default), `RNCamera.Constants.FlashMode.on`, `RNCamera.Constants.FlashMode.auto` or `RNCamera.Constants.FlashMode.torch`.
@@ -698,7 +704,7 @@ A rewritten version of `react-native-barcode-mask` using `Hooks` and `Reanimated
 - Customizable
 - Provide custom hook to "scan barcode within finder area"
 
-Read more about it here [@nartc/react-native-barcode-mask](https://github.com/nartc/react-native-barcode-mask) 
+Read more about it here [@nartc/react-native-barcode-mask](https://github.com/nartc/react-native-barcode-mask)
 
 ## Testing
 

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -234,7 +234,7 @@ Make sure to follow README instructions for audio recording permissions [here](R
 
 Values: boolean `true` | `false` (false)
 
-(iOS Only) When the camera is unmounted, it will release any audio session it acquired (if `captureAudio=true`) so other media can continue playing. However, this might not be always desirable (e.g., if video is played afterwards) and can be disabled by setting it to `true`. Setting this to `true`, means you app will not release the audio session. Note: other apps might still "steal" the audio session from your app.
+(iOS Only) When the camera is unmounted, it will release any audio session it acquired (if `captureAudio=true`) so other media can continue playing. However, this might not be always desirable (e.g., if video is played afterwards) and can be disabled by setting it to `true`. Setting this to `true`, means your app will not release the audio session. Note: other apps might still "steal" the audio session from your app.
 
 ### `flashMode`
 

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -46,6 +46,7 @@
 @property(nonatomic, assign) BOOL canDetectFaces;
 @property(nonatomic, assign) BOOL canDetectBarcodes;
 @property(nonatomic, assign) BOOL captureAudio;
+@property(nonatomic, assign) BOOL keepAudioSession;
 @property(nonatomic, assign) CGRect rectOfInterest;
 @property(assign, nonatomic) AVVideoCodecType videoCodecType;
 @property(assign, nonatomic)

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1342,19 +1342,22 @@ BOOL _sessionInterrupted = NO;
 
         // Deactivate our audio session so other audio can resume
         // playing, if any. E.g., background music.
-        NSError *error = nil;
+        // unless told not to
+        if(!self.keepAudioSession){
+            NSError *error = nil;
 
-        BOOL setInactive = [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:&error];
+            BOOL setInactive = [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:&error];
 
-        if (!setInactive) {
-            RCTLogWarn(@"Audio device could not set inactive: %s: %@", __func__, error);
+            if (!setInactive) {
+                RCTLogWarn(@"Audio device could not set inactive: %s: %@", __func__, error);
+            }
         }
-
+        
         self.audioCaptureDeviceInput = nil;
 
         // inform that audio was interrupted
         if(audioRemoved && self.onAudioInterrupted){
-           self.onAudioInterrupted(nil);
+            self.onAudioInterrupted(nil);
         }
     }
 }

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -305,6 +305,11 @@ RCT_CUSTOM_VIEW_PROPERTY(captureAudio, BOOL, RNCamera)
     [view updateCaptureAudio];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(keepAudioSession, BOOL, RNCamera)
+{
+    [view setKeepAudioSession:[RCTConvert BOOL:json]];
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(rectOfInterest, CGRect, RNCamera)
 {
     [view setRectOfInterest: [RCTConvert CGRect:json]];

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -270,6 +270,7 @@ type PropsType = typeof View.props & {
   onFacesDetected?: ({ faces: Array<TrackedFaceFeature> }) => void,
   onTextRecognized?: ({ textBlocks: Array<TrackedTextFeature> }) => void,
   captureAudio?: boolean,
+  keepAudioSession?: boolean,
   useCamera2Api?: boolean,
   playSoundOnCapture?: boolean,
   videoStabilizationMode?: number | string,
@@ -417,6 +418,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     notAuthorizedView: PropTypes.element,
     pendingAuthorizationView: PropTypes.element,
     captureAudio: PropTypes.bool,
+    keepAudioSession: PropTypes.bool,
     useCamera2Api: PropTypes.bool,
     playSoundOnCapture: PropTypes.bool,
     videoStabilizationMode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -466,6 +468,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
       </View>
     ),
     captureAudio: true,
+    keepAudioSession: false,
     useCamera2Api: false,
     playSoundOnCapture: false,
     pictureSize: 'None',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -223,6 +223,8 @@ export interface RNCameraProps {
 
   // -- IOS ONLY PROPS
   defaultVideoQuality?: keyof VideoQuality;
+  /* if true, audio session will not be released on component unmount */
+  keepAudioSession?: boolean;
 }
 
 interface Point<T = number> {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Allow RNCamera to not release the audio session after it has acquired it. Should help in cases where other parts of the app uses audio (e.g., video playing) and the camera unmounting process interferes with it.

Added `keepAudioSession` (default false, no current behaviour changes, iOS only) to tell the code to not release the audio session.

Should fix/help https://github.com/react-native-community/react-native-camera/issues/2592

For such cases, use `keepAudioSession={true}`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Tested on iPhone 7 (13.2.3)

### What's required for testing (prerequisites)?
Real device

### What are the steps to reproduce (after prerequisites)?
-

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
