### PR TITLE
crash fix for android sdk < 18

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraView.java
@@ -146,7 +146,13 @@ public class CameraView extends FrameLayout {
 
     public void cleanup(){
         if(mBgThread != null){
-            mBgThread.quitSafely();
+            if(Build.VERSION.SDK_INT < 18){
+                mBgThread.quit();
+            }
+            else{
+                mBgThread.quitSafely();
+            }
+
             mBgThread = null;
         }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
Fixes a crash on Android <= 4.1 due to the use of an unsupported method.

Fix for https://github.com/react-native-community/react-native-camera/issues/2671

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Tested on Motorola G5 without the SDK check test to make sure the `quit` call does not crash due to it being more aggressive than `quitSafely`. 

Should wait for @arifinoid to test it as well.

### What's required for testing (prerequisites)?
Real device or simulated camera

### What are the steps to reproduce (after prerequisites)?
-

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
