### PR TITLE
Added pause and resume recording

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -853,6 +853,16 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     }
 
     @Override
+    void pauseRecording() {
+        pauseMediaRecorder();
+    }
+
+    @Override
+    void resumeRecording() {
+        resumeMediaRecorder();
+    }
+
+    @Override
     int getCameraOrientation() {
         return mCameraInfo.orientation;
     }
@@ -1567,6 +1577,14 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             mCallback.onVideoRecorded(mVideoPath, mOrientation != Constants.ORIENTATION_AUTO ? mOrientation : deviceOrientation, deviceOrientation);
             mVideoPath = null;
         }
+    }
+
+    private void pauseMediaRecorder() {
+        // mMediaRecorder.pause();
+    }
+
+    private void resumeMediaRecorder() {
+        // mMediaRecorder.resume();
     }
 
     @Override

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -1580,11 +1580,15 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     }
 
     private void pauseMediaRecorder() {
-        // mMediaRecorder.pause();
+        if (Build.VERSION.SDK_INT >= 24) {
+            mMediaRecorder.pause();
+        }
     }
 
     private void resumeMediaRecorder() {
-        // mMediaRecorder.resume();
+        if (Build.VERSION.SDK_INT >= 24) {
+            mMediaRecorder.resume();
+        }
     }
 
     @Override

--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -44,6 +44,7 @@ import android.util.SparseIntArray;
 import android.view.Surface;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Build;
 
 import com.facebook.react.bridge.ReadableMap;
 
@@ -617,6 +618,16 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
             }
             startCaptureSession();
         }
+    }
+
+    @Override
+    void pauseRecording() {
+        pauseMediaRecorder();
+    }
+
+    @Override
+    void resumeRecording() {
+        resumeMediaRecorder();
     }
 
     @Override
@@ -1426,6 +1437,18 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
         // @TODO: implement videoOrientation and deviceOrientation calculation
         mCallback.onVideoRecorded(mVideoPath, 0, 0);
         mVideoPath = null;
+    }
+
+    private void pauseMediaRecorder() {
+        if (Build.VERSION.SDK_INT >= 24) {
+            mMediaRecorder.pause();
+        }
+    }
+
+    private void resumeMediaRecorder() {
+        if (Build.VERSION.SDK_INT >= 24) {
+            mMediaRecorder.resume();
+        }
     }
 
     /**

--- a/android/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraView.java
@@ -635,6 +635,14 @@ public class CameraView extends FrameLayout {
         mImpl.stopRecording();
     }
 
+    public void pauseRecording() {
+        mImpl.pauseRecording();
+    }
+
+    public void resumeRecording() {
+        mImpl.resumeRecording();
+    }
+
     public void resumePreview() {
         mImpl.resumePreview();
     }

--- a/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
@@ -105,6 +105,10 @@ abstract class CameraViewImpl {
 
     abstract void stopRecording();
 
+    abstract void pauseRecording();
+
+    abstract void resumeRecording();
+
     abstract int getCameraOrientation();
 
     abstract void setDisplayOrientation(int displayOrientation);

--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -325,6 +325,48 @@ public class CameraModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void pauseRecording(final int viewTag) {
+    final ReactApplicationContext context = getReactApplicationContext();
+    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+    uiManager.addUIBlock(new UIBlock() {
+      @Override
+      public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+          final RNCameraView cameraView;
+
+          try {
+              cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
+              if (cameraView.isCameraOpened()) {
+                  cameraView.pauseRecording();
+              }
+          } catch (Exception e) {
+              e.printStackTrace();
+          }
+      }
+    });
+  }
+
+  @ReactMethod
+  public void resumeRecording(final int viewTag) {
+    final ReactApplicationContext context = getReactApplicationContext();
+    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+    uiManager.addUIBlock(new UIBlock() {
+      @Override
+      public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+          final RNCameraView cameraView;
+
+          try {
+              cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
+              if (cameraView.isCameraOpened()) {
+                  cameraView.resumeRecording();
+              }
+          } catch (Exception e) {
+              e.printStackTrace();
+          }
+      }
+    });
+  }
+
+  @ReactMethod
   public void getSupportedRatios(final int viewTag, final Promise promise) {
       final ReactApplicationContext context = getReactApplicationContext();
       UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -624,6 +624,14 @@ export default class Camera extends React.Component<PropsType, StateType> {
     CameraManager.stopRecording(this._cameraHandle);
   }
 
+  pauseRecording() {
+    CameraManager.pauseRecording(this._cameraHandle);
+  }
+
+  resumeRecording() {
+    CameraManager.resumeRecording(this._cameraHandle);
+  }
+
   pausePreview() {
     CameraManager.pausePreview(this._cameraHandle);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Added pause recording and resume recording functionality for Android (API Version 24 onwards). It uses MediaRecorder's pause and resume methods.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Usage

To pause recording use : 
`this.camera.pauseRecording();`
To resume recording use : 
`this.camera.resumeRecording();`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device (Android API 29)
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
