### PR TITLE
Android Camera1 Crash Fix

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -766,13 +766,25 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                         synchronized(Camera1.this){
                             if(mCamera != null){
                                 if (options.hasKey("pauseAfterCapture") && !options.getBoolean("pauseAfterCapture")) {
-                                    mCamera.startPreview();
-                                    mIsPreviewActive = true;
-                                    if (mIsScanning) {
-                                        mCamera.setPreviewCallback(Camera1.this);
+                                    try{
+                                        mCamera.startPreview();
+                                        mIsPreviewActive = true;
+                                        if (mIsScanning) {
+                                            mCamera.setPreviewCallback(Camera1.this);
+                                        }
+                                    }
+                                    catch(Exception e){
+                                        mIsPreviewActive = false;
+                                        mCamera.setPreviewCallback(null);
+                                        Log.e("CAMERA_1::", "camera startPreview failed", e);
                                     }
                                 } else {
-                                    mCamera.stopPreview();
+                                    try{
+                                        mCamera.stopPreview();
+                                    }
+                                    catch(Exception e){
+                                        Log.e("CAMERA_1::", "camera stopPreview failed", e);
+                                    }
                                     mIsPreviewActive = false;
                                     mCamera.setPreviewCallback(null);
                                 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Fix a very random android crash when resuming preview after a capture.  

Our crash logs reported a crash at the `startPreview` right after a capture.  Looks like the hardware/OS failed to start the camera and it raised an exception. This exception was unhandled until this PR. 

The idea is to handle the exception just like in the other `startPreview` call.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Android real device

### What are the steps to reproduce (after prerequisites)?
Capture lots of photos with Camera1 very quickly.  Hard to reproduce

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
