### PR TITLE
Document and improve `pictureSize`

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -463,31 +463,55 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         return mPictureSizes.sizes(ratio);
     }
 
+    // Returns the best available size match for a given
+    // width and height
+    // returns the biggest available size
+    private Size getBestSizeMatch(int desiredWidth, int desiredHeight, SortedSet<Size> sizes) {
+        if(sizes == null || sizes.isEmpty()){
+            return null;
+        }
+
+        Size result = sizes.last();
+
+        // iterate from smallest to largest, and stay with the closest-biggest match
+        if(desiredWidth != 0 && desiredHeight != 0){
+            for (Size size : sizes) {
+                if (desiredWidth <= size.getWidth() && desiredHeight <= size.getHeight()) {
+                    result = size;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+
     @Override
     void setPictureSize(Size size) {
-        if (size == null) {
-            if (mAspectRatio == null) {
-                return;
-            }
-          SortedSet<Size> sizes = mPictureSizes.sizes(mAspectRatio);
-          if(sizes != null && !sizes.isEmpty())
-          {
-            mPictureSize = sizes.last();
-          }
-        } else {
-          mPictureSize = size;
-        }
-        synchronized(this){
-            if (mCameraParameters != null && mCamera != null) {
-                mCameraParameters.setPictureSize(mPictureSize.getWidth(), mPictureSize.getHeight());
-                try{
-                    mCamera.setParameters(mCameraParameters);
-                }
-                catch(RuntimeException e ) {
-                    Log.e("CAMERA_1::", "setParameters failed", e);
-                }
 
-            }
+        // if no changes, don't do anything
+        if(size == null && mPictureSize == null){
+            return;
+        }
+        else if(size != null && size.equals(mPictureSize)){
+            return;
+        }
+
+        mPictureSize = size;
+
+        // if camera is opened, request parameters update
+        if (isCameraOpened()) {
+            mBgHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    synchronized(Camera1.this){
+                        if(mCamera != null){
+                            adjustCameraParameters();
+                        }
+                    }
+                }
+            });
         }
     }
 
@@ -1034,6 +1058,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             if (mAspectRatio == null) {
                 mAspectRatio = Constants.DEFAULT_ASPECT_RATIO;
             }
+
             adjustCameraParameters();
             mCamera.setDisplayOrientation(calcDisplayOrientation(mDisplayOrientation));
             mCallback.onCameraOpened();
@@ -1061,17 +1086,37 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             mAspectRatio = chooseAspectRatio();
             sizes = mPreviewSizes.sizes(mAspectRatio);
         }
-        Size size = chooseOptimalSize(sizes);
 
-        // Always re-apply camera parameters
-        mPictureSize = mPictureSizes.sizes(mAspectRatio).last();
+        // make sure both preview and picture size are always
+        // valid for the currently chosen camera and aspect ratio
+        Size size = chooseOptimalSize(sizes);
+        Size pictureSize = null;
+
+        // do not alter mPictureSize
+        // since it may be valid for other camera/aspect ratio updates
+        // just make sure we get the right and most suitable value
+        if(mPictureSize != null){
+            pictureSize = getBestSizeMatch(
+                mPictureSize.getWidth(),
+                mPictureSize.getHeight(),
+                mPictureSizes.sizes(mAspectRatio)
+            );
+        }
+        else{
+            pictureSize = getBestSizeMatch(
+                0,
+                0,
+                mPictureSizes.sizes(mAspectRatio)
+            );
+        }
+
         boolean needsToStopPreview = mIsPreviewActive;
         if (needsToStopPreview) {
             mCamera.stopPreview();
             mIsPreviewActive = false;
         }
         mCameraParameters.setPreviewSize(size.getWidth(), size.getHeight());
-        mCameraParameters.setPictureSize(mPictureSize.getWidth(), mPictureSize.getHeight());
+        mCameraParameters.setPictureSize(pictureSize.getWidth(), pictureSize.getHeight());
         if (mOrientation != Constants.ORIENTATION_AUTO) {
             mCameraParameters.setRotation(calcCameraRotation(orientationEnumToRotation(mOrientation)));
         } else {
@@ -1129,7 +1174,6 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         if (mCamera != null) {
             mCamera.release();
             mCamera = null;
-            mPictureSize = null;
             mCallback.onCameraClosed();
 
             // reset these flags
@@ -1611,7 +1655,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         Log.w("CAMERA_1::", "fps (framePerSecond) received an unsupported value and will be ignored.");
         return false;
     }
-    
+
     private void setCamcorderProfile(CamcorderProfile profile, boolean recordAudio, int fps) {
         int compatible_fps = isCompatibleWithDevice(fps) ? fps : profile.videoFrameRate;
         mMediaRecorder.setOutputFormat(profile.fileFormat);

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,6 +16,7 @@ title: Work in progress
 - [`whiteBalance`](API.md#whiteBalance)
 - [`autoFocus`](API.md#autoFocus)
 - [`ratio`](API.md#ratio)
+- [`pictureSize`](API.md#pictureSize)
 - [`focusDepth`](API.md#focusDepth)
 - [`onMountError`](API.md#onMountError)
 - [`onCameraReady`](API.md#onCameraReady)
@@ -94,6 +95,28 @@ torch: 'off'
 | Type   | Default Value |
 | ------ | ------------- |
 | object | `{ off: 1 }`  |
+
+### `ratio`
+
+A string representing the camera ratio in the format 'height:width'. Default is `"4:3"`.
+
+Use `getSupportedRatiosAsync` method to get ratio strings supported by your camera on Android.
+
+| Type   | Default Value |
+| ------ | ------------- |
+| string | `4:3`         |
+
+### `pictureSize`
+
+This prop has a different behaviour for Android and iOS and should rarely be set.
+
+For Android, this prop attempts to control the camera sensor capture resolution, similar to how `ratio` behaves. This is useful for cases where a low resolution image is required, and makes further resizing less intensive on the device's memory. The list of possible values can be requested with `getAvailablePictureSizes`, and the value should be set in the format of `<width>x<height>`. Internally, the native code will attempt to get the best suited resolution for the given `pictureSize` value if the provided value is invalid, and will default to the highest resolution available.
+
+For iOS, this prop controls the internal camera preset value and should rarely be changed. However, this value can be set to setup the sensor to match the video recording's quality in order to prevent flickering. The list of valid values can be gathered from https://developer.apple.com/documentation/avfoundation/avcapturesessionpreset and can also be requested with `getAvailablePictureSizes`.
+
+| Type   | Default Value |
+| ------ | ------------- |
+| string | `None`        |
 
 ## Methods
 
@@ -375,7 +398,7 @@ const previewRange = await this.camera.getSupportedPreviewFpsRange();
     MINIMUM_FPS: "15000",
     MAXIMUM_FPS: "15000"
   },
-  { 
+  {
     MINIMUM_FPS: "20000",
     MAXIMUM_FPS: "20000"
   }

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -393,6 +393,14 @@ This option specifies the quality of the video to be taken. The possible values 
 If nothing is passed the device's highest camera quality will be used as default.
 Note: This solve the flicker video recording issue for iOS
 
+### `pictureSize`
+
+This prop has a different behaviour for Android and iOS and should rarely be set.
+
+For Android, this prop attempts to control the camera sensor capture resolution, similar to how `ratio` behaves. This is useful for cases where a low resolution image is required, and makes further resizing less intensive on the device's memory. The list of possible values can be requested with `getAvailablePictureSizes`, and the value should be set in the format of `<width>x<height>`. Internally, the native code will attempt to get the best suited resolution for the given `pictureSize` value if the provided value is invalid, and will default to the highest resolution available.
+
+For iOS, this prop controls the internal camera preset value and should rarely be changed. However, this value can be set to setup the sensor to match the video recording's quality in order to prevent flickering. The list of valid values can be gathered from https://developer.apple.com/documentation/avfoundation/avcapturesessionpreset and can also be requested with `getAvailablePictureSizes`.
+
 ### Native Event callbacks props
 
 ### `onCameraReady`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Document `pictureSize` and make sure Camera1 implementation uses it appropriately.

Write about `pictureSize` behaviour, and make sure it is properly used in Camera1 implementation.  Previously, this prop was used but immediately lost in the current Camera1 implementation.  The update aims to make sure this property works as expected.

Note that there were no changes for iOS, except docs updates that explain what the prop does and why you would use it.

## Test Plan
Tested on Motorola G5 (Android 8.1) and Google Pixel 2 (Android 10).  Will be testing further in the following days against various other devices.

### What's required for testing (prerequisites)?
Real Device

### What are the steps to reproduce (after prerequisites)?
Test various `pictureSize` values on Android and review the final picture resolution.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)