### PR TITLE
fix: Correct the way GoogleBarcodeDetectionMode is exposed in props

### DIFF
--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -82,13 +82,13 @@ RCT_EXPORT_VIEW_PROPERTY(onTouch, RCTDirectEventBlock);
              @"VideoStabilization": [[self class] validVideoStabilizationModes],
              @"GoogleVisionBarcodeDetection": @{
                  @"BarcodeType": [[self class] barcodeDetectorConstants],
-             },
-             @"GoogleVisionBarcodeMode" : @{
+                 @"BarcodeMode": @{
                      @"NORMAL" : @(RNCameraGoogleVisionBarcodeModeNormal),
                      @"ALTERNATE" : @(RNCameraGoogleVisionBarcodeModeAlternate),
                      @"INVERTED" : @(RNCameraGoogleVisionBarcodeModeInverted),
                      },
-             };
+             },
+    };
 }
 
 - (NSArray<NSString *> *)supportedEvents


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Make the prop `googleVisionBarcodeMode` for iOS in sync with Android. i.e. it should be invoked as `RNCamera.Constants.GoogleVisionBarcodeDetection.BarcodeMode.ALTERNATE` instead of `RNCamera.Constants.GoogleBarcodeDetectionMode.ALTERNATE`. This discrepancy was introduced in [this PR ](https://github.com/react-native-community/react-native-camera/pull/2851).

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
