### PR TITLE
Fix image path on Android, and add iOS implementation.

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -247,11 +247,9 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
     mBgHandler.post(new Runnable() {
       @Override
       public void run() {
-        final File path = options.hasKey("path") ?  new File(options.getString("path"))  : cacheDirectory;
-        
         mPictureTakenPromises.add(promise);
         mPictureTakenOptions.put(promise, options);
-        mPictureTakenDirectories.put(promise, path);
+        mPictureTakenDirectories.put(promise, cacheDirectory);
 
         try {
           RNCameraView.super.takePicture(options);

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -180,15 +180,10 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
                 if (!mOptions.hasKey("doNotSave") || !mOptions.getBoolean("doNotSave")) {
 
                     // Prepare file output
-                    File imageFile;
-                    if(mCacheDirectory.isDirectory()){
+                    File imageFile = new File(getImagePath());
 
-                        imageFile = new File(RNFileUtils.getOutputFilePath(mCacheDirectory, ".jpg"));
-                    }
-                    else{
-                        imageFile=mCacheDirectory;
-                    }
                     imageFile.createNewFile();
+
                     FileOutputStream fOut = new FileOutputStream(imageFile);
 
                     // Save byte array (it is already a JPEG)
@@ -318,13 +313,20 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
         return rotationDegrees;
     }
 
+    private String getImagePath() throws IOException{
+        if(mOptions.hasKey("path")){
+            return mOptions.getString("path");
+        }
+        return RNFileUtils.getOutputFilePath(mCacheDirectory, ".jpg");
+    }
+
     private String writeStreamToFile(ByteArrayOutputStream inputStream) throws IOException {
         String outputPath = null;
         IOException exception = null;
         FileOutputStream outputStream = null;
 
         try {
-            outputPath = RNFileUtils.getOutputFilePath(mCacheDirectory, ".jpg");
+            outputPath = getImagePath();
             outputStream = new FileOutputStream(outputPath);
             inputStream.writeTo(outputStream);
         } catch (IOException e) {

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -915,7 +915,13 @@ BOOL _sessionInterrupted = NO;
 
                     NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
 
-                    NSString *path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+                    NSString *path = nil;
+                    if (options[@"path"]) {
+                        path = options[@"path"];
+                    }
+                    else{
+                        path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+                    }
 
                     if (![options[@"doNotSave"] boolValue]) {
                         response[@"uri"] = [RNImageUtils writeImage:destData toPath:path];
@@ -1129,7 +1135,7 @@ BOOL _sessionInterrupted = NO;
                     device.activeVideoMinFrameDuration = CMTimeMake(1, (int32_t)desiredFPS);
                     device.activeVideoMaxFrameDuration = CMTimeMake(1, (int32_t)desiredFPS);
                     [device unlockForConfiguration];
-                } 
+                }
             } else {
                 RCTLog(@"We could not find a suitable format for this device.");
             }

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -336,9 +336,19 @@ RCT_REMAP_METHOD(takePicture,
             RCTLogError(@"Invalid view returned from registry, expecting RNCamera, got: %@", view);
         } else {
 #if TARGET_IPHONE_SIMULATOR
+
             NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
+
             float quality = [options[@"quality"] floatValue];
-            NSString *path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+
+            NSString *path = nil;
+
+            if (options[@"path"]) {
+                path = options[@"path"];
+            }
+            else{
+                path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+            }
             UIImage *generatedPhoto = [RNImageUtils generatePhotoOfSize:CGSizeMake(200, 200)];
             BOOL useFastMode = options[@"fastMode"] && [options[@"fastMode"] boolValue];
             if (useFastMode) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Bug fixes to https://github.com/react-native-community/react-native-camera/pull/2769 and hopefully a bugfix to https://github.com/react-native-community/react-native-camera/issues/2778 (couldn't reproduce locally).
The implementation removed the need to check for `isDirectory` in case it fails for other reasons, and uses the path provided if given, or the default implementation if not (just like video recording).

Additionally, implement `path` for iOS as well.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Tested on Motorola G5 (8.1), Google Pixel 2 (10) and iPhone 7 (13.4).  Tested passing a `path` parameter to `takePictureAsync` and an undefined value (current behaviour that stores on the Cache folder). 

### What's required for testing (prerequisites)?
Real device

### What are the steps to reproduce (after prerequisites)?
-

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
