### PR TITLE
Accept path while taking picture in android

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -247,9 +247,11 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
     mBgHandler.post(new Runnable() {
       @Override
       public void run() {
+        final File path = options.hasKey("path") ?  new File(options.getString("path"))  : cacheDirectory;
+        
         mPictureTakenPromises.add(promise);
         mPictureTakenOptions.put(promise, options);
-        mPictureTakenDirectories.put(promise, cacheDirectory);
+        mPictureTakenDirectories.put(promise, path);
 
         try {
           RNCameraView.super.takePicture(options);

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -180,7 +180,14 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
                 if (!mOptions.hasKey("doNotSave") || !mOptions.getBoolean("doNotSave")) {
 
                     // Prepare file output
-                    File imageFile = new File(RNFileUtils.getOutputFilePath(mCacheDirectory, ".jpg"));
+                    File imageFile;
+                    if(mCacheDirectory.isDirectory()){
+
+                        imageFile = new File(RNFileUtils.getOutputFilePath(mCacheDirectory, ".jpg"));
+                    }
+                    else{
+                        imageFile=mCacheDirectory;
+                    }
                     imageFile.createNewFile();
                     FileOutputStream fOut = new FileOutputStream(imageFile);
 

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -51,7 +51,7 @@ class ExampleApp extends PureComponent {
     );
   }
 
-  takePicture = async() => {
+  takePicture = async () => {
     if (this.camera) {
       const options = { quality: 0.5, base64: true };
       const data = await this.camera.takePictureAsync(options);
@@ -217,8 +217,8 @@ On iOS, focusing will not change the exposure automatically unless autoExposure 
 Hint:
 for portrait orientation, apply 90° clockwise rotation + translation: [Example](https://gist.github.com/Craigtut/6632a9ac7cfff55e74fb561862bc4edb)
 
-
 ### iOS `onSubjectAreaChanged`
+
 iOS only.
 
 if autoFocusPointOfInterest is set, this event will be fired when a substancial change is detected with the following object: `{ nativeEvent: { prevPoint: { x: number; y: number; } } }`
@@ -287,6 +287,7 @@ The idea is that you select the appropriate white balance setting for the type o
 Use the `whiteBalance` property to specify which white balance setting the camera should use.
 
 ### `exposure`
+
 Value: float from `0` to `1.0`, or `-1` (default) for auto.
 
 Sets the camera's exposure value.
@@ -340,8 +341,8 @@ Note: Must also provide cameraViewDimensions prop for Android device
 An `{width:, height: }` object which defines the width and height of the cameraView. This prop is used to adjust the effect of Aspect Raio for rectOfInterest area on Android
 
 ### `Android` `playSoundOnCapture`
-Boolean to turn on or off the camera's shutter sound (default false). Note that in some countries, the shutter sound cannot be turned off.
 
+Boolean to turn on or off the camera's shutter sound (default false). Note that in some countries, the shutter sound cannot be turned off.
 
 ### `iOS` `videoStabilizationMode`
 
@@ -407,7 +408,6 @@ iOS only. Function to be called when the camera audio session is interrupted or 
 
 iOS only. Function to be called when the camera audio session is connected. This will be fired the first time the camera is mounted with `captureAudio={true}`, and any time the audio device connection is established. Note that this event might not always fire after an interruption due to iOS' behavior. For example, if the audio was already interrupted before the camera was mounted, this event will only fire once a recording is attempted.
 
-
 ### `onPictureTaken`
 
 Function to be called when native code emit onPictureTaken event, when camera has taken a picture, but before all extra processing happens. This can be useful to allow the UI to take other pictures while the processing of the current picture is still taking place.
@@ -424,7 +424,6 @@ Event will contain the following fields:
 ### `onRecordingEnd`
 
 Function to be called when native code stops recording video, but before all video processing takes place. This event will only fire after a successful video recording, and it will not fire if video recording fails (use the error returned from `recordAsync` instead).
-
 
 ### Bar Code Related props
 
@@ -501,6 +500,7 @@ Like `onBarCodeRead`, but using Firebase MLKit to scan barcodes. More info can b
 Like `barCodeTypes`, but applies to the Firebase MLKit barcode detector.
 Example: `<RNCamera googleVisionBarcodeType={RNCamera.Constants.GoogleVisionBarcodeDetection.BarcodeType.DATA_MATRIX} />`
 Available settings:
+
 - CODE_128
 - CODE_39
 - CODE_93
@@ -578,12 +578,13 @@ Supported options:
 - `mirrorImage` (boolean true or false). Use this with `true` if you want the resulting rendered picture to be mirrored (inverted in the vertical axis). If no value is specified `mirrorImage:false` is used.
 
 - `writeExif`: (boolean or object, defaults to true). Setting this to a boolean indicates if the image exif should be preserved after capture, or removed. Setting it to an object, merges any data with the final exif output. This is useful, for example, to add GPS metadata (note that GPS info is correctly transalted from double values to the EXIF format, so there's no need to read the EXIF protocol).
+
 ```js
 writeExif = {
-  "GPSLatitude": latitude,
-  "GPSLongitude": longitude,
-  "GPSAltitude": altitude
-}
+  GPSLatitude: latitude,
+  GPSLongitude: longitude,
+  GPSAltitude: altitude,
+};
 ```
 
 - `exif` (boolean true or false) Use this with `true` if you want a exif data map of the picture taken on the return data of your promise. If no value is specified `exif:false` is used.
@@ -597,6 +598,8 @@ writeExif = {
 - `pauseAfterCapture` (boolean true or false). If true, pause the preview layer immediately after capturing the image. You will need to call `cameraRef.resumePreview()` before using the camera again. If no value is specified `pauseAfterCapture:false` is used.
 
 - `orientation` (string or number). Specifies the orientation that us used for taking the picture. Possible values: `"portrait"`, `"portraitUpsideDown"`, `"landscapeLeft"` or `"landscapeRight"`.
+
+- `path` (file path on disk). Specifies the path on disk to save picture to.
 
 The promise will be fulfilled with an object with some of the following properties:
 
@@ -730,6 +733,7 @@ Read more about [react-native-barcode-mask](https://github.com/shahnawaz/react-n
 ### @nartc/react-native-barcode-mask
 
 A rewritten version of `react-native-barcode-mask` using `Hooks` and `Reanimated`. If you're already using `react-native-reanimated` (`react-navigation` dependency) then you might benefit from this rewritten component.
+
 - Customizable
 - Provide custom hook to "scan barcode within finder area"
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
With this PR, user are able to add a path options while taking picture same as recording picture. It will save image in given path i.e if it is file path then picture will be save with give in that location else if it is directory then name will be randomly generated.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
User will be able to save image in specified location by providing just an option **i.e path**.
* How did you implement the solution? 
If path not provided then it will act default like before i.e saving image in cache. If path is provided it'll save on that specified location.
* What areas of the library does it impact?
--> It impact the photo taking process.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
