### PR TITLE
feat(windows): updates for RNW 0.63

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ This document is split into two main sections:
 
 # Required installation steps
 
-_These steps assume installation for iOS/Android. To install it with Windows, see manual install [below](#windows)_
+_These steps assume installation for iOS/Android. To install it with Windows, see [Windows](#windows) below_
 
 ## Mostly automatic install with autolinking (RN > 0.60)
 
@@ -430,9 +430,14 @@ ext {
 
 # Windows
 
-## Manual linking for RNW 0.62
+## Mostly automatic install with autolinking (RNW >= 0.63)
 
-1. `yarn install react-native-camera`
+1. `npm install react-native-camera --save`
+2. See [Additional steps - Windows](#additional-steps-windows) below
+
+## Manual install - Windows (RNW 0.62)
+
+1. `npm install react-native-camera --save`
 2. Link the library as described below:
    1. Add the _ReactNativeCameraCPP_ project to your solution (eg. `windows\yourapp.sln`)
       1. Open your solution in Visual Studio 2019
@@ -447,11 +452,17 @@ ext {
       1. Add `#include "winrt/ReactNativeCameraCPP.h"`
    2. `App.cpp`
       1. Add `PackageProviders().Append(winrt::ReactNativeCameraCPP::ReactPackageProvider());` before `InitializeComponent();`
-4. Add the capabilities (permissions) for the webcam and microphone as described here: [Add capability declarations to the app manifest](https://docs.microsoft.com/en-us/windows/uwp/audio-video-camera/simple-camera-preview-access#add-capability-declarations-to-the-app-manifest)
-5. If you plan on capturing images to the Pictures Library, or videos to the Videos Library, be sure to enable those capabilities too
+4. See [Additional steps - Windows](#additional-steps-windows) below
 
-## Manual linking for RNW 0.61
+## Manual install - Windows (RNW 0.61)
 
-Follow the same manual steps for RNW 0.62 above, but for step 2 substitute _ReactNativeCameraCPP61_ for _ReactNativeCameraCPP_.
+Follow [Manual install - Windows (RNW 0.62)](#manual-install-windows-rnw-062) above, but for step 2 substitute _ReactNativeCameraCPP61_ for _ReactNativeCameraCPP_.
+
+## Additional steps - Windows
+
+You need to declare that your app wants to access the camera:
+
+1. Add the capabilities (permissions) for the webcam and microphone as described here: [Add capability declarations to the app manifest](https://docs.microsoft.com/en-us/windows/uwp/audio-video-camera/simple-camera-preview-access#add-capability-declarations-to-the-app-manifest)
+2. If you plan on capturing images to the Pictures Library, or videos to the Videos Library, be sure to enable those capabilities too
 
 Follow the [Q & A](QA.md) section if you are having compilation issues.

--- a/windows/README.md
+++ b/windows/README.md
@@ -17,17 +17,35 @@ RNW was then rebuilt from scratch in C++, and version 0.61 was the first release
 
 RNW 0.62 brought a variety of build improvements, but now requires both Visual Studio 2019 and a newer Windows SDK. So while the native module APIs are 99% forward-compatible, it's currently necessary to maintain a separate `ReactNativeCameraCPP61.vcxproj` project for RNW 0.61 users. The `ReactNativeCameraCPP.vcxproj` project targets RNW >= 0.62 users.
 
-# Local Development Setup (RNW >= 0.62)
+# Local Development Setup (RNW >= 0.61)
 
 In order to work on _ReactNativeCameraCPP_, you'll need to install the [Windows Development Dependencies](https://microsoft.github.io/react-native-windows/docs/rnw-dependencies).
 
 In addition, `react-native-camera` targets React Native 0.59 and doesn't include React Native Windows as a dependency. So in order to build _ReactNativeCameraCPP_ locally you'll need to temporarily upgrade the development dependencies:
 
+## RNW >= 0.63
+
 ```
-yarn upgrade react-native@^0.62.2
-yarn add react-native-windows@^0.62.0 --dev
+yarn upgrade react-native@^0.63
+yarn add react-native-windows@^0.63 --dev
 ```
 
 Now you should be able to open `ReactNativeCameraCPP.sln` in Visual Studio and build the project.
 
-> _Note:_ In order to test your code changes don't break RNW 0.61, you'll want to do the above steps but targeting RN/RNW 0.61, and using `ReactNativeCameraCPP61.sln`.
+## RNW 0.62
+
+```
+yarn upgrade react-native@^0.62
+yarn add react-native-windows@^0.62 --dev
+```
+
+Now you should be able to open `ReactNativeCameraCPP62.sln` in Visual Studio and build the project.
+
+## RNW 0.61
+
+```
+yarn upgrade react-native@^0.61
+yarn add react-native-windows@^0.61 --dev
+```
+
+Now you should be able to open `ReactNativeCameraCPP61.sln` in Visual Studio and build the project.

--- a/windows/ReactNativeCameraCPP/ReactCameraView.cpp
+++ b/windows/ReactNativeCameraCPP/ReactCameraView.cpp
@@ -353,7 +353,7 @@ IAsyncAction ReactCameraView::RecordAsync(
     mediaCapture.AudioDeviceController().Muted(muteAudio);
 
     float maxDurationInSeconds;
-    TryGetValueAsFloat(capturedOptions, "maxDuration", maxDurationInSeconds, FLT_MAX);
+    TryGetValueAsFloat(capturedOptions, "maxDuration", maxDurationInSeconds, 0.0f);
 
     // Default with no options is to save the video to the temp folder and return the uri
     // This follows the expectations of RNCamera without requiring extra app capabilities
@@ -475,7 +475,9 @@ IAsyncAction ReactCameraView::ResumePreviewAsync() noexcept {
 // start a timer to end the recording after the specified time
 void ReactCameraView::DelayStopRecording(float totalRecordingInSecs) {
   ResetEvent(m_signal.get());
-  std::chrono::duration<int, std::milli> secs(static_cast<int>(1000 * totalRecordingInSecs));
+  auto totalRecordingInMs = static_cast<int32_t>(1000 * totalRecordingInSecs);
+
+  std::chrono::duration<int32_t, std::milli> secs(totalRecordingInMs <= 0 ? INT32_MAX : totalRecordingInMs);
   m_recordTimer = winrt::Windows::System::Threading::ThreadPoolTimer::CreateTimer(
       [this](const winrt::Windows::System::Threading::ThreadPoolTimer) noexcept { SetEvent(m_signal.get()); }, secs);
 }

--- a/windows/ReactNativeCameraCPP/ReactNativeCameraCPP.vcxproj
+++ b/windows/ReactNativeCameraCPP/ReactNativeCameraCPP.vcxproj
@@ -165,7 +165,7 @@
   </Target>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets" Condition="Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets')" />
+    <Import Project="$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.1.0\build\native\ZXingWinRT.targets" Condition="Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.1.0\build\native\ZXingWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -173,6 +173,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.1.0\build\native\ZXingWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.1.0\build\native\ZXingWinRT.targets'))" />
   </Target>
 </Project>

--- a/windows/ReactNativeCameraCPP/packages.config
+++ b/windows/ReactNativeCameraCPP/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />
-  <package id="huycn.zxingcpp.winrt" version="1.0.7" targetFramework="native" />
+  <package id="huycn.zxingcpp.winrt" version="1.1.0" targetFramework="native" />
 </packages>

--- a/windows/ReactNativeCameraCPP61.sln
+++ b/windows/ReactNativeCameraCPP61.sln
@@ -40,17 +40,15 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
-		..\node_modules\react-native-windows\ReactWindowsCore\ReactWindowsCore.vcxitems*{11c084a3-a57c-4296-a679-cac17b603144}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
-		..\node_modules\react-native-windows\Microsoft.ReactNative.SharedManaged\Microsoft.ReactNative.SharedManaged.projitems*{67a1076f-7790-4203-86ea-4402ccb5e782}*SharedItemsImports = 13
 		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{5898d41d-92cc-48d0-95cd-9954572c266d}*SharedItemsImports = 4
+		..\node_modules\react-native-windows\Microsoft.ReactNative.SharedManaged\Microsoft.ReactNative.SharedManaged.projitems*{67a1076f-7790-4203-86ea-4402ccb5e782}*SharedItemsImports = 13
 		..\node_modules\react-native-windows\Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
 		..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{a62d504a-16b8-41d2-9f19-e2e86019e5e4}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
 		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9
 		..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
-		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 	EndGlobalSection

--- a/windows/ReactNativeCameraCPP61/ReactNativeCameraCPP61.vcxproj
+++ b/windows/ReactNativeCameraCPP61/ReactNativeCameraCPP61.vcxproj
@@ -156,7 +156,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets" Condition="Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets')" />
+    <Import Project="$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.1.0\build\native\ZXingWinRT.targets" Condition="Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.1.0\build\native\ZXingWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -164,6 +164,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.0.7\build\native\ZXingWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.1.0\build\native\ZXingWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\huycn.zxingcpp.winrt.1.1.0\build\native\ZXingWinRT.targets'))" />
   </Target>
 </Project>

--- a/windows/ReactNativeCameraCPP61/packages.config
+++ b/windows/ReactNativeCameraCPP61/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.190730.2" targetFramework="native" />
-  <package id="huycn.zxingcpp.winrt" version="1.0.7" targetFramework="native" />
+  <package id="huycn.zxingcpp.winrt" version="1.1.0" targetFramework="native" />
 </packages>

--- a/windows/ReactNativeCameraCPP62.sln
+++ b/windows/ReactNativeCameraCPP62.sln
@@ -25,13 +25,16 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactCommon", "..\node_modu
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative.Cxx", "..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems", "{DA8B35B3-DA00-4B02-BDE6-6A397B3FD46B}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative.Shared", "..\node_modules\react-native-windows\Shared\Shared.vcxitems", "{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Shared", "..\node_modules\react-native-windows\Shared\Shared.vcxitems", "{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore", "..\node_modules\react-native-windows\ReactWindowsCore\ReactWindowsCore.vcxproj", "{11C084A3-A57C-4296-A679-CAC17B603144}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Include", "..\node_modules\react-native-windows\include\Include.vcxitems", "{EF074BA1-2D54-4D49-A28E-5E040B47CD2E}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
+		..\node_modules\react-native-windows\ReactWindowsCore\ReactWindowsCore.vcxitems*{11c084a3-a57c-4296-a679-cac17b603144}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
 		..\node_modules\react-native-windows\Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
 		..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{a62d504a-16b8-41d2-9f19-e2e86019e5e4}*SharedItemsImports = 4
@@ -203,6 +206,30 @@ Global
 		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.WinUI3|x64.Build.0 = Release|x64
 		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.WinUI3|x86.ActiveCfg = Release|Win32
 		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.WinUI3|x86.Build.0 = Release|Win32
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|ARM.ActiveCfg = Debug|ARM
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|ARM.Build.0 = Debug|ARM
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|ARM64.Build.0 = Debug|ARM64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|x64.ActiveCfg = Debug|x64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|x64.Build.0 = Debug|x64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|x86.ActiveCfg = Debug|Win32
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|x86.Build.0 = Debug|Win32
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|ARM.ActiveCfg = Release|ARM
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|ARM.Build.0 = Release|ARM
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|ARM64.ActiveCfg = Release|ARM64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|ARM64.Build.0 = Release|ARM64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|x64.ActiveCfg = Release|x64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|x64.Build.0 = Release|x64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|x86.ActiveCfg = Release|Win32
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|x86.Build.0 = Release|Win32
+		{11C084A3-A57C-4296-A679-CAC17B603144}.WinUI3|ARM.ActiveCfg = WinUI3|ARM
+		{11C084A3-A57C-4296-A679-CAC17B603144}.WinUI3|ARM.Build.0 = WinUI3|ARM
+		{11C084A3-A57C-4296-A679-CAC17B603144}.WinUI3|ARM64.ActiveCfg = WinUI3|ARM64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.WinUI3|ARM64.Build.0 = WinUI3|ARM64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.WinUI3|x64.ActiveCfg = WinUI3|x64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.WinUI3|x64.Build.0 = WinUI3|x64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.WinUI3|x86.ActiveCfg = WinUI3|Win32
+		{11C084A3-A57C-4296-A679-CAC17B603144}.WinUI3|x86.Build.0 = WinUI3|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -218,6 +245,7 @@ Global
 		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD} = {4F6E56C3-12C5-4457-9239-0ACF0B7150A8}
 		{DA8B35B3-DA00-4B02-BDE6-6A397B3FD46B} = {4F6E56C3-12C5-4457-9239-0ACF0B7150A8}
 		{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0} = {4F6E56C3-12C5-4457-9239-0ACF0B7150A8}
+		{11C084A3-A57C-4296-A679-CAC17B603144} = {4F6E56C3-12C5-4457-9239-0ACF0B7150A8}
 		{EF074BA1-2D54-4D49-A28E-5E040B47CD2E} = {4F6E56C3-12C5-4457-9239-0ACF0B7150A8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution


### PR DESCRIPTION
# Summary

This PR updates the ReactNativeCameraCPP windows implementation to align with RNW 0.63, enabling ARM64 support, and updating the install and dev setup instructions.

Closes #2943, #2944

Build:
* Updated huycn.zxingcpp.winrt to v1.1.0, enables ARM64 build on RNW >= 0.61
* Updated ReactNativeCameraCPP.sln with RNW 0.63 dependencies
* Added ReactNativeCameraCPP62.sln for building against RNW 0.62
* Cleaned up ReactNativeCameraCPP61.sln for building against RNW 0.61

ReactNativeCamera RNCamera component:
* Passing unspecified maxDuration to recordAsync no longer stops recording immediately

Documentation:
* Updated installation docs for RNW 0.63 auto-linking

## Test Plan

All of the new code has been tested locally against RNW 0.61, 0.62, and 0.63 using a copy of the example app code.

### What's required for testing (prerequisites)?

A RNW development environment. See [Windows System Requirements](https://microsoft.github.io/react-native-windows/docs/rnw-dependencies).

### What are the steps to reproduce (after prerequisites)?

1. Create a base windows test app:
    ```
    npx react-native init TestApp --version ^0.63
    cd TestApp
    npx react-native-windows-init --version ^0.63
    ```
2. Enable webcam and microphone app capabilities as described here: [Add capability declarations to the app manifest](https://docs.microsoft.com/en-us/windows/uwp/audio-video-camera/simple-camera-preview-access#add-capability-declarations-to-the-app-manifest)
2. Overwrite `TestApp\App.js` with `examples\basic\App.js`.
3. `npx react-native run-windows`

## Compatibility

| OS | Implemented |
| ------- | :---------: |
| Windows | ✅ |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator