### PR TITLE
fix instance-method-conflict warning

### DIFF
--- a/ios/RCT/NSMutableDictionary+ImageMetadata.h
+++ b/ios/RCT/NSMutableDictionary+ImageMetadata.h
@@ -1,0 +1,13 @@
+//
+//  NSMutableDictionary+ImageMetadata.m
+//  RCTCamera
+//
+//  Created by Nick Hodapp on 5/1/20.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSMutableDictionary(ImageMetadata)
+- (void)mergeMetadata:(NSDictionary *)inputMetadata;
+@end

--- a/ios/RCT/NSMutableDictionary+ImageMetadata.m
+++ b/ios/RCT/NSMutableDictionary+ImageMetadata.m
@@ -9,9 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <ImageIO/ImageIO.h>
 
-@interface NSMutableDictionary(ImageMetadata)
-- (void)mergeMetadata:(NSDictionary *)inputMetadata;
-@end
+#import "NSMutableDictionary+ImageMetadata.h"
 
 @implementation NSMutableDictionary(ImageMetadata)
 

--- a/ios/RCT/RCTCameraManager.m
+++ b/ios/RCT/RCTCameraManager.m
@@ -5,7 +5,7 @@
 #import <React/RCTUtils.h>
 #import <React/RCTLog.h>
 #import <React/UIView+React.h>
-#import "NSMutableDictionary+ImageMetadata.m"
+#import "NSMutableDictionary+ImageMetadata.h"
 #import <AssetsLibrary/ALAssetsLibrary.h>
 #import <AVFoundation/AVFoundation.h>
 #import <ImageIO/ImageIO.h>

--- a/ios/RNCamera.xcodeproj/project.pbxproj
+++ b/ios/RNCamera.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		71C7FFD52013C824006EB75A /* RNFileSystem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNFileSystem.m; sourceTree = "<group>"; };
 		9FE592B11CA3CBF500788287 /* RCTSensorOrientationChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTSensorOrientationChecker.h; sourceTree = "<group>"; };
 		9FE592B21CA3CBF500788287 /* RCTSensorOrientationChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTSensorOrientationChecker.m; sourceTree = "<group>"; };
+		C5627D22245D10A100B761CF /* NSMutableDictionary+ImageMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableDictionary+ImageMetadata.h"; sourceTree = "<group>"; };
 		F8393BEA21469C0000AB1995 /* RNSensorOrientationChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNSensorOrientationChecker.h; sourceTree = "<group>"; };
 		F8393BEB21469C0000AB1995 /* RNSensorOrientationChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNSensorOrientationChecker.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -98,6 +99,7 @@
 				9FE592B21CA3CBF500788287 /* RCTSensorOrientationChecker.m */,
 				0314E39C1B661A460092D183 /* CameraFocusSquare.m */,
 				0314E39B1B661A0C0092D183 /* CameraFocusSquare.h */,
+				C5627D22245D10A100B761CF /* NSMutableDictionary+ImageMetadata.h */,
 				454EBCF31B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m */,
 				410701471ACB732B00C6AA39 /* RCTCamera.h */,
 				410701481ACB732B00C6AA39 /* RCTCamera.m */,


### PR DESCRIPTION
# Summary

When linking `react-native-camera` on iOS, the following warnings are emitted:

```
ld: warning: instance method 'getGPSDictionaryForLocation:' in category from /Users/nicholashodapp/Library/Developer/Xcode/DerivedData/Remitly-aouvfdqqojlkkyatnrqzidccuurd/Build/Products/Debug-iphoneos/react-native-camera/libreact-native-camera.a(RCTCameraManager.o) conflicts with same method from another category
ld: warning: instance method 'mergeMetadata:' in category from /Users/nicholashodapp/Library/Developer/Xcode/DerivedData/Remitly-aouvfdqqojlkkyatnrqzidccuurd/Build/Products/Debug-iphoneos/react-native-camera/libreact-native-camera.a(RCTCameraManager.o) conflicts with same method from another category

```

These are because the module that implements the category `NSDictionary+imageMetadata` is being compiled twice into the resulting binary.   

## Test Plan

I tested by running pod-install on a patched `react-native-camera` node-module.   The warning went away and everything still worked.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
