### PR TITLE
feat: Add ability to scan inverted-color barcodes on iOS using Google Vision

### DIFF
--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -541,7 +541,7 @@ Available settings:
 
 ### `googleVisionBarcodeMode`
 
-Change the mode in order to scan "inverted" barcodes. You can either change it to `alternate`, which will inverted the image data every second screen and be able to read both normal and inverted barcodes, or `inverted`, which will only read inverted barcodes. Default is `normal`, which only reads "normal" barcodes. Note: this property only applies to the Google Vision barcode detector.
+Change the mode in order to scan "inverted" barcodes. You can either change it to `alternate`, which will inverted the image data every second screen and be able to read both normal and inverted barcodes, or `inverted`, which will only read inverted barcodes. Default is `alternate`, which reads both "normal" and "inverted" barcodes. Note: this property only applies to the Google Vision barcode detector.
 Example: `<RNCamera googleVisionBarcodeMode={RNCamera.Constants.GoogleVisionBarcodeDetection.BarcodeMode.ALTERNATE} />`
 
 ### Face Detection Related props

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -541,7 +541,7 @@ Available settings:
 
 ### `googleVisionBarcodeMode`
 
-Change the mode in order to scan "inverted" barcodes. You can either change it to `alternate`, which will inverted the image data every second screen and be able to read both normal and inverted barcodes, or `inverted`, which will only read inverted barcodes. Default is `alternate`, which reads both "normal" and "inverted" barcodes. Note: this property only applies to the Google Vision barcode detector.
+Change the mode in order to scan "inverted" barcodes. You can either change it to `alternate`, which will inverted the image data every second screen and be able to read both normal and inverted barcodes, or `inverted`, which will only read inverted barcodes. Default is `normal`, which only reads "normal" barcodes. Note: this property only applies to the Google Vision barcode detector.
 Example: `<RNCamera googleVisionBarcodeMode={RNCamera.Constants.GoogleVisionBarcodeDetection.BarcodeMode.ALTERNATE} />`
 
 ### Face Detection Related props

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -20,7 +20,7 @@ class ExampleApp extends PureComponent {
     return (
       <View style={styles.container}>
         <RNCamera
-          ref={ref => {
+          ref={(ref) => {
             this.camera = ref;
           }}
           style={styles.preview}
@@ -144,7 +144,7 @@ class ExampleApp extends PureComponent {
     );
   }
 
-  takePicture = async function(camera) {
+  takePicture = async function (camera) {
     const options = { quality: 0.5, base64: true };
     const data = await camera.takePictureAsync(options);
     //  eslint-disable-next-line
@@ -436,6 +436,7 @@ Function to be called when native code stops recording video, but before all vid
 Function to be called when a touch within the camera view is recognized.
 The function is also called on the first touch of double tap.
 Event will contain the following fields:
+
 - `x`
 - `y`
 
@@ -443,6 +444,7 @@ Event will contain the following fields:
 
 Function to be called when a double touch within the camera view is recognized.
 Event will contain the following fields:
+
 - `x`
 - `y`
 
@@ -537,7 +539,7 @@ Available settings:
 - DATA_MATRIX
 - ALL
 
-### `Android` `googleVisionBarcodeMode`
+### `googleVisionBarcodeMode`
 
 Change the mode in order to scan "inverted" barcodes. You can either change it to `alternate`, which will inverted the image data every second screen and be able to read both normal and inverted barcodes, or `inverted`, which will only read inverted barcodes. Default is `normal`, which only reads "normal" barcodes. Note: this property only applies to the Google Vision barcode detector.
 Example: `<RNCamera googleVisionBarcodeMode={RNCamera.Constants.GoogleVisionBarcodeDetection.BarcodeMode.ALTERNATE} />`

--- a/examples/mlkit/App.js
+++ b/examples/mlkit/App.js
@@ -87,14 +87,14 @@ export default class CameraScreen extends React.Component {
     });
   }
 
-  takePicture = async function() {
+  takePicture = async function () {
     if (this.camera) {
       const data = await this.camera.takePictureAsync();
       console.warn('takePicture ', data);
     }
   };
 
-  takeVideo = async function() {
+  takeVideo = async function () {
     if (this.camera) {
       try {
         const promise = this.camera.recordAsync(this.state.recordOptions);
@@ -111,7 +111,7 @@ export default class CameraScreen extends React.Component {
     }
   };
 
-  toggle = value => () => this.setState(prevState => ({ [value]: !prevState[value] }));
+  toggle = (value) => () => this.setState((prevState) => ({ [value]: !prevState[value] }));
 
   facesDetected = ({ faces }) => this.setState({ faces });
 
@@ -139,7 +139,7 @@ export default class CameraScreen extends React.Component {
   );
 
   renderLandmarksOfFace(face) {
-    const renderLandmark = position =>
+    const renderLandmark = (position) =>
       position && (
         <View
           style={[
@@ -204,7 +204,7 @@ export default class CameraScreen extends React.Component {
     </React.Fragment>
   );
 
-  textRecognized = object => {
+  textRecognized = (object) => {
     const { textBlocks } = object;
     this.setState({ textBlocks });
   };
@@ -238,7 +238,7 @@ export default class CameraScreen extends React.Component {
     const { canDetectFaces, canDetectText, canDetectBarcode } = this.state;
     return (
       <RNCamera
-        ref={ref => {
+        ref={(ref) => {
           this.camera = ref;
         }}
         style={{
@@ -272,6 +272,7 @@ export default class CameraScreen extends React.Component {
         onTextRecognized={canDetectText ? this.textRecognized : null}
         onGoogleVisionBarcodesDetected={canDetectBarcode ? this.barcodeRecognized : null}
         googleVisionBarcodeType={RNCamera.Constants.GoogleVisionBarcodeDetection.BarcodeType.ALL}
+        googleVisionBarcodeMode={RNCamera.Constants.GoogleVisionBarcodeMode.ALTERNATE}
       >
         <View
           style={{

--- a/ios/RN/BarcodeDetectorManagerMlkit.h
+++ b/ios/RN/BarcodeDetectorManagerMlkit.h
@@ -11,6 +11,7 @@ typedef void(^postRecognitionBlock)(NSArray *barcodes);
 
 -(BOOL)isRealDetector;
 -(void)setType:(id)json queue:(dispatch_queue_t)sessionQueue;
+-(void)setMode:(id)json queue:(dispatch_queue_t)sessionQueue;
 -(void)findBarcodesInFrame:(UIImage *)image scaleX:(float)scaleX scaleY:(float)scaleY completed:(postRecognitionBlock)completed;
 +(NSDictionary *)constants;
 

--- a/ios/RN/BarcodeDetectorManagerMlkit.h
+++ b/ios/RN/BarcodeDetectorManagerMlkit.h
@@ -10,7 +10,7 @@ typedef void(^postRecognitionBlock)(NSArray *barcodes);
 - (instancetype)init;
 
 -(BOOL)isRealDetector;
--(NSInteger)detectionMode;
+-(NSInteger)fetchDetectionMode;
 -(void)setType:(id)json queue:(dispatch_queue_t)sessionQueue;
 -(void)setMode:(id)json queue:(dispatch_queue_t)sessionQueue;
 -(void)findBarcodesInFrame:(UIImage *)image scaleX:(float)scaleX scaleY:(float)scaleY completed:(postRecognitionBlock)completed;

--- a/ios/RN/BarcodeDetectorManagerMlkit.h
+++ b/ios/RN/BarcodeDetectorManagerMlkit.h
@@ -10,6 +10,7 @@ typedef void(^postRecognitionBlock)(NSArray *barcodes);
 - (instancetype)init;
 
 -(BOOL)isRealDetector;
+-(NSInteger)detectionMode;
 -(void)setType:(id)json queue:(dispatch_queue_t)sessionQueue;
 -(void)setMode:(id)json queue:(dispatch_queue_t)sessionQueue;
 -(void)findBarcodesInFrame:(UIImage *)image scaleX:(float)scaleX scaleY:(float)scaleY completed:(postRecognitionBlock)completed;

--- a/ios/RN/BarcodeDetectorManagerMlkit.m
+++ b/ios/RN/BarcodeDetectorManagerMlkit.m
@@ -6,6 +6,7 @@
 @property(nonatomic, strong) FIRVisionBarcodeDetector *barcodeRecognizer;
 @property(nonatomic, strong) FIRVision *vision;
 @property(nonatomic, assign) FIRVisionBarcodeFormat setOption;
+@property(nonatomic, assign) NSInteger setMode;
 @property(nonatomic, assign) float scaleX;
 @property(nonatomic, assign) float scaleY;
 @end
@@ -61,6 +62,12 @@
           });
       }
   }
+}
+
+-(void)setMode:(id)json queue:(dispatch_queue_t)sessionQueue
+{
+    NSInteger requestedValue = [RCTConvert NSInteger:json];
+    self.setMode = requestedValue;
 }
 
 - (void)findBarcodesInFrame:(UIImage *)uiImage

--- a/ios/RN/BarcodeDetectorManagerMlkit.m
+++ b/ios/RN/BarcodeDetectorManagerMlkit.m
@@ -6,7 +6,7 @@
 @property(nonatomic, strong) FIRVisionBarcodeDetector *barcodeRecognizer;
 @property(nonatomic, strong) FIRVision *vision;
 @property(nonatomic, assign) FIRVisionBarcodeFormat setOption;
-@property(nonatomic, assign) NSInteger setMode;
+@property(nonatomic, assign) NSInteger detectionMode;
 @property(nonatomic, assign) float scaleX;
 @property(nonatomic, assign) float scaleY;
 @end
@@ -27,9 +27,9 @@
   return true;
 }
 
--(NSInteger)detectionMode
+-(NSInteger)fetchDetectionMode
 {
-    return self.setMode;
+    return self.detectionMode;
 }
 
 + (NSDictionary *)constants
@@ -72,7 +72,7 @@
 -(void)setMode:(id)json queue:(dispatch_queue_t)sessionQueue
 {
     NSInteger requestedValue = [RCTConvert NSInteger:json];
-    self.setMode = requestedValue;
+    self.detectionMode = requestedValue;
 }
 
 - (void)findBarcodesInFrame:(UIImage *)uiImage

--- a/ios/RN/BarcodeDetectorManagerMlkit.m
+++ b/ios/RN/BarcodeDetectorManagerMlkit.m
@@ -27,6 +27,11 @@
   return true;
 }
 
+-(NSInteger)detectionMode
+{
+    return self.setMode;
+}
+
 + (NSDictionary *)constants
 {
     return @{

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -25,8 +25,8 @@
 @property(nonatomic, strong) id runtimeErrorHandlingObserver;
 @property(nonatomic, strong) NSArray *barCodeTypes;
 @property(nonatomic, strong) NSArray *googleVisionBarcodeTypes;
-@property(nonatomic, strong) NSInteger *googleVisionBarcodeMode;
 
+@property(nonatomic, assign) NSInteger *googleVisionBarcodeMode;
 @property(nonatomic, assign) NSInteger presetCamera;
 @property(nonatomic, copy) NSString *cameraId; // copy required for strings/pointers
 @property(assign, nonatomic) NSInteger flashMode;

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -25,7 +25,7 @@
 @property(nonatomic, strong) id runtimeErrorHandlingObserver;
 @property(nonatomic, strong) NSArray *barCodeTypes;
 @property(nonatomic, strong) NSArray *googleVisionBarcodeTypes;
-@property(nonatomic, strong) NSArray *googleVisionBarcodeMode;
+@property(nonatomic, strong) NSInteger *googleVisionBarcodeMode;
 
 @property(nonatomic, assign) NSInteger presetCamera;
 @property(nonatomic, copy) NSString *cameraId; // copy required for strings/pointers

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -25,6 +25,7 @@
 @property(nonatomic, strong) id runtimeErrorHandlingObserver;
 @property(nonatomic, strong) NSArray *barCodeTypes;
 @property(nonatomic, strong) NSArray *googleVisionBarcodeTypes;
+@property(nonatomic, strong) NSArray *googleVisionBarcodeMode;
 
 @property(nonatomic, assign) NSInteger presetCamera;
 @property(nonatomic, copy) NSString *cameraId; // copy required for strings/pointers
@@ -76,6 +77,7 @@
 - (void)updateRectOfInterest;
 // google Barcode props
 - (void)updateGoogleVisionBarcodeType:(id)requestedTypes;
+- (void)updateGoogleVisionBarcodeMode:(id)requestedMode;
 
 - (void)takePicture:(NSDictionary *)options
             resolve:(RCTPromiseResolveBlock)resolve

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -2298,7 +2298,7 @@ BOOL _sessionInterrupted = NO;
                     break;
             }
 
-            if (invertImageData) {
+            if (self.invertImageData) {
                 image = [RNImageUtils invertColors:image];
             }
             

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -2283,6 +2283,7 @@ BOOL _sessionInterrupted = NO;
             _finishedDetectingBarcodes = false;
             self.startBarcode = [NSDate date];
 
+            // Check for the barcode detection mode (Normal, Alternate, Inverted)
             switch ([self.barcodeDetector detectionMode]) {
                 case RNCameraGoogleVisionBarcodeModeNormal:
                     self.invertImageData = false;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -2285,16 +2285,16 @@ BOOL _sessionInterrupted = NO;
 
             switch ([self.barcodeDetector detectionMode]) {
                 case RNCameraGoogleVisionBarcodeModeNormal:
-                    invertImageData = false;
+                    self.invertImageData = false;
                     break;
                 case RNCameraGoogleVisionBarcodeModeAlternate:
-                    invertImageData = !invertImageData;
+                    self.invertImageData = !self.invertImageData;
                     break;
                 case RNCameraGoogleVisionBarcodeModeInverted:
-                    invertImageData = true;
+                    self.invertImageData = true;
                     break;
                 default:
-                    invertImageData = false;
+                    self.invertImageData = false;
                     break;
             }
 

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -2175,6 +2175,11 @@ BOOL _sessionInterrupted = NO;
     [self.barcodeDetector setType:requestedTypes queue:self.sessionQueue];
 }
 
+- (void)updateGoogleVisionBarcodeMode:(id)requestedMode
+{
+    [self.barcodeDetector setMode:requestedMode queue:self.sessionQueue];
+}
+
 - (void)onBarcodesDetected:(NSDictionary *)event
 {
     if (_onGoogleVisionBarcodesDetected && _session) {

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -43,6 +43,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onSubjectAreaChanged;
 @property (nonatomic, assign) BOOL isFocusedOnPoint;
 @property (nonatomic, assign) BOOL isExposedOnPoint;
+@property (nonatomic, assign) BOOL invertImageData;
 
 @end
 
@@ -89,6 +90,7 @@ BOOL _sessionInterrupted = NO;
         self.cameraId = nil;
         self.isFocusedOnPoint = NO;
         self.isExposedOnPoint = NO;
+        self.invertImageData = false;
         _recordRequested = NO;
         _sessionInterrupted = NO;
 
@@ -2281,7 +2283,6 @@ BOOL _sessionInterrupted = NO;
             _finishedDetectingBarcodes = false;
             self.startBarcode = [NSDate date];
 
-            BOOL invertImageData = false;
             switch ([self.barcodeDetector detectionMode]) {
                 case RNCameraGoogleVisionBarcodeModeNormal:
                     invertImageData = false;
@@ -2298,7 +2299,7 @@ BOOL _sessionInterrupted = NO;
             }
 
             if (invertImageData) {
-                image = [RNImageUtils inverseColors:image];
+                image = [RNImageUtils invertColors:image];
             }
             
             [self.barcodeDetector findBarcodesInFrame:image scaleX:scaleX scaleY:scaleY completed:^(NSArray * barcodes) {

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -2284,7 +2284,7 @@ BOOL _sessionInterrupted = NO;
             self.startBarcode = [NSDate date];
 
             // Check for the barcode detection mode (Normal, Alternate, Inverted)
-            switch ([self.barcodeDetector detectionMode]) {
+            switch ([self.barcodeDetector fetchDetectionMode]) {
                 case RNCameraGoogleVisionBarcodeModeNormal:
                     self.invertImageData = false;
                     break;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -2280,6 +2280,27 @@ BOOL _sessionInterrupted = NO;
         if (canSubmitForBarcodeDetection) {
             _finishedDetectingBarcodes = false;
             self.startBarcode = [NSDate date];
+
+            BOOL invertImageData = false;
+            switch ([self.barcodeDetector detectionMode]) {
+                case RNCameraGoogleVisionBarcodeModeNormal:
+                    invertImageData = false;
+                    break;
+                case RNCameraGoogleVisionBarcodeModeAlternate:
+                    invertImageData = !invertImageData;
+                    break;
+                case RNCameraGoogleVisionBarcodeModeInverted:
+                    invertImageData = true;
+                    break;
+                default:
+                    invertImageData = false;
+                    break;
+            }
+
+            if (invertImageData) {
+                image = [RNImageUtils inverseColors:image];
+            }
+            
             [self.barcodeDetector findBarcodesInFrame:image scaleX:scaleX scaleY:scaleY completed:^(NSArray * barcodes) {
                 NSDictionary *eventBarcode = @{@"type" : @"barcode", @"barcodes" : barcodes};
                 [self onBarcodesDetected:eventBarcode];

--- a/ios/RN/RNCameraManager.h
+++ b/ios/RN/RNCameraManager.h
@@ -55,6 +55,12 @@ typedef NS_ENUM(NSInteger, RNCameraVideoResolution) {
     RNCameraVideo288p = 4,
 };
 
+typedef NS_ENUM(NSInteger, RNCameraGoogleVisionBarcodeMode) {
+    RNCameraGoogleVisionBarcodeModeNormal = 0,
+    RNCameraGoogleVisionBarcodeModeAlternate = 1,
+    RNCameraGoogleVisionBarcodeModeInverted = 2,
+};
+
 @interface RNCameraManager : RCTViewManager <RCTBridgeModule>
 
 + (NSDictionary *)validBarCodeTypes;

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -81,7 +81,12 @@ RCT_EXPORT_VIEW_PROPERTY(onTouch, RCTDirectEventBlock);
              @"VideoStabilization": [[self class] validVideoStabilizationModes],
              @"GoogleVisionBarcodeDetection": @{
                  @"BarcodeType": [[self class] barcodeDetectorConstants],
-             }
+             },
+             @"googleVisionBarcodeMode" : @{
+                     @"NORMAL" : @(RNCameraGoogleVisionBarcodeModeNormal),
+                     @"ALTERNATE" : @(RNCameraGoogleVisionBarcodeModeAlternate),
+                     @"INVERTED" : @(RNCameraGoogleVisionBarcodeModeInverted),
+                     },
              };
 }
 
@@ -295,6 +300,11 @@ RCT_CUSTOM_VIEW_PROPERTY(barCodeTypes, NSArray, RNCamera)
 RCT_CUSTOM_VIEW_PROPERTY(googleVisionBarcodeType, NSString, RNCamera)
 {
     [view updateGoogleVisionBarcodeType:json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(googleVisionBarcodeMode, NSString, RNCamera)
+{
+    [view updateGoogleVisionBarcodeMode:json];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(googleVisionBarcodeDetectorEnabled, BOOL, RNCamera)

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -82,7 +82,7 @@ RCT_EXPORT_VIEW_PROPERTY(onTouch, RCTDirectEventBlock);
              @"GoogleVisionBarcodeDetection": @{
                  @"BarcodeType": [[self class] barcodeDetectorConstants],
              },
-             @"googleVisionBarcodeMode" : @{
+             @"GoogleVisionBarcodeMode" : @{
                      @"NORMAL" : @(RNCameraGoogleVisionBarcodeModeNormal),
                      @"ALTERNATE" : @(RNCameraGoogleVisionBarcodeModeAlternate),
                      @"INVERTED" : @(RNCameraGoogleVisionBarcodeModeInverted),

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -302,7 +302,7 @@ RCT_CUSTOM_VIEW_PROPERTY(googleVisionBarcodeType, NSString, RNCamera)
     [view updateGoogleVisionBarcodeType:json];
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(googleVisionBarcodeMode, NSString, RNCamera)
+RCT_CUSTOM_VIEW_PROPERTY(googleVisionBarcodeMode, NSInteger, RNCamera)
 {
     [view updateGoogleVisionBarcodeMode:json];
 }

--- a/ios/RN/RNImageUtils.h
+++ b/ios/RN/RNImageUtils.h
@@ -18,6 +18,7 @@
 + (NSString *)writeImage:(NSData *)image toPath:(NSString *)path;
 + (UIImage *) scaleImage:(UIImage*)image toWidth:(NSInteger)width;
 + (void)updatePhotoMetadata:(CMSampleBufferRef)imageSampleBuffer withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response;
++ (UIImage *)inverseColors:(UIImage *)image;
 
 @end
 

--- a/ios/RN/RNImageUtils.h
+++ b/ios/RN/RNImageUtils.h
@@ -18,7 +18,7 @@
 + (NSString *)writeImage:(NSData *)image toPath:(NSString *)path;
 + (UIImage *) scaleImage:(UIImage*)image toWidth:(NSInteger)width;
 + (void)updatePhotoMetadata:(CMSampleBufferRef)imageSampleBuffer withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response;
-+ (UIImage *)inverseColors:(UIImage *)image;
++ (UIImage *)invertColors:(UIImage *)image;
 
 @end
 

--- a/ios/RN/RNImageUtils.m
+++ b/ios/RN/RNImageUtils.m
@@ -115,5 +115,23 @@
     response[@"exif"] = metadata;
 }
 
++ (UIImage *)inverseColors:(UIImage *)image
+{
+    CIImage *inputCIImage = [[CIImage alloc] initWithImage:image];
+
+    // Invert colors
+    CIFilter *filterColorInvert = [CIFilter filterWithName:@"CIColorInvert"];
+    [filterColorInvert setValue:inputCIImage forKey:kCIInputImageKey];
+    CIImage *outputCIImage = [filterColorInvert valueForKey:kCIOutputImageKey];
+
+    // A UIImage initialized directly from CIImage has its CGImage property set to NULL. So it has
+    // to be converted to a CGImage first.
+    CIContext *context = [CIContext context];
+    CGImageRef outputCGImage = [context createCGImage:outputCIImage fromRect:[outputCIImage extent]];
+
+    UIImage *outputUIImage = [UIImage imageWithCGImage:outputCGImage];
+    return outputUIImage;
+}
+
 @end
 

--- a/ios/RN/RNImageUtils.m
+++ b/ios/RN/RNImageUtils.m
@@ -115,7 +115,7 @@
     response[@"exif"] = metadata;
 }
 
-+ (UIImage *)inverseColors:(UIImage *)image
++ (UIImage *)invertColors:(UIImage *)image
 {
     CIImage *inputCIImage = [[CIImage alloc] initWithImage:image];
 

--- a/ios/RNCamera.xcodeproj/project.pbxproj
+++ b/ios/RNCamera.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0314E39D1B661A460092D183 /* CameraFocusSquare.m in Sources */ = {isa = PBXBuildFile; fileRef = 0314E39C1B661A460092D183 /* CameraFocusSquare.m */; };
+		1354413B2487FF390024C19F /* BarcodeDetectorManagerMlkit.m in Sources */ = {isa = PBXBuildFile; fileRef = 1354413A2487FF390024C19F /* BarcodeDetectorManagerMlkit.m */; };
 		2647D6712256BBD5007D2F91 /* FaceDetectorManagerMlkit.m in Sources */ = {isa = PBXBuildFile; fileRef = 2647D6702256BBD5007D2F91 /* FaceDetectorManagerMlkit.m */; };
 		2647D6742256BBE8007D2F91 /* RNFaceDetectorModuleMLKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 2647D6722256BBE8007D2F91 /* RNFaceDetectorModuleMLKit.m */; };
 		4107014D1ACB732B00C6AA39 /* RCTCamera.m in Sources */ = {isa = PBXBuildFile; fileRef = 410701481ACB732B00C6AA39 /* RCTCamera.m */; };
@@ -37,6 +38,8 @@
 /* Begin PBXFileReference section */
 		0314E39B1B661A0C0092D183 /* CameraFocusSquare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CameraFocusSquare.h; sourceTree = "<group>"; };
 		0314E39C1B661A460092D183 /* CameraFocusSquare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CameraFocusSquare.m; sourceTree = "<group>"; };
+		135441392487FF390024C19F /* BarcodeDetectorManagerMlkit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BarcodeDetectorManagerMlkit.h; sourceTree = "<group>"; };
+		1354413A2487FF390024C19F /* BarcodeDetectorManagerMlkit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BarcodeDetectorManagerMlkit.m; sourceTree = "<group>"; };
 		2647D66F2256BBD5007D2F91 /* FaceDetectorManagerMlkit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FaceDetectorManagerMlkit.h; sourceTree = "<group>"; };
 		2647D6702256BBD5007D2F91 /* FaceDetectorManagerMlkit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FaceDetectorManagerMlkit.m; sourceTree = "<group>"; };
 		2647D6722256BBE8007D2F91 /* RNFaceDetectorModuleMLKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNFaceDetectorModuleMLKit.m; sourceTree = "<group>"; };
@@ -112,6 +115,8 @@
 		714166162013E1B600EE9FCC /* RN */ = {
 			isa = PBXGroup;
 			children = (
+				135441392487FF390024C19F /* BarcodeDetectorManagerMlkit.h */,
+				1354413A2487FF390024C19F /* BarcodeDetectorManagerMlkit.m */,
 				F8393BEA21469C0000AB1995 /* RNSensorOrientationChecker.h */,
 				F8393BEB21469C0000AB1995 /* RNSensorOrientationChecker.m */,
 				2647D66F2256BBD5007D2F91 /* FaceDetectorManagerMlkit.h */,
@@ -194,6 +199,7 @@
 				71C7FFD62013C824006EB75A /* RNFileSystem.m in Sources */,
 				4107014E1ACB732B00C6AA39 /* RCTCameraManager.m in Sources */,
 				4107014D1ACB732B00C6AA39 /* RCTCamera.m in Sources */,
+				1354413B2487FF390024C19F /* BarcodeDetectorManagerMlkit.m in Sources */,
 				F8393BEC21469C0000AB1995 /* RNSensorOrientationChecker.m in Sources */,
 				71C7FFD02013C7E5006EB75A /* RNCameraUtils.m in Sources */,
 				7162BE682013EAA400FE51FF /* RNCameraManager.m in Sources */,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.28.7",
+  "version": "3.28.8",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.28.6",
+  "version": "3.28.7",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.28.3",
+  "version": "3.28.4",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.28.9",
+  "version": "3.28.10",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.27.1",
+  "version": "3.27.0",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.28.10",
+  "version": "3.28.11",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.27.0",
+  "version": "3.26.0",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.27.0",
+  "version": "3.27.1",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.26.2",
+  "version": "3.28.3",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.28.4",
+  "version": "3.28.5",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.26.0",
+  "version": "3.26.2",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.28.5",
+  "version": "3.28.6",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.28.8",
+  "version": "3.28.9",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.28.11",
+  "version": "3.27.0",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -362,6 +362,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     VideoCodec: CameraManager.VideoCodec,
     BarCodeType: CameraManager.BarCodeType,
     GoogleVisionBarcodeDetection: CameraManager.GoogleVisionBarcodeDetection,
+    GoogleVisionBarcodeMode: CameraManager.GoogleVisionBarcodeMode,
     FaceDetection: CameraManager.FaceDetection,
     CameraStatus,
     RecordAudioPermissionStatus: RecordAudioPermissionStatusEnum,
@@ -379,6 +380,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
   static ConversionTables = {
     type: CameraManager.Type,
     flashMode: CameraManager.FlashMode,
+    googleVisionBarcodeMode: CameraManager.GoogleVisionBarcodeMode,
     exposure: CameraManager.Exposure,
     autoFocus: CameraManager.AutoFocus,
     whiteBalance: CameraManager.WhiteBalance,

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -462,7 +462,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     googleVisionBarcodeType: ((CameraManager.GoogleVisionBarcodeDetection || {}).BarcodeType || {})
       .None,
     googleVisionBarcodeMode: ((CameraManager.GoogleVisionBarcodeDetection || {}).BarcodeMode || {})
-      .NORMAL,
+      .ALTERNATE,
     faceDetectionLandmarks: ((CameraManager.FaceDetection || {}).Landmarks || {}).none,
     faceDetectionClassifications: ((CameraManager.FaceDetection || {}).Classifications || {}).none,
     permissionDialogTitle: '',

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -247,7 +247,7 @@ type Rect = {
 
 type PropsType = typeof View.props & {
   zoom?: number,
-  useNativeZoom?:boolean,
+  useNativeZoom?: boolean,
   maxZoom?: number,
   ratio?: string,
   focusDepth?: number,
@@ -392,7 +392,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
   static propTypes = {
     ...ViewPropTypes,
     zoom: PropTypes.number,
-    useNativeZoom:PropTypes.bool,
+    useNativeZoom: PropTypes.bool,
     maxZoom: PropTypes.number,
     ratio: PropTypes.string,
     focusDepth: PropTypes.number,
@@ -445,7 +445,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
 
   static defaultProps: Object = {
     zoom: 0,
-    useNativeZoom:false,
+    useNativeZoom: false,
     maxZoom: 0,
     ratio: '4:3',
     focusDepth: 0,
@@ -651,7 +651,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     if (this.props.onTap && !nativeEvent.isDoubleTap) {
       this.props.onTap(nativeEvent.touchOrigin);
     }
-    if (this.props.onDoubleTap && nativeEvent.isDoubleTap){
+    if (this.props.onDoubleTap && nativeEvent.isDoubleTap) {
       this.props.onTap(nativeEvent.touchOrigin);
     }
   };
@@ -694,7 +694,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     }
   };
 
-  _onSubjectAreaChanged = e => {
+  _onSubjectAreaChanged = (e) => {
     if (this.props.onSubjectAreaChanged) {
       this.props.onSubjectAreaChanged(e);
     }
@@ -869,7 +869,6 @@ export default class Camera extends React.Component<PropsType, StateType> {
     }
 
     if (Platform.OS === 'ios') {
-      delete newProps.googleVisionBarcodeMode;
       delete newProps.ratio;
     }
 
@@ -893,7 +892,7 @@ const RNCamera = requireNativeComponent('RNCamera', Camera, {
     accessibilityLabel: true,
     accessibilityLiveRegion: true,
     barCodeScannerEnabled: true,
-    touchDetectorEnabled:true,
+    touchDetectorEnabled: true,
     googleVisionBarcodeDetectorEnabled: true,
     faceDetectorEnabled: true,
     textRecognizerEnabled: true,
@@ -905,7 +904,7 @@ const RNCamera = requireNativeComponent('RNCamera', Camera, {
     onAudioConnected: true,
     onPictureSaved: true,
     onFaceDetected: true,
-    onTouch:true,
+    onTouch: true,
     onLayout: true,
     onMountError: true,
     onSubjectAreaChanged: true,

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -462,7 +462,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
     googleVisionBarcodeType: ((CameraManager.GoogleVisionBarcodeDetection || {}).BarcodeType || {})
       .None,
     googleVisionBarcodeMode: ((CameraManager.GoogleVisionBarcodeDetection || {}).BarcodeMode || {})
-      .ALTERNATE,
+      .NORMAL,
     faceDetectionLandmarks: ((CameraManager.FaceDetection || {}).Landmarks || {}).none,
     faceDetectionClassifications: ((CameraManager.FaceDetection || {}).Classifications || {}).none,
     permissionDialogTitle: '',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This PR adds the capability to scan inverted-color barcodes [on iOS](https://github.com/react-native-community/react-native-camera/issues/2850) using Google Vision ML library. This PR is similar to what was done for [Android](https://github.com/react-native-community/react-native-camera/pull/1896). 

Adds two additional modes - `inverted` and `alternate`, in addition to `normal` (default).

`inverted`: each image will be inverted before being passed to the barcode detector. In this case only `inverted` barcodes can be detected.

`alternate`: each second frame will be inverted before being passed to the barcode detector. This mode will detect both `normal` and `inverted` barcodes.

When no mode is provided the barcode scanner behaves like normal and only `normal` barcodes can be detected.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
