### PR TITLE
Expose an ability to change the frames per second.

### DIFF
--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -223,6 +223,7 @@ type RecordingOptions = {
   maxFileSize?: number,
   orientation?: Orientation,
   quality?: number | string,
+  fps?: number,
   codec?: string,
   mute?: boolean,
   path?: string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -412,6 +412,7 @@ interface RecordOptions {
 
   /** iOS only */
   codec?: keyof VideoCodec | VideoCodec[keyof VideoCodec];
+  fps?: number;
 }
 
 export interface RecordResponse {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

This PR implements a change to frames per second for iOS. There is a new `fps` option in recording that lets the dev do this. It tries to stay true to the current selected quality, so it will forgo changing the fps if the quality does not allow for it.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

It's been working in production for my app, however I have not had a chance to write tests for this and produces videos that have higher FPS. Example ffmpeg output:

```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'Documents/2-21-2020_11-25-34-AM.mov':
  Metadata:
    major_brand     : qt
    minor_version   : 0
    compatible_brands: qt
    creation_time   : 2020-02-21T16:25:35.000000Z
  Duration: 00:00:08.98, start: 0.000000, bitrate: 8822 kb/s
    Stream #0:0(und): Video: hevc (Main) (hvc1 / 0x31637668), yuvj420p(pc, smpte170m/bt709/bt709), 1280x720, 8727 kb/s, 60.01 fps, 60 tbr, 600 tbn, 600 tbc (default)
    Metadata:
      creation_time   : 2020-02-21T16:25:35.000000Z
      handler_name    : Core Media Video
      encoder         : HEVC
    Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, mono, fltp, 82 kb/s (default)
    Metadata:
      creation_time   : 2020-02-21T16:25:35.000000Z
      handler_name    : Core Media Audio

```

### What's required for testing (prerequisites)?


### What are the steps to reproduce (after prerequisites)?

Add in `fps = 60` to the recordOptions passed to `recordAsync` on a compatible device+camera. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
