### PR TITLE
Fix camera parameters getting lost on setting focus.

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -1145,7 +1145,6 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             public void run() {
                 synchronized(Camera1.this){
                     if (mCamera != null) {
-                        Camera.Parameters parameters = null;
 
                         // do not create a new object, use existing.
                         Camera.Parameters parameters = mCameraParameters;

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -1147,15 +1147,8 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                     if (mCamera != null) {
                         Camera.Parameters parameters = null;
 
-                        // This might crash on some devices if the camera is not
-                        // available/locked, with a RuntimeException("getParameters failed (empty parameters)")
-                        try{
-                            parameters = mCamera.getParameters();
-                        }
-                        catch(Exception e){
-                            Log.e("CAMERA_1::", "setFocusArea.getParameters failed", e);
-                            parameters = null;
-                        }
+                        // do not create a new object, use existing.
+                        Camera.Parameters parameters = mCameraParameters;
 
                         if (parameters == null) return;
 
@@ -1250,14 +1243,9 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 if (mCamera != null) {
                     mCamera.cancelAutoFocus();
 
-                    Camera.Parameters parameters = null;
-                    try{
-                        parameters = mCamera.getParameters();
-                    }
-                    catch(Exception e){
-                        Log.e("CAMERA_1::", "resetFocus.getParameters failed", e);
-                        parameters = null;
-                    }
+                    // do not create a new object, use existing.
+                    Camera.Parameters parameters = mCameraParameters;
+
                     if (parameters == null) return;
 
                     if (parameters.getFocusMode() != Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE) {
@@ -1611,7 +1599,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         Log.w("CAMERA_1::", "fps (framePerSecond) received an unsupported value and will be ignored.");
         return false;
     }
-    
+
     private void setCamcorderProfile(CamcorderProfile profile, boolean recordAudio, int fps) {
         int compatible_fps = isCompatibleWithDevice(fps) ? fps : profile.videoFrameRate;
         mMediaRecorder.setOutputFormat(profile.fileFormat);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fixes https://github.com/react-native-community/react-native-camera/issues/2420 (again)

Basically, the updated focus area/rect was lost after a following setParameters call.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
Tested on Motorola G5 (Android 8.1) and Pixel 2 (Android 10)

### What's required for testing (prerequisites)?
Real device

### What are the steps to reproduce (after prerequisites)?
Test tap-to-focus, take a picture, and test again to make sure the focus is kept.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
