### PR TITLE
Fix app crash in barcode detection without FirebaseMLVision

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -2105,7 +2105,9 @@ BOOL _sessionInterrupted = NO;
 
 - (void)updateGoogleVisionBarcodeMode:(id)requestedMode
 {
-    [self.barcodeDetector setMode:requestedMode queue:self.sessionQueue];
+    if ([self.barcodeDetector isRealDetector]) {
+        [self.barcodeDetector setMode:requestedMode queue:self.sessionQueue];
+    }
 }
 
 - (void)onBarcodesDetected:(NSDictionary *)event


### PR DESCRIPTION
Update the mode of the barcode detector only if it is a real detector.
Otherwise, the app will crash due to `-[BarcodeDetectorManagerMlkit setMode:queue:]:  unrecognized selector sent to instance`.

