### PR TITLE
[iOS] Optimize invertColors / fix memory leak

### DIFF
--- a/ios/RN/RNImageUtils.m
+++ b/ios/RN/RNImageUtils.m
@@ -126,10 +126,13 @@
 
     // A UIImage initialized directly from CIImage has its CGImage property set to NULL. So it has
     // to be converted to a CGImage first.
-    CIContext *context = [CIContext context];
+    static CIContext *context = nil; if (!context) context = [CIContext contextWithOptions:nil];
     CGImageRef outputCGImage = [context createCGImage:outputCIImage fromRect:[outputCIImage extent]];
 
     UIImage *outputUIImage = [UIImage imageWithCGImage:outputCGImage];
+
+    CGImageRelease(outputCGImage);
+
     return outputUIImage;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
Releases the CGImage that was created in order to populate the UIImage's CGImage property. This probably relates to #2904 and possibly #2950.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Tested on iPhone X (14.0b5), iPhone 11 Simulator (13.5, 14.0), iPhone 11 Pro Simulator (13.5, 14.0)

I used Xcode's Leak Instruments to narrow down the reason for the increasing memory usage over time and found that the CGImage that was being created wasn't being released in a timely manner, as the images were being processed.

### What's required for testing (prerequisites)?
Device (using example code works)

### What are the steps to reproduce (after prerequisites)?
Compare memory usage before/after implementing these changes via a debugger/profiler

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
