### PR TITLE
Make camera ready events to fire also on camera/device change to be c…

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -369,7 +369,7 @@ Note: This solve the flicker video recording issue for iOS
 
 ### `onCameraReady`
 
-Function to be called when native code emit onCameraReady event, when camera is ready.
+Function to be called when native code emit onCameraReady event, when camera is ready. This event will also fire when changing cameras (by `type` or `cameraId`).
 
 ### `onMountError`
 

--- a/examples/advanced/advanced/src/screens/Camera.js
+++ b/examples/advanced/advanced/src/screens/Camera.js
@@ -300,7 +300,7 @@ class Camera extends Component{
     if(s.cameraStatus == 'READY'){
 
       let audioDisabled = s.recordAudioPermissionStatus == 'NOT_AUTHORIZED';
-      this.setState({cameraReady: true, audioDisabled: audioDisabled}, async () => {
+      this.setState({audioDisabled: audioDisabled}, async () => {
 
         let ids = [];
 
@@ -354,6 +354,18 @@ class Camera extends Component{
         this.setState({cameraReady: false});
       }
     }
+  }
+
+  onCameraReady = () => {
+    if(!this.state.cameraReady){
+      this.setState({cameraReady: true});
+    }
+  }
+
+  onCameraMountError = () => {
+    setTimeout(()=>{
+      Alert.alert("Error", "Camera start failed.");
+    }, 150);
   }
 
 
@@ -614,6 +626,8 @@ class Camera extends Component{
                 buttonNegative: 'Cancel',
               }}
               onStatusChange={this.onCameraStatusChange}
+              onCameraReady={this.onCameraReady}
+              onMountError={this.onCameraMountError}
               pendingAuthorizationView={
                 <SafeAreaView style={styles.cameraLoading}>
                   <Spinner color={style.brandLight}/>
@@ -898,11 +912,6 @@ class Camera extends Component{
         else{
           this.setState({cameraId: cameraId, ...defaultCameraOptions});
         }
-
-        // disable and reenable camera on camera change
-        setTimeout(()=>{
-          this.setState({cameraReady: true});
-        }, 550);
       });
     });
   }

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1187,8 +1187,11 @@ BOOL _sessionInterrupted = NO;
 #endif
     dispatch_async(self.sessionQueue, ^{
 
-        // if session already running, also return.
+        // if session already running, also return and fire ready event
+        // this is helpfu when the device type or ID is changed and we must
+        // receive another ready event (like Android does)
         if(self.session.isRunning){
+            [self onReady:nil];
             return;
         }
 
@@ -1380,6 +1383,7 @@ BOOL _sessionInterrupted = NO;
 
         // if the device we are setting is also invalid/nil, return
         if(captureDevice == nil){
+            [self onMountingError:@{@"message": @"Invalid camera device."}];
             return;
         }
 
@@ -1406,6 +1410,7 @@ BOOL _sessionInterrupted = NO;
         if (error || captureDeviceInput == nil) {
             RCTLog(@"%s: %@", __func__, error);
             [self.session commitConfiguration];
+            [self onMountingError:@{@"message": @"Failed to setup capture device."}];
             return;
         }
 
@@ -1454,6 +1459,8 @@ BOOL _sessionInterrupted = NO;
         }
         else{
             RCTLog(@"The selected device does not work with the Preset [%@] or configuration provided", self.session.sessionPreset);
+            
+            [self onMountingError:@{@"message": @"Camera device does not support selected settings."}];
         }
 
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fire cameraReady events on iOS also when the camera is changed (by type or ID) to match Android behaviour.

Add mountError event to iOS. It was already there, but never fired. It will now fire on various of the camera load steps to indicate an error.

Updated example app to properly use the camera ready event.

Fixes: https://github.com/react-native-community/react-native-camera/issues/2518

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Tested on iPhone 7 and Motorola G5. Tested using invalid camera IDs and camera switching to ensure all events are fired consistently.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
