### PR TITLE
Reset cached exposure limits to avoid a crash.

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -76,7 +76,7 @@ BOOL _sessionInterrupted = NO;
         self.previewLayer.needsDisplayOnBoundsChange = YES;
 #endif
         self.rectOfInterest = CGRectMake(0, 0, 1.0, 1.0);
-       
+
         UITapGestureRecognizer * tapHandler=[self createTapGestureRecognizer];
         [self addGestureRecognizer:tapHandler];
         UITapGestureRecognizer * doubleTabHandler=[self createDoubleTapGestureRecognizer];
@@ -107,14 +107,14 @@ BOOL _sessionInterrupted = NO;
     UITapGestureRecognizer *doubleTapGestureRecognizer =  [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTap:)];
     doubleTapGestureRecognizer.numberOfTapsRequired = 2;
     return doubleTapGestureRecognizer;
-          
+
 }
 -(UITapGestureRecognizer*)createTapGestureRecognizer
 {
     UITapGestureRecognizer *tapGestureRecognizer =  [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
     tapGestureRecognizer.numberOfTapsRequired = 1;
     return tapGestureRecognizer;
-          
+
 }
 -(void)handleDoubleTap:(UITapGestureRecognizer*)doubleTapRecognizer {
     [self handleTouch:doubleTapRecognizer isDoubleTap:true];
@@ -389,7 +389,7 @@ BOOL _sessionInterrupted = NO;
             RCTLogWarn(@"%s: device doesn't support flash mode", __func__);
             return;
         }
-        
+
         [self lockDevice:device andApplySettings:^{
             if ([device isTorchActive]) {
                 [device setTorchMode:AVCaptureTorchModeOff];
@@ -585,7 +585,7 @@ BOOL _sessionInterrupted = NO;
     [self lockDevice:device andApplySettings:^{
         float maxZoom = [self getMaxZoomFactor:device];
         device.videoZoomFactor = (maxZoom - 1) * self.zoom + 1;
-    }];   
+    }];
 }
 
 - (void)updateWhiteBalance {
@@ -610,7 +610,7 @@ BOOL _sessionInterrupted = NO;
                 .tint = 0,
             };
             AVCaptureWhiteBalanceGains rgbGains = [device deviceWhiteBalanceGainsForTemperatureAndTintValues:temperatureAndTint];
-            
+
             @try{
                 [device setWhiteBalanceModeLockedWithDeviceWhiteBalanceGains:rgbGains completionHandler:nil];
             }
@@ -636,11 +636,11 @@ BOOL _sessionInterrupted = NO;
             CGFloat redGain = rgbGains.redGain + self.customWhiteBalanceSettings.redGainOffset;
             CGFloat greenGain = rgbGains.greenGain + self.customWhiteBalanceSettings.greenGainOffset;
             CGFloat blueGain = rgbGains.blueGain + self.customWhiteBalanceSettings.blueGainOffset;
-            
+
             rgbGains.redGain = MAX(1.0f, MIN(device.maxWhiteBalanceGain, redGain));
             rgbGains.greenGain = MAX(1.0f, MIN(device.maxWhiteBalanceGain, greenGain));
             rgbGains.blueGain = MAX(1.0f, MIN(device.maxWhiteBalanceGain, blueGain));
-            
+
             @try{
                 [device setWhiteBalanceModeLockedWithDeviceWhiteBalanceGains:rgbGains completionHandler:nil];
             } @catch(NSException *exception){
@@ -690,7 +690,13 @@ BOOL _sessionInterrupted = NO;
             }
 
             // Only set the ISO for now, duration will be default as a change might affect frame rate.
-            [device setExposureModeCustomWithDuration:AVCaptureExposureDurationCurrent ISO:appliedExposure completionHandler:nil];
+            @try{
+                [device setExposureModeCustomWithDuration:AVCaptureExposureDurationCurrent ISO:appliedExposure completionHandler:nil];
+            }
+            @catch(NSException *exception){
+                RCTLogError(@"Failed to update exposure: %@", exception);
+            }
+
         } else {
             RCTLog(@"Device does not support AVCaptureExposureModeCustom");
         }
@@ -1508,6 +1514,13 @@ BOOL _sessionInterrupted = NO;
         self.session.sessionPreset = [self getDefaultPreset];
 
 
+        // reset iso cached values, these might be different
+        // from camera to camera. Otherwise, the camera may crash
+        // when changing cameras and exposure.
+        self.exposureIsoMin = 0;
+        self.exposureIsoMax = 0;
+
+
         if ([self.session canAddInput:captureDeviceInput]) {
             [self.session addInput:captureDeviceInput];
 
@@ -2222,7 +2235,7 @@ BOOL _sessionInterrupted = NO;
             if (self.invertImageData) {
                 image = [RNImageUtils invertColors:image];
             }
-            
+
             [self.barcodeDetector findBarcodesInFrame:image scaleX:scaleX scaleY:scaleY completed:^(NSArray * barcodes) {
                 NSDictionary *eventBarcode = @{@"type" : @"barcode", @"barcodes" : barcodes};
                 [self onBarcodesDetected:eventBarcode];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fixes a crash due to exposure limits being cached and not updated after a camera switch.

Additionally, prevent a full crash by wrapping the exposure call in a try/catch statement.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
Tested on iPhone 7 (iOS 13.6)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Real device

### What are the steps to reproduce (after prerequisites)?
Test exposure changes from 0 to 1 through all available cameras.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
