### PR TITLE
stop/release camera in non-UI thread

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -138,7 +138,28 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
 
             @Override
             public void onSurfaceDestroyed() {
-                stop();
+
+                // need to this early so we don't get buffer errors due to sufrace going away.
+                // Then call stop in bg thread since it might be quite slow and will freeze
+                // the UI or cause an ANR while it is happening.
+                synchronized(Camera1.this){
+                    if(mCamera != null){
+                        try{
+                            mCamera.setPreviewCallback(null);
+                            // note: this might give a debug message that can be ignored.
+                            mCamera.setPreviewDisplay(null);
+                        }
+                        catch(Exception e){
+                            Log.e("CAMERA_1::", "onSurfaceDestroyed preview cleanup failed", e);
+                        }
+                    }
+                }
+                mBgHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        stop();
+                    }
+                });
             }
         });
     }
@@ -235,8 +256,13 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
 
             if (mCamera != null) {
                 mIsPreviewActive = false;
-                mCamera.stopPreview();
-                mCamera.setPreviewCallback(null);
+                try{
+                    mCamera.stopPreview();
+                    mCamera.setPreviewCallback(null);
+                }
+                catch(Exception e){
+                    Log.e("CAMERA_1::", "stop preview cleanup failed", e);
+                }
             }
 
             releaseCamera();

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -124,6 +124,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     private boolean mIsScanning;
 
     private boolean mustUpdateSurface;
+    private boolean surfaceWasDestroyed;
 
     private SurfaceTexture mPreviewTexture;
 
