### PR TITLE
feat(windows): added barcode scanning support

### DIFF
--- a/windows/ReactNativeCameraCPP/CameraRotationHelper.cpp
+++ b/windows/ReactNativeCameraCPP/CameraRotationHelper.cpp
@@ -1,5 +1,7 @@
 ﻿#include "pch.h"
+
 #include "CameraRotationHelper.h"
+
 #include "CameraRotationHelper.g.cpp"
 
 namespace winrt {

--- a/windows/ReactNativeCameraCPP/CameraRotationHelper.h
+++ b/windows/ReactNativeCameraCPP/CameraRotationHelper.h
@@ -1,7 +1,5 @@
 ﻿#pragma once
 
-#include "winrt/Windows.Graphics.Display.h"
-
 #include "CameraRotationHelper.g.h"
 
 // This is a Cpp/WinRT implementation of the Camera Rotation Helper class(C#) on MSDN:

--- a/windows/ReactNativeCameraCPP/ReactCameraConstants.h
+++ b/windows/ReactNativeCameraCPP/ReactCameraConstants.h
@@ -2,6 +2,13 @@
 
 #include <functional>
 
+#include <winrt/Windows.Media.Devices.h>
+#include <winrt/Windows.Media.MediaProperties.h>
+
+#include "JSValue.h"
+
+#define BarcodeReadEvent L"onBarCodeRead"
+
 namespace winrt::ReactNativeCameraCPP {
 class ReactCameraConstants {
  public:
@@ -36,15 +43,14 @@ class ReactCameraConstants {
   static const int CameraWhiteBalanceSunny = (int)winrt::Windows::Media::Devices::ColorTemperaturePreset::Daylight;
   static const int CameraWhiteBalanceCloudy = (int)winrt::Windows::Media::Devices::ColorTemperaturePreset::Cloudy;
   static const int CameraWhiteBalanceShadow = (int)winrt::Windows::Media::Devices::ColorTemperaturePreset::Candlelight;
-  static const int CameraWhiteBalanceIncandescent = (int)winrt::Windows::Media::Devices::ColorTemperaturePreset::Tungsten;
+  static const int CameraWhiteBalanceIncandescent =
+      (int)winrt::Windows::Media::Devices::ColorTemperaturePreset::Tungsten;
   static const int CameraWhiteBalanceFluorescent =
       (int)winrt::Windows::Media::Devices::ColorTemperaturePreset::Fluorescent;
-  static const int CameraVideoQualityAuto =
-      (int)winrt::Windows::Media::MediaProperties::VideoEncodingQuality::Auto;
+  static const int CameraVideoQualityAuto = (int)winrt::Windows::Media::MediaProperties::VideoEncodingQuality::Auto;
   static const int CameraVideoQuality2160P =
       (int)winrt::Windows::Media::MediaProperties::VideoEncodingQuality::Uhd2160p;
-  static const int CameraVideoQuality1080P =
-      (int)winrt::Windows::Media::MediaProperties::VideoEncodingQuality::HD1080p;
+  static const int CameraVideoQuality1080P = (int)winrt::Windows::Media::MediaProperties::VideoEncodingQuality::HD1080p;
   static const int CameraVideoQuality720P = (int)winrt::Windows::Media::MediaProperties::VideoEncodingQuality::HD720p;
   static const int CameraVideoQualityWVGA = (int)winrt::Windows::Media::MediaProperties::VideoEncodingQuality::Wvga;
   static const int CameraVideoQualityVGA = (int)winrt::Windows::Media::MediaProperties::VideoEncodingQuality::Vga;
@@ -55,16 +61,35 @@ class ReactCameraConstants {
   static const int MediaTypeMP4 = 2;
   static const int MediaTypeWMV = 3;
 
+  static const int BarcodeReadIntervalMinMS = 200;
+  static const int BarcodeReadIntervalMS = 500;
+  static const int BarcodeReadTimeoutMS = 5000;
+
   static winrt::Microsoft::ReactNative::JSValueObject GetAspectConstants() noexcept {
     return winrt::Microsoft::ReactNative::JSValueObject{
-        {"stretch", CameraAspectStretch},
-        {"fit", CameraAspectFit},
-        {"fill", CameraAspectFill}
-    };
+        {"stretch", CameraAspectStretch}, {"fit", CameraAspectFit}, {"fill", CameraAspectFill}};
   }
 
   static winrt::Microsoft::ReactNative::JSValue GetBarcodeConstants() noexcept {
-    return winrt::Microsoft::ReactNative::JSValue::EmptyObject.Copy();
+    return winrt::Microsoft::ReactNative::JSValueObject{
+        {"aztec", "AZTEC"}, // winrt::ZXing::BarcodeType::AZTEC
+        {"codabar", "CODABAR"}, // winrt::ZXing::BarcodeType::CODABAR
+        {"code39", "CODE_39"}, // winrt::ZXing::BarcodeType::CODE_39
+        {"code93", "CODE_93"}, // winrt::ZXing::BarcodeType::CODE_93
+        {"code128", "CODE_128"}, // winrt::ZXing::BarcodeType::CODE_128
+        {"datamatrix", "DATA_MATRIX"}, // winrt::ZXing::BarcodeType::DATA_MATRIX
+        {"ean8", "EAN_8"}, // winrt::ZXing::BarcodeType::EAN_8
+        {"ean13", "EAN_13"}, // winrt::ZXing::BarcodeType::EAN_13
+        {"interleaved2of5", "ITF"}, // winrt::ZXing::BarcodeType::ITF
+        {"maxicode", "MAXICODE"}, // winrt::ZXing::BarcodeType::MAXICODE
+        {"pdf417", "PDF_417"}, // winrt::ZXing::BarcodeType::PDF_417
+        {"qr", "QR_CODE"}, // winrt::ZXing::BarcodeType::QR_CODE
+        {"rss14", "RSS_14"}, // winrt::ZXing::BarcodeType::RSS_14
+        {"rssexpanded", "RSS_EXPANDED"}, // winrt::ZXing::BarcodeType::RSS_EXPANDED
+        {"upc_a", "UPC_A"}, // winrt::ZXing::BarcodeType::UPC_A
+        {"upc_e", "UPC_E"}, // winrt::ZXing::BarcodeType::UPC_E
+        {"upc_ean", "UPC_EAN_EXTENSION"}, // winrt::ZXing::BarcodeType::UPC_EAN_EXTENSION
+    };
   }
 
   static winrt::Microsoft::ReactNative::JSValueObject GetFaceDetectionConstants() noexcept {

--- a/windows/ReactNativeCameraCPP/ReactCameraModule.h
+++ b/windows/ReactNativeCameraCPP/ReactCameraModule.h
@@ -1,20 +1,12 @@
 #pragma once
 
-#include "pch.h"
-
 #include <functional>
 #include <sstream>
 #include <system_error>
 
-#include <winrt/Windows.Devices.Enumeration.h>
-#include <winrt/Windows.Devices.Sensors.h>
-#include <winrt/Windows.Media.Mediaproperties.h>
-#include <winrt/Windows.Storage.Streams.h>
-#include <winrt/Windows.UI.Core.h>
-
+#include "JSValue.h"
 #include "NativeModules.h"
 
-#include "JSValueTreeWriter.h"
 #include "ReactCameraConstants.h"
 #include "ReactCameraViewManager.h"
 
@@ -23,7 +15,7 @@ using namespace winrt::Microsoft::ReactNative;
 #ifdef RNW61
 #define JSVALUEOBJECTPARAMETER
 #else
-#define JSVALUEOBJECTPARAMETER const&
+#define JSVALUEOBJECTPARAMETER const &
 #endif
 
 namespace winrt {
@@ -89,16 +81,16 @@ struct RNCameraModule {
 
   REACT_METHOD(stopRecording)
   void stopRecording(int viewTag) noexcept {
-    auto asyncOp =
-        winrt::ReactNativeCameraCPP::implementation::ReactCameraViewManager::StopRecordAsync(viewTag);
+    auto asyncOp = winrt::ReactNativeCameraCPP::implementation::ReactCameraViewManager::StopRecordAsync(viewTag);
   }
 
   REACT_METHOD(isRecording)
   void isRecording(int viewTag, winrt::Microsoft::ReactNative::ReactPromise<bool> const &result) noexcept {
-    auto asyncOp = winrt::ReactNativeCameraCPP::implementation::ReactCameraViewManager::IsRecordingAsync(viewTag, result);
+    auto asyncOp =
+        winrt::ReactNativeCameraCPP::implementation::ReactCameraViewManager::IsRecordingAsync(viewTag, result);
     asyncOp.Completed(MakeAsyncActionCompletedHandler(result));
   }
-  
+
   REACT_METHOD(pausePreview)
   void pausePreview(int viewTag) noexcept {
     auto asyncOp = winrt::ReactNativeCameraCPP::implementation::ReactCameraViewManager::PausePreviewAsync(viewTag);
@@ -128,8 +120,8 @@ struct RNCameraModule {
   }
 
   REACT_METHOD(getCameraIds)
-  void getCameraIds(winrt::Microsoft::ReactNative::ReactPromise<winrt::Microsoft::ReactNative::JSValueArray> const
-                        &result) noexcept {
+  void getCameraIds(
+      winrt::Microsoft::ReactNative::ReactPromise<winrt::Microsoft::ReactNative::JSValueArray> const &result) noexcept {
     auto asyncOp = winrt::ReactNativeCameraCPP::implementation::ReactCameraViewManager::GetCameraIdsAsync(result);
     asyncOp.Completed(MakeAsyncActionCompletedHandler(result));
   }

--- a/windows/ReactNativeCameraCPP/ReactCameraView.h
+++ b/windows/ReactNativeCameraCPP/ReactCameraView.h
@@ -1,10 +1,9 @@
 #pragma once
-#include <pch.h>
 
+#include "JSValue.h"
 #include "NativeModules.h"
 
 #include "CameraRotationHelper.h"
-#include "JSValueTreeWriter.h"
 #include "ReactCameraConstants.h"
 
 namespace winrt::ReactNativeCameraCPP {
@@ -39,6 +38,9 @@ struct ReactCameraView : winrt::Windows::UI::Xaml::Controls::GridT<ReactCameraVi
   void UpdateMirrorVideo(bool mirrorVideo);
   void UpdateAspect(int aspect);
   void UpdateDefaultVideoQuality(int videoQuality);
+  void UpdateBarcodeScannerEnabled(bool barcodeScannerEnabled);
+  void UpdateBarcodeTypes(winrt::Microsoft::ReactNative::JSValueArray const &barcodeTypes);
+  void UpdateBarcodeReadIntervalMS(int barcodeReadIntervalMS);
 
   fire_and_forget UpdateDeviceId(std::string cameraId);
   fire_and_forget UpdateDeviceType(int type);
@@ -62,6 +64,10 @@ struct ReactCameraView : winrt::Windows::UI::Xaml::Controls::GridT<ReactCameraVi
   winrt::Windows::Foundation::IAsyncAction UpdateFilePropertiesAsync(
       winrt::Windows::Storage::StorageFile storageFile,
       winrt::Microsoft::ReactNative::JSValueObject const &options);
+
+  void StartBarcodeScanner();
+  void StopBarcodeScanner();
+  winrt::Windows::Foundation::IAsyncAction ScanForBarcodeAsync();
 
   void OnOrientationChanged(const bool updatePreview);
   void OnApplicationSuspending();
@@ -98,6 +104,7 @@ struct ReactCameraView : winrt::Windows::UI::Xaml::Controls::GridT<ReactCameraVi
   winrt::Windows::System::Display::DisplayRequest m_displayRequest{nullptr};
 
   winrt::Windows::System::Threading::ThreadPoolTimer m_recordTimer{nullptr};
+  winrt::Windows::System::Threading::ThreadPoolTimer m_barcodeScanTimer{nullptr};
 
   winrt::event_token m_rotationEventToken{};
   winrt::Windows::UI::Xaml::Application::Suspending_revoker m_applicationSuspendingEventToken;
@@ -112,6 +119,9 @@ struct ReactCameraView : winrt::Windows::UI::Xaml::Controls::GridT<ReactCameraVi
   int m_focusMode{ReactCameraConstants::CameraAutoFocusOn};
   bool m_isPreview{false};
   bool m_mirrorVideo{false};
+  bool m_barcodeScannerEnabled{false};
+
+  int m_barcodeReadIntervalMS{ReactCameraConstants::BarcodeReadIntervalMS};
 
   std::string m_cameraId;
 
@@ -120,7 +130,8 @@ struct ReactCameraView : winrt::Windows::UI::Xaml::Controls::GridT<ReactCameraVi
   winrt::Windows::Foundation::Collections::IVectorView<winrt::Windows::Media::MediaProperties::IMediaEncodingProperties>
       m_availableVideoEncodingProperties;
 
-  int m_defaultVideoQuality{ReactCameraConstants::CameraVideoQualityAuto};
+  std::vector<winrt::ZXing::BarcodeType> m_barcodeTypes;
 
+  int m_defaultVideoQuality{ReactCameraConstants::CameraVideoQualityAuto};
 };
 } // namespace winrt::ReactNativeCameraCPP

--- a/windows/ReactNativeCameraCPP/ReactCameraViewManager.cpp
+++ b/windows/ReactNativeCameraCPP/ReactCameraViewManager.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
-#include "ReactCameraViewManager.h"
+
 #include "ReactCameraConstants.h"
+#include "ReactCameraViewManager.h"
 
 #include <iomanip>
 
@@ -59,8 +60,9 @@ IMapView<hstring, ViewManagerPropertyType> ReactCameraViewManager::NativeProps()
   nativeProps.Insert(L"whiteBalance", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"torchMode", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"flashMode", ViewManagerPropertyType::Number);
-  //        nativeProps.Insert(L"barcodeScannerEnabled", ViewManagerPropertyType::Boolean);
-  //        nativeProps.Insert(L"barCodeTypes", ViewManagerPropertyType::Array);
+  nativeProps.Insert(L"barCodeScannerEnabled", ViewManagerPropertyType::Boolean);
+  nativeProps.Insert(L"barCodeTypes", ViewManagerPropertyType::Array);
+  nativeProps.Insert(L"barCodeReadIntervalMS", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"keepAwake", ViewManagerPropertyType::Boolean);
   nativeProps.Insert(L"mirrorVideo", ViewManagerPropertyType::Boolean);
   nativeProps.Insert(L"defaultVideoQuality", ViewManagerPropertyType::Number);
@@ -74,6 +76,20 @@ void ReactCameraViewManager::UpdateProperties(
   if (auto reactCameraView = view.try_as<ReactNativeCameraCPP::ReactCameraView>()) {
     reactCameraView->UpdateProperties(propertyMapReader);
   }
+}
+
+// IViewManagerWithExportedEventTypeConstants
+ConstantProviderDelegate ReactCameraViewManager::ExportedCustomBubblingEventTypeConstants() noexcept {
+  return nullptr;
+}
+
+ConstantProviderDelegate ReactCameraViewManager::ExportedCustomDirectEventTypeConstants() noexcept {
+  return [](winrt::Microsoft::ReactNative::IJSValueWriter const &constantWriter) {
+    constantWriter.WritePropertyName(BarcodeReadEvent);
+    constantWriter.WriteObjectBegin();
+    WriteProperty(constantWriter, L"registrationName", BarcodeReadEvent);
+    constantWriter.WriteObjectEnd();
+  };
 }
 
 void ReactCameraViewManager::RemoveViewFromList(winrt::com_ptr<ReactNativeCameraCPP::ReactCameraView> view) {
@@ -124,7 +140,7 @@ IAsyncAction ReactCameraViewManager::StopRecordAsync(int viewTag) noexcept {
 
 IAsyncAction ReactCameraViewManager::IsRecordingAsync(
     int viewTag,
-    winrt::Microsoft::ReactNative::ReactPromise<bool> const& result) noexcept {
+    winrt::Microsoft::ReactNative::ReactPromise<bool> const &result) noexcept {
   auto capturedPromise = result;
 
   auto index = co_await FindCamera(viewTag);
@@ -173,7 +189,7 @@ IAsyncAction ReactCameraViewManager::CheckMediaCapturePermissionAsync(
 }
 
 winrt::IAsyncAction ReactCameraViewManager::GetCameraIdsAsync(
-    winrt::ReactPromise<winrt::JSValueArray> const& result) noexcept {
+    winrt::ReactPromise<winrt::JSValueArray> const &result) noexcept {
   auto capturedPromise = result;
 
   auto allVideoDevices = co_await winrt::DeviceInformation::FindAllAsync(winrt::DeviceClass::VideoCapture);
@@ -211,7 +227,7 @@ IAsyncOperation<int> ReactCameraViewManager::FindCamera(int viewTag) noexcept {
     co_await resume_background();
     index++;
   }
-  co_return - 1;
+  co_return -1;
 }
 
 } // namespace winrt::ReactNativeCameraCPP::implementation

--- a/windows/ReactNativeCameraCPP/ReactCameraViewManager.h
+++ b/windows/ReactNativeCameraCPP/ReactCameraViewManager.h
@@ -1,5 +1,8 @@
 #pragma once
-#include "pch.h"
+
+#include "NativeModules.h"
+
+#include "ReactCameraView.h"
 
 namespace winrt::ReactNativeCameraCPP::implementation {
 
@@ -7,7 +10,8 @@ struct ReactCameraViewManager : winrt::implements<
                                     ReactCameraViewManager,
                                     winrt::Microsoft::ReactNative::IViewManager,
                                     winrt::Microsoft::ReactNative::IViewManagerWithReactContext,
-                                    winrt::Microsoft::ReactNative::IViewManagerWithNativeProperties> {
+                                    winrt::Microsoft::ReactNative::IViewManagerWithNativeProperties,
+                                    winrt::Microsoft::ReactNative::IViewManagerWithExportedEventTypeConstants> {
  public:
   ReactCameraViewManager();
 
@@ -27,6 +31,11 @@ struct ReactCameraViewManager : winrt::implements<
   void UpdateProperties(
       winrt::Windows::UI::Xaml::FrameworkElement const &view,
       winrt::Microsoft::ReactNative::IJSValueReader const &propertyMapReader) noexcept;
+
+  // IViewManagerWithExportedEventTypeConstants
+  winrt::Microsoft::ReactNative::ConstantProviderDelegate ExportedCustomBubblingEventTypeConstants() noexcept;
+
+  winrt::Microsoft::ReactNative::ConstantProviderDelegate ExportedCustomDirectEventTypeConstants() noexcept;
 
   static winrt::Windows::Foundation::IAsyncAction TakePictureAsync(
       winrt::Microsoft::ReactNative::JSValueObject const &options,

--- a/windows/ReactNativeCameraCPP/ReactNativeCameraCPP.vcxproj
+++ b/windows/ReactNativeCameraCPP/ReactNativeCameraCPP.vcxproj
@@ -104,6 +104,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -164,6 +165,7 @@
   </Target>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets" Condition="Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -171,5 +173,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets'))" />
   </Target>
 </Project>

--- a/windows/ReactNativeCameraCPP/packages.config
+++ b/windows/ReactNativeCameraCPP/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />
+  <package id="huycn.zxingcpp.winrt" version="1.0.7" targetFramework="native" />
 </packages>

--- a/windows/ReactNativeCameraCPP/pch.h
+++ b/windows/ReactNativeCameraCPP/pch.h
@@ -5,11 +5,11 @@
 #include <winrt/Windows.Devices.Sensors.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Graphics.Display.h>
 #include <winrt/Windows.Graphics.Imaging.h>
 #include <winrt/Windows.Media.Capture.h>
 #include <winrt/Windows.Media.Devices.h>
 #include <winrt/Windows.Media.MediaProperties.h>
-#include <winrt/Windows.Media.Mediaproperties.h>
 #include <winrt/Windows.Security.Cryptography.h>
 #include <winrt/Windows.Storage.FileProperties.h>
 #include <winrt/Windows.Storage.Streams.h>
@@ -27,5 +27,4 @@
 
 #include "winrt/Microsoft.ReactNative.h"
 
-#include "JSValueTreeWriter.h"
-#include "ReactCameraView.h"
+#include "winrt/ZXing.h"

--- a/windows/ReactNativeCameraCPP61/ReactNativeCameraCPP61.vcxproj
+++ b/windows/ReactNativeCameraCPP61/ReactNativeCameraCPP61.vcxproj
@@ -93,12 +93,13 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
-      <ModuleDefinitionFile>ReactNativeCameraCPP.def</ModuleDefinitionFile>
+      <ModuleDefinitionFile>..\ReactNativeCameraCPP\ReactNativeCameraCPP.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -155,6 +156,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets" Condition="Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -162,5 +164,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets'))" />
   </Target>
 </Project>

--- a/windows/ReactNativeCameraCPP61/packages.config
+++ b/windows/ReactNativeCameraCPP61/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.190730.2" targetFramework="native" />
+  <package id="huycn.zxingcpp.winrt" version="1.0.7" targetFramework="native" />
 </packages>


### PR DESCRIPTION
# Summary

This PR updates the ReactNativeCameraCPP windows implementation with barcode scanning support via ZXing.

Closes #2830

Build:
* Fixed issue with edit and continue debug symbols
* Fixed ReactNativeCameraCPP61 builds
* Added dependency on huycn.zxingcpp.winrt for barcode support

ReactNativeCameraCPP RNCamera component:
* Added onBarCodeRead event support
* Added barCodeScannerEnabled property support
* Added barCodeTypes property support
* Added barCodeReadIntervalMS property to alter how often the scan
  occurs when enabled

ReactNativeCameraCPP RNCamera module:
* Added BarCodeType constants

Other:
* Fixed intermittent issue with thread marshalling
* Re-ran clang formatting

## Test Plan

All of the new code has been tested locally against both RNW 0.61 and RNW 0.62 using a copy of the example app code.

### What's required for testing (prerequisites)?

A RNW development environment. See [Windows System Requirements](https://microsoft.github.io/react-native-windows/docs/rnw-dependencies).

### What are the steps to reproduce (after prerequisites)?

1. Create a base windows test app:
    ```
    npx react-native init TestApp --version ^0.62
    cd TestApp
    npx react-native-windows-init --version ^0.62
    ```
2. Enable webcam and microphone app capabilities as described here: [Add capability declarations to the app manifest](https://docs.microsoft.com/en-us/windows/uwp/audio-video-camera/simple-camera-preview-access#add-capability-declarations-to-the-app-manifest)
2. Overwrite `TestApp\App.js` with `examples\basic\App.js`.
3. `npx react-native run-windows`

## Compatibility

| OS | Implemented |
| ------- | :---------: |
| Windows | ✅ |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator

