### PR TITLE
Feature/add native zoom

### DIFF
--- a/android/src/main/java/org/reactnative/camera/CameraViewManager.java
+++ b/android/src/main/java/org/reactnative/camera/CameraViewManager.java
@@ -119,6 +119,10 @@ public class CameraViewManager extends ViewGroupManager<RNCameraView> {
     view.setZoom(zoom);
   }
 
+  @ReactProp(name = "useNativeZoom")
+  public void setUseNativeZoom(RNCameraView view, boolean useNativeZoom) {
+    view.setUseNativeZoom(useNativeZoom);
+  }
   @ReactProp(name = "whiteBalance")
   public void setWhiteBalance(RNCameraView view, int whiteBalance) {
     view.setWhiteBalance(whiteBalance);

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -292,6 +292,12 @@ Value: float from `0` to `1.0`, or `-1` (default) for auto.
 
 Sets the camera's exposure value.
 
+### `useNativeZoom`
+
+Boolean to turn on native pinch to zoom. Works with the `maxZoom` property on iOS.
+
+Warning: The Android Touch-Event-System causes childviews to catch the touch events. Therefore avoid using screenfilling touchables inside of the cameraview.
+
 ### `zoom`
 
 Value: float from `0` to `1.0`

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -47,6 +47,8 @@
 @property(nonatomic, assign) BOOL canDetectBarcodes;
 @property(nonatomic, assign) BOOL captureAudio;
 @property(nonatomic, assign) BOOL keepAudioSession;
+@property(nonatomic, assign) BOOL useNativeZoom;
+
 @property(nonatomic, assign) CGRect rectOfInterest;
 @property(assign, nonatomic) AVVideoCodecType videoCodecType;
 @property(assign, nonatomic)
@@ -90,6 +92,7 @@
 - (void)stopRecording;
 - (void)resumePreview;
 - (void)pausePreview;
+- (void)setupOrDisablePinchZoom;
 - (void)setupOrDisableBarcodeScanner;
 - (void)setupOrDisableTextDetector;
 - (void)setupOrDisableFaceDetector;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -95,6 +95,15 @@ BOOL _sessionInterrupted = NO;
     }
     return self;
 }
+-(float) getMaxZoomFactor:(AVCaptureDevice*)device {
+    float maxZoom;
+    if(self.maxZoom > 1){
+        maxZoom = MIN(self.maxZoom, device.activeFormat.videoMaxZoomFactor);
+    }else{
+        maxZoom = device.activeFormat.videoMaxZoomFactor;
+    }
+    return maxZoom;
+}
 
 -(void) handlePinchToZoomRecognizer:(UIPinchGestureRecognizer*)pinchRecognizer {
     const CGFloat pinchVelocityDividerFactor = 5.0f;
@@ -603,13 +612,7 @@ BOOL _sessionInterrupted = NO;
         return;
     }
 
-    float maxZoom;
-    if(self.maxZoom > 1){
-        maxZoom = MIN(self.maxZoom, device.activeFormat.videoMaxZoomFactor);
-    }
-    else{
-        maxZoom = device.activeFormat.videoMaxZoomFactor;
-    }
+    float maxZoom = [self getMaxZoomFactor:device];
 
     device.videoZoomFactor = (maxZoom - 1) * self.zoom + 1;
 

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -114,10 +114,11 @@ BOOL _sessionInterrupted = NO;
             return;
         }
         NSError *error = nil;
+        float maxZoom = [self getMaxZoomFactor:device]
         if ([device lockForConfiguration:&error]) {
             CGFloat desiredZoomFactor = device.videoZoomFactor + atan2f(pinchRecognizer.velocity, pinchVelocityDividerFactor);
             // Check if desiredZoomFactor fits required range from 1.0 to activeFormat.videoMaxZoomFactor
-            device.videoZoomFactor = MAX(1.0, MIN(desiredZoomFactor, device.activeFormat.videoMaxZoomFactor));
+            device.videoZoomFactor = MAX(1.0, MIN(desiredZoomFactor, maxZoom));
             [device unlockForConfiguration];
         } else {
             NSLog(@"error: %@", error);

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -215,6 +215,12 @@ RCT_CUSTOM_VIEW_PROPERTY(focusDepth, NSNumber, RNCamera)
     [view updateFocusDepth];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(useNativeZoom, BOOL, RNCamera)
+{
+    view.useNativeZoom=[RCTConvert BOOL:json];
+    [view setupOrDisablePinchZoom];
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(zoom, NSNumber, RNCamera)
 {
     [view setZoom:[RCTConvert CGFloat:json]];

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -247,6 +247,7 @@ type Rect = {
 
 type PropsType = typeof View.props & {
   zoom?: number,
+  useNativeZoom?:boolean,
   maxZoom?: number,
   ratio?: string,
   focusDepth?: number,
@@ -389,6 +390,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
   static propTypes = {
     ...ViewPropTypes,
     zoom: PropTypes.number,
+    useNativeZoom:PropTypes.bool,
     maxZoom: PropTypes.number,
     ratio: PropTypes.string,
     focusDepth: PropTypes.number,
@@ -439,6 +441,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
 
   static defaultProps: Object = {
     zoom: 0,
+    useNativeZoom:false,
     maxZoom: 0,
     ratio: '4:3',
     focusDepth: 0,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -170,7 +170,8 @@ export interface RNCameraProps {
   /** iOS only */
   onAudioInterrupted?(): void;
   onAudioConnected?(): void;
-
+  /** Use native pinch to zoom implementation*/
+  useNativeZoom?:boolean;
   /** Value: float from 0 to 1.0 */
   zoom?: number;
   /** iOS only. float from 0 to any. Locks the max zoom value to the provided value


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Since none of the js pinch-to-zoom implementation
offer a satisfying solution, whether PanResponder or react-native-gesture-handler is used. I have implemented a native solution which can be activated with the property "useNativeZoom". 
But the Android touch event handling causes that child views catch the touch events and therefore the implementation does not work in combination with the touch-to-focus implementation from the advanced example.
If this PR is accepted, I would make another one, which extends the Camera-View with onTap and onDoubleTab events to provide a solution/workaround

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
For testing a real device is required
### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added ~~the~~ documentation ~~in `README.md`~~
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