@@ -133,7 +134,25 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         preview.setCallback(new PreviewImpl.Callback() {
             @Override
             public void onSurfaceChanged() {
-                updateSurface();
+
+                // if we got our surface destroyed
+                // we must re-start the camera and surface
+                // otherwise, just update our surface
+
+
+                synchronized(Camera1.this){
+                    if(!surfaceWasDestroyed){
+                        updateSurface();
+                    }
+                    else{
+                        mBgHandler.post(new Runnable() {
+                            @Override
+                            public void run() {
+                                start();
+                            }
+                        });
+                    }
+                }
             }
 
             @Override
@@ -144,6 +163,11 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 // the UI or cause an ANR while it is happening.
                 synchronized(Camera1.this){
                     if(mCamera != null){
+
+                        // let the instance know our surface was destroyed
+                        // and we might need to re-create it and restart the camera
+                        surfaceWasDestroyed = true;
+
                         try{
                             mCamera.setPreviewCallback(null);
                             // note: this might give a debug message that can be ignored.
@@ -273,6 +297,8 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     @SuppressLint("NewApi")
     void setUpPreview() {
         try {
+            surfaceWasDestroyed = false;
+
             if(mCamera != null){
                 if (mPreviewTexture != null) {
                     mCamera.setPreviewTexture(mPreviewTexture);

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -522,10 +522,17 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
       mGoogleBarcodeDetector.release();
     }
     mMultiFormatReader = null;
-    stop();
     mThemedReactContext.removeLifecycleEventListener(this);
 
-    this.cleanup();
+    // camera release can be quite expensive. Run in on bg handler
+    // and cleanup last once everything has finished
+    mBgHandler.post(new Runnable() {
+        @Override
+        public void run() {
+          stop();
+          cleanup();
+        }
+      });
   }
 
   private boolean hasCameraPermissions() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

**Note: Changes still under testing. Do not merge yet until I fully confirm this causes no further issues in production. Will report back with findings in a week or so after I get enough testing. **

Update stop and surface destroyed code on Android (and Camera1) so the camera is released in a background thread (similar to the start updates).  This is due to release and stop preview being quite slow on some devices and reporting ANRs from time to time.

An example ANR that was recently reported:
```
ANR  Input dispatching timed out (Waiting to send non-key event because the touched window has not finished processing certain input events that were delivered to it over 500.0ms ago.  Wait queue length: 46.  Wait queue head age: 5506.2ms.) 
    Camera.java:-2 android.hardware.Camera.native_release
    Camera.java:673 android.hardware.Camera.release
    Camera1.java:1009 com.google.android.cameraview.Camera1.releaseCamera
    Camera1.java:242 com.google.android.cameraview.Camera1.stop
    Camera1.java:141 com.google.android.cameraview.Camera1$1.onSurfaceDestroyed
    PreviewImpl.java:60 com.google.android.cameraview.PreviewImpl.dispatchSurfaceDestroyed
    TextureViewPreview.java:59 com.google.android.cameraview.TextureViewPreview$1.onSurfaceTextureDestroyed
    TextureView.java:249 android.view.TextureView.releaseSurfaceTexture
    TextureView.java:222 android.view.TextureView.onDetachedFromWindowInternal
    View.java:18447 android.view.View.dispatchDetachedFromWindow
    ViewGroup.java:3771 android.view.ViewGroup.dispatchDetachedFromWindow
    ViewGroup.java:3771 android.view.ViewGroup.dispatchDetachedFromWindow
    ViewGroup.java:3771 android.view.ViewGroup.dispatchDetachedFromWindow
    ViewGroup.java:3771 android.view.ViewGroup.dispatchDetachedFromWindow
    ViewGroup.java:3771 android.view.ViewGroup.dispatchDetachedFromWindow
    ViewGroup.java:3771 android.view.ViewGroup.dispatchDetachedFromWindow
    ViewGroup.java:3771 android.view.ViewGroup.dispatchDetachedFromWindow
    ViewGroup.java:5362 android.view.ViewGroup.removeViewInternal
    ViewGroup.java:5309 android.view.ViewGroup.removeViewAt
    ReactViewGroup.java:469 com.facebook.react.views.view.ReactViewGroup.removeViewAt
    ReactViewManager.java:389 com.facebook.react.views.view.ReactViewManager.removeViewAt
    ReactViewManager.java:37 com.facebook.react.views.view.ReactViewManager.removeViewAt
    NativeViewHierarchyManager.java:457 com.facebook.react.uimanager.NativeViewHierarchyManager.manageChildren
    UIViewOperationQueue.java:205 com.facebook.react.uimanager.UIViewOperationQueue$ManageChildrenOperation.execute
    UIViewOperationQueue.java:779 com.facebook.react.uimanager.UIViewOperationQueue$1.run
    UIViewOperationQueue.java:888 com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches
    UIViewOperationQueue.java:42 com.facebook.react.uimanager.UIViewOperationQueue.access$2200
    UIViewOperationQueue.java:948 com.facebook.react.uimanager.UIViewOperationQueue$DispatchUIFrameCallback.doFrameGuarded
    GuardedFrameCallback.java:28 com.facebook.react.uimanager.GuardedFrameCallback.doFrame
    ReactChoreographer.java:174 com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame
    ChoreographerCompat.java:84 com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame
    Choreographer.java:947 android.view.Choreographer$CallbackRecord.run
    Choreographer.java:761 android.view.Choreographer.doCallbacks
    Choreographer.java:693 android.view.Choreographer.doFrame
    Choreographer.java:935 android.view.Choreographer$FrameDisplayEventReceiver.run
    Handler.java:873 android.os.Handler.handleCallback
    Handler.java:99 android.os.Handler.dispatchMessage
    Looper.java:215 android.os.Looper.loop
    ActivityThread.java:6952 android.app.ActivityThread.main
    Method.java:-2 java.lang.reflect.Method.invoke
    RuntimeInit.java:493 com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run
    ZygoteInit.java:870 com.android.internal.os.ZygoteInit.main
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Initially tested on a Google Pixel 2 (Android 10) and motorola G5 (Android 8.1). Will be testing in production with multiple devices to confirm this change does not cause other issues and does indeed resolve the reported ANR.

### What's required for testing (prerequisites)?
Real device with camera

### What are the steps to reproduce (after prerequisites)?
Mount and dismount a <RNCamera> component. Observe how the application becomes non responsive on unmount for a brief period. After the update, unmounting should no longer block the UI and JS threads.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
