### PR TITLE
call onStatusChange after refreshAuthorizationStatus

### DIFF
--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -741,11 +741,14 @@ export default class Camera extends React.Component<PropsType, StateType> {
       return;
     }
 
-    this.setState({
-      isAuthorized: hasCameraPermissions,
-      isAuthorizationChecked: true,
-      recordAudioPermissionStatus,
-    });
+    this.setState(
+      {
+        isAuthorized: hasCameraPermissions,
+        isAuthorizationChecked: true,
+        recordAudioPermissionStatus,
+      },
+      this._onStatusChange,
+    );
   }
 
   async componentDidMount() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Those changes make sure that `onStatusChanged` is called after `refreshAuthorizationStatus`. The component is listening on `onStatusChanged` in order to show or hide authorization infos. After navigating back from the settings screen (changing permissions), `refreshAuthorizationStatus` gets called, but any changes to that stay unnoticed.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
