### PR TITLE
add pictureSize type to RNCameraProps

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -136,6 +136,8 @@ export interface RNCameraProps {
 
   autoFocus?: keyof AutoFocus;
   autoFocusPointOfInterest?: Point;
+  pictureSize?: string;
+  
   /* iOS only */
   onSubjectAreaChanged?: (event: { nativeEvent: { prevPoint: { x: number; y: number; } } }) => void;
   type?: keyof CameraType;


### PR DESCRIPTION
# Summary

- add optional `pictureSize` prop to `RNCameraProps`
- `pictureSize` is a [recognized prop on RNCamera](https://github.com/react-native-community/react-native-camera/blob/fe5d11d12fe2a7eb7d0582776f260415f1b2865b/src/RNCamera.js#L277)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
