### PR TITLE
Fix Duplicate module rn

### DIFF
--- a/examples/basic/metro.config.js
+++ b/examples/basic/metro.config.js
@@ -1,0 +1,30 @@
+/**
+ * This file overrides metro config so
+ */
+'use strict';
+
+const path = require('path');
+const blacklist = require('metro-config/src/defaults/blacklist');
+
+const reactNativeCameraRoot = path.resolve(__dirname, '..', '..');
+
+module.exports = {
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: false,
+      },
+    }),
+  },
+  watchFolders: [path.resolve(__dirname, 'node_modules'), reactNativeCameraRoot],
+  resolver: {
+    blacklistRE: blacklist([
+      new RegExp(`${reactNativeCameraRoot}/examples/mlkit/.*`),
+      new RegExp(`${reactNativeCameraRoot}/node_modules/react-native/.*`),
+      new RegExp(
+        `${reactNativeCameraRoot}/examples/advanced/advanced/node_modules/react-native/.*`,
+      ),
+    ]),
+  },
+};

--- a/examples/mlkit/metro.config.js
+++ b/examples/mlkit/metro.config.js
@@ -1,0 +1,30 @@
+/**
+ * This file overrides metro config so
+ */
+'use strict';
+
+const path = require('path');
+const blacklist = require('metro-config/src/defaults/blacklist');
+
+const reactNativeCameraRoot = path.resolve(__dirname, '..', '..');
+
+module.exports = {
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: false,
+      },
+    }),
+  },
+  watchFolders: [path.resolve(__dirname, 'node_modules'), reactNativeCameraRoot],
+  resolver: {
+    blacklistRE: blacklist([
+      new RegExp(`${reactNativeCameraRoot}/examples/basic/.*`),
+      new RegExp(`${reactNativeCameraRoot}/node_modules/react-native/.*`),
+      new RegExp(
+        `${reactNativeCameraRoot}/examples/advanced/advanced/node_modules/react-native/.*`,
+      ),
+    ]),
+  },
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fixes [1767][1] and [2733][10].

Related issues [2547][6], [2733][4], [1791][2], [1747][3], [2528][5].

The basic and mlkit example does not build correctly for android. I experienced [1767][1], [2547][6].

I quote the `cli` [configuration][7] documentation: 
 
>Note: Configuring CLI used to be possible via rn-cli.config.js (that has been renamed to metro.config.js) and never documented rnpm entry on the package.json. We have provided migration guides where possible.

the additional change was adding a new [Regex rule][8] to the [Blacklist][9]. This change fixed the error `Duplicate module name: react-native`, as it excludes the folder `react-native-camera/examples/advanced/advanced/node_modules/react-native/*` from the build.

[1]: https://github.com/react-native-community/react-native-camera/issues/1767
[2]: https://github.com/react-native-community/react-native-camera/issues/1791
[3]: https://github.com/react-native-community/react-native-camera/issues/1747
[4]: https://github.com/react-native-community/react-native-camera/issues/2733
[5]: https://github.com/react-native-community/react-native-camera/issues/2528#issuecomment-546997174
[6]: https://github.com/react-native-community/react-native-camera/issues/2547
[7]: https://github.com/react-native-community/cli/blob/master/docs/configuration.md#configuration
[8]: https://github.com/react-native-community/react-native-camera/compare/master...fabriziobertoglio1987:fix/basic-example-rn-cli-config?expand=1#diff-3196553af8550ada6c3fcb79532f87c3R25-R27
[9]: https://github.com/react-native-community/react-native-camera/compare/master...fabriziobertoglio1987:fix/basic-example-rn-cli-config?expand=1#diff-3196553af8550ada6c3fcb79532f87c3R22-R28
[10]: https://github.com/react-native-community/react-native-camera/issues/2733
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
More information included in issue [2733][10]. Prerequisites is using `metro` and latest dependencies to build, as you can read at [rn-docs][11]

>If you previously installed a global `react-native-cli` package, please remove it as it may cause unexpected issues.

and explained in [react-native-community/cli][12], the package `react-native-cli` is based on the `react-native-community/cli` repository.

>There are currently two CLIs:

>    `@react-native-community/cli` – the one used directly by react-native. That makes it a transitive dependency of your project.
>    `react-native-cli` – an optional global convenience package, which is a proxy to `@react-native-community/cli` and global installation helper. Please consider it legacy, because it's not necessary anymore.

to reproduce this issue you should have the same tooling as specified in react native 0.61 [installation instructions][12].

[11]: https://reactnative.dev/docs/getting-started
[12]: https://github.com/react-native-community/cli#about
### What are the steps to reproduce (after prerequisites)?
the next steps will be 

```
cd examples/basic/android
chmod +x ./gradlew && ./gradlew clean && ./gradlew build
```
or 
```
cd examples/basic
yarn start 
```
and `yarn react-native run-android`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
