### PR TITLE
fix(RNCameraManager) expose videoStabilizationMode from native

### DIFF
--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -23,6 +23,7 @@ RCT_EXPORT_VIEW_PROPERTY(onPictureTaken, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onPictureSaved, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTextRecognized, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onSubjectAreaChanged, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(videoStabilizationMode, NSInteger);
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,6 +22,7 @@ type Orientation = Readonly<{
 }>;
 type OrientationNumber = 1 | 2 | 3 | 4;
 type AutoFocus = Readonly<{ on: any; off: any }>;
+type VideoStabilization = Readonly<{off: any, standard: any, cinematic: any, auto: any}>;
 type FlashMode = Readonly<{ on: any; off: any; torch: any; auto: any }>;
 type CameraType = Readonly<{ front: any; back: any }>;
 type WhiteBalance = Readonly<{
@@ -127,6 +128,7 @@ export interface Constants {
     portrait: 'portrait';
     portraitUpsideDown: 'portraitUpsideDown';
   };
+  VideoStabilization: VideoStabilization;
 }
 
 export interface RNCameraProps {
@@ -222,6 +224,7 @@ export interface RNCameraProps {
   } | null;
 
   // -- IOS ONLY PROPS
+  videoStabilizationMode?: keyof VideoStabilization;
   defaultVideoQuality?: keyof VideoQuality;
   /* if true, audio session will not be released on component unmount */
   keepAudioSession?: boolean;


### PR DESCRIPTION
### Motivation

Working on an enterprise project using RNCamera while setting **videoStabilizationMode** prop specifically for iOS, it doesn't seem to have any effect on the shakiness from the video, even though the implementation for setting the stabilization mode is correct  [connection setPreferredVideoStabilizationMode:self.videoStabilizationMode]; .

**self.videoStabilizationMode is always 0**

### Solution

Expose the videoStabilizationMode property from native code to JS.

### Steps to reproduce

Start recording video with the **recordAsync** method and the response from that video should respect the option that you assigned by the prop

- `RNCamera.Constants.VideoStabilization['off']`
- `RNCamera.Constants.VideoStabilization['standard']`
- `RNCamera.Constants.VideoStabilization['cinematic']`
- `RNCamera.Constants.VideoStabilization['auto']`


### Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

### Checklist

- [ x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
